### PR TITLE
Structured logs for controller actions now contain the tenant

### DIFF
--- a/config/initializers/tenanting.rb
+++ b/config/initializers/tenanting.rb
@@ -2,3 +2,7 @@ Rails.application.configure do |config|
   # uuugh this resolver proc is so gross.
   config.middleware.use ActiveRecord::Tenanted::TenantSelector, "ApplicationRecord", ->(request) { request.subdomain.split(".").first }
 end
+
+ActiveSupport.on_load(:action_controller_base) do
+  before_action { logger.struct tenant: ApplicationRecord.current_tenant }
+end


### PR DESCRIPTION
ref: https://37s.fizzy.37signals.com/buckets/693169862/bubbles/999008682