### PR TITLE
Use bash for bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,28 +1,34 @@
-#!/usr/bin/env ruby
-require "fileutils"
+#!/usr/bin/env bash
+set -eo pipefail
 
-APP_ROOT = File.expand_path("..", __dir__)
-APP_NAME = "splat"
+app_root="$( cd "$(dirname "$0")/.."; pwd )"
+app_name="splat"
 
-def system!(*args)
-  system(*args, exception: true)
-end
+# Use application binstubs
+export PATH="$app_root/bin:$PATH"
 
-FileUtils.chdir APP_ROOT do
-  puts "== Installing dependencies =="
-  system! "gem install bundler --conservative"
-  system!("bundle install")
+announce() {
+  echo
+  echo "--- $@"
+}
 
-  puts "\n== Preparing database =="
-  system! "bin/rails db:prepare"
+announce "Installing dependencies"
+gem install bundler --conservative
+bundle check || bundle install
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! "bin/rails log:clear tmp:clear"
+announce "Preparing database"
+rails db:prepare
 
-  puts "\n== Restarting application server =="
-  system! "bin/rails restart"
+announce "Removing old logs and tempfiles"
+rails log:clear tmp:clear
 
-  puts "\n== Configuring puma-dev =="
-  system "ln -nfs #{APP_ROOT} ~/.puma-dev/#{APP_NAME}"
-  system "curl -Is https://#{APP_NAME}.test/up | head -n 1"
-end
+announce "Restarting services"
+rails restart
+
+if [ -d "$HOME/.puma-dev" ]; then
+  announce "Configuring puma-dev"
+  ln -nfs "$app_root" "$HOME/.puma-dev/$app_name"
+
+  announce "Checking https://$app_name.test/up: "
+  curl -Is "https://$app_name.test/up" | head -n 1
+fi


### PR DESCRIPTION
That the ruby version is mostly shelling out is a hint that a shell language might be a better choice. It's more direct, slightly faster, it sidesteps chicken/egg problems when installing ruby, and writing things in bash is fun.

It's good to have an excuse to flex those shell muscles 💪

Some different opinions here, where @jorgemanrubia posted about converting in the opposite direction: https://x.com/jorgemanru/status/1808405894889169124. I think the purpose of the script matters: a ruby script that installs a specific ruby version, as our `setup` is wont to do, can be fraught! When we're bootstrapping the system, staying close to the metal is an advantage. For scripts that depend on a functioning environment, ruby is the way to go.