### PR TITLE
fix: Send assignment notifications only to the assignee

### DIFF
--- a/app/models/notifier/assigned.rb
+++ b/app/models/notifier/assigned.rb
@@ -1,2 +1,6 @@
 class Notifier::Assigned < Notifier
+  private
+    def recipients
+      event.assignees
+    end
 end

--- a/test/models/notifier_test.rb
+++ b/test/models/notifier_test.rb
@@ -33,4 +33,10 @@ class NotifierTest < ActiveSupport::TestCase
 
     assert_equal bubbles(:logo), Notification.last.resource
   end
+
+  test "for assignment events only create a notification for the assignee" do
+    notifications = Notifier.for(events(:logo_assignment_jz)).generate
+
+    assert_equal [ users(:jz) ], notifications.map(&:user)
+  end
 end


### PR DESCRIPTION
ref: https://37s.fizzy.37signals.com/buckets/693169850/bubbles/999008619