### PR TITLE
Use counter cache to track bubble comments

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  belongs_to :bubble, touch: true
+  belongs_to :bubble, touch: true, counter_cache: { column: :comments_count, if: :comment? }
 
   delegated_type :messageable, types: Messageable::TYPES, inverse_of: :message, dependent: :destroy
 

--- a/db/migrate/20241113221955_add_comments_count_to_bubbles.rb
+++ b/db/migrate/20241113221955_add_comments_count_to_bubbles.rb
@@ -1,0 +1,5 @@
+class AddCommentsCountToBubbles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :bubbles, :comments_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_13_185136) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_13_221955) do
   create_table "accesses", force: :cascade do |t|
     t.integer "bucket_id", null: false
     t.integer "user_id", null: false
@@ -92,6 +92,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_13_185136) do
     t.integer "bucket_id", null: false
     t.integer "boost_count", default: 0, null: false
     t.integer "stage_id"
+    t.integer "comments_count", default: 0, null: false
     t.index ["bucket_id"], name: "index_bubbles_on_bucket_id"
     t.index ["stage_id"], name: "index_bubbles_on_stage_id"
   end

--- a/lib/rails_ext/conditional_counter_cache.rb
+++ b/lib/rails_ext/conditional_counter_cache.rb
@@ -1,0 +1,34 @@
+module ConditionalCounterCache
+  private
+    def normalize_options(options)
+      counter_cache = options[:counter_cache]
+
+      if counter_cache
+        super.deep_merge(counter_cache: { if: counter_cache[:if] })
+      else
+        super
+      end
+    end
+end
+
+module ConditionalCounterCacheCheck
+  private
+    def require_counter_update?
+      super && counter_cacheable?
+    end
+
+    def counter_cacheable?
+      if counter_cache_if.present?
+        owner.send(counter_cache_if)
+      else
+        true
+      end
+    end
+
+    def counter_cache_if
+      options.fetch(:counter_cache, {})[:if]
+    end
+end
+
+ActiveRecord::Reflection::MacroReflection.prepend ConditionalCounterCache
+ActiveRecord::Associations::BelongsToAssociation.prepend ConditionalCounterCacheCheck

--- a/test/fixtures/bubbles.yml
+++ b/test/fixtures/bubbles.yml
@@ -6,6 +6,7 @@ logo:
   due_on: <%= 3.days.from_now %>
   created_at: <%= 1.week.ago %>
   boost_count: 5
+  comments_count: 2
 
 layout:
   bucket: writebook
@@ -13,6 +14,7 @@ layout:
   title: Layout is broken
   color: "#698F9C"
   created_at: <%= 1.week.ago %>
+  comments_count: 1
 
 text:
   bucket: writebook
@@ -20,6 +22,7 @@ text:
   title: The text is too small
   color: "#3B4B59"
   created_at: <%= 1.week.ago %>
+  comments_count: 0
 
 shipping:
   bucket: writebook
@@ -27,3 +30,4 @@ shipping:
   title: We need to ship the app
   color: "#ED8008"
   created_at: <%= 1.week.ago %>
+  comments_count: 0

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class MessageTest < ActiveSupport::TestCase
+  setup do
+    Current.session = sessions(:david)
+  end
+
+  test "updating bubble counter" do
+    assert_difference "bubbles(:logo).comments_count", 1 do
+      bubbles(:logo).capture Comment.new(body: "I'd prefer something more rustic")
+    end
+
+    assert_difference "bubbles(:logo).comments_count", -1 do
+      bubbles(:logo).messages.comments.last.destroy
+    end
+
+    assert_no_difference "bubbles(:logo).comments_count" do
+      bubbles(:logo).capture EventSummary.new
+    end
+
+    assert_no_difference "bubbles(:logo).comments_count" do
+      bubbles(:logo).messages.event_summaries.last.destroy
+    end
+  end
+end


### PR DESCRIPTION
* Counter caches don't use `COUNT` statements — they increment/decrement counters by 1 https://github.com/basecamp/rails/blob/59064f88d8abda19f81d4bf400cd17d91eb9c65c/activerecord/lib/active_record/associations/belongs_to_association.rb#L53-L59
* Which means introducing a condition is a matter of asking the incumbent record whether it should be counted, not a matter of introducing a `WHERE` clause
* The counter is updated using `update_all` — no callbacks are run https://github.com/basecamp/rails/blob/f1cc2221315b82989f37c999da6e8ba0d0e270eb/activerecord/lib/active_record/relation.rb#L943
* But the bubble _will_ be touched if the association is configured to do so https://github.com/basecamp/rails/blob/59064f88d8abda19f81d4bf400cd17d91eb9c65c/activerecord/lib/active_record/associations/belongs_to_association.rb#L106
* Additionally, dirty-tracked changes on the counter column are cleared after incrementing/decrementing and touching https://github.com/basecamp/rails/blob/3ae6284f0e4f252429210e469b2129a84495612e/activerecord/lib/active_record/persistence.rb#L648
* That means if we went down this path we have three options to recalculate an activity score after a comment is added
   1) hook into `after_touch` (suboptimal, since most touching doesn't require updating the activity score, and no dirty attribute tracking is available to do it conditionally)
   2) hook into `clear_comments_count_change` (hacky, this isn't what the method is for — it's meant for clearing dirty attribute changes, which unfortunately there are none at this point, since `comments_count_will_change!` is never called)
   3) use the counter cache for counting — but recalculate activity in a `Comment` callback (which would have to be `after_commit` because the Comment's `after_save` happens before the counter cache change)

I'm making this PR and then closing to document my findings. But I don't think this is the way to go. I'm thinking we should increment/decrement the counter manually, as well as instruct the bubble to recalculate its score — all in one go inside a Comment's `after_save` callback. Like this:

```diff
diff --git a/app/models/bubble.rb b/app/models/bubble.rb
index a52cb6b..2711997 100644
--- a/app/models/bubble.rb
+++ b/app/models/bubble.rb
@@ -38,6 +38,12 @@ def activity_count
     boost_count + messages.comments.size
   end

+  def rescore
+    update! \
+      activity_count: boost_count + comments_count, # for sorting by activity
+      expires_at: 1.month.from_now # for popping due to entropy
+  end
+
   private
     def set_default_title
       self.title = title.presence || "Untitled"
diff --git a/app/models/bubble/boostable.rb b/app/models/bubble/boostable.rb
index 0853603..f4b1792 100644
--- a/app/models/bubble/boostable.rb
+++ b/app/models/bubble/boostable.rb
@@ -9,6 +9,7 @@ def boost!
     transaction do
       increment! :boost_count
       track_event :boosted
+      rescore
     end
   end
 end
diff --git a/app/models/comment.rb b/app/models/comment.rb
index 4a9afb2..86b235d 100644
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,4 +4,20 @@ class Comment < ApplicationRecord
   belongs_to :creator, class_name: "User", default: -> { Current.user }

   searchable_by :body, using: :comments_search_index
+
+  after_create :increment_bubble_comments_count, :rescore_bubble
+  after_destroy :decrement_bubble_comments_count, :rescore_bubble
+
+  private
+    def increment_bubble_comments_count
+      message.bubble.increment!(:comments_count)
+    end
+
+    def decrement_bubble_comments_count
+      message.bubble.decrement!(:comments_count)
+    end
+
+    def rescore_bubble
+      message.bubble.rescore
+    end
 end
```

cc @kevinmcconnell