### PR TITLE
Test that bucket creators are given access

### DIFF
--- a/app/models/bucket/accessible.rb
+++ b/app/models/bucket/accessible.rb
@@ -10,18 +10,17 @@ module Bucket::Accessible
         end
       end
 
-      private
-        def grant_to(users)
-          Access.insert_all Array(users).collect { |user| { bucket_id: proxy_association.owner.id, user_id: user.id } }
-        end
+      def grant_to(users)
+        Access.insert_all Array(users).collect { |user| { bucket_id: proxy_association.owner.id, user_id: user.id } }
+      end
 
-        def revoke_from(users)
-          destroy_by user: users
-        end
+      def revoke_from(users)
+        destroy_by user: users
+      end
     end
 
     has_many :users, through: :accesses
 
-    after_create -> { accesses.grant_to(creator) }
+    after_create -> { accesses.grant_to creator }
   end
 end

--- a/test/controllers/buckets_controller_test.rb
+++ b/test/controllers/buckets_controller_test.rb
@@ -5,6 +5,27 @@ class BucketsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as :kevin
   end
 
+  test "index" do
+    get buckets_url
+    assert_response :success
+  end
+
+  test "new" do
+    get new_bucket_url
+    assert_response :success
+  end
+
+  test "create" do
+    assert_difference -> { Bucket.count }, +1 do
+      post buckets_url, params: { bucket: { name: "Remodel Punch List" } }
+    end
+
+    bucket = Bucket.last
+    assert_redirected_to bucket_bubbles_url(bucket)
+    assert_includes bucket.users, users(:kevin)
+    assert_equal "Remodel Punch List", bucket.name
+  end
+
   test "edit" do
     get edit_bucket_url(buckets(:writebook))
     assert_response :success
@@ -12,8 +33,16 @@ class BucketsControllerTest < ActionDispatch::IntegrationTest
 
   test "update" do
     patch bucket_url(buckets(:writebook)), params: { bucket: { name: "Writebook bugs" }, user_ids: users(:david, :jz).pluck(:id) }
+
     assert_redirected_to bucket_bubbles_url(buckets(:writebook))
-    assert_equal users(:david, :jz), buckets(:writebook).users
     assert_equal "Writebook bugs", buckets(:writebook).reload.name
+    assert_equal users(:david, :jz), buckets(:writebook).users
+  end
+
+  test "destroy" do
+    assert_difference -> { Bucket.count }, -1 do
+      delete bucket_url(buckets(:writebook))
+      assert_redirected_to buckets_url
+    end
   end
 end

--- a/test/models/bucket_test.rb
+++ b/test/models/bucket_test.rb
@@ -4,5 +4,11 @@ class BucketTest < ActiveSupport::TestCase
   test "revising access" do
     buckets(:writebook).accesses.revise granted: users(:david, :jz), revoked: users(:kevin)
     assert_equal users(:david, :jz), buckets(:writebook).users
+
+    buckets(:writebook).accesses.grant_to users(:kevin)
+    assert_includes buckets(:writebook).users.reload, users(:kevin)
+
+    buckets(:writebook).accesses.revoke_from users(:kevin)
+    assert_not_includes buckets(:writebook).users.reload, users(:kevin)
   end
 end


### PR DESCRIPTION
`#grant_to` was previously private, which raised upon bucket creation