### PR TITLE
dep: bump dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 2f6cc655066556716a40d268d19a856f9610096c
+  revision: 951ea8f75d9bf6d2999df2f0497347976dce9476
   branch: main
   specs:
     actioncable (8.1.0.alpha)
@@ -191,7 +191,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.10.1)
+    json (2.10.2)
     kamal (2.5.3)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -221,7 +221,7 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    minitest (5.25.5)
     msgpack (1.8.0)
     net-imap (0.5.6)
       date
@@ -312,7 +312,7 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
     rqrcode_core (1.2.0)
-    rubocop (1.73.2)
+    rubocop (1.74.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -348,10 +348,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.22.4)
+    sentry-rails (5.23.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.22.4)
-    sentry-ruby (5.22.4)
+      sentry-ruby (~> 5.23.0)
+    sentry-ruby (5.23.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     solid_cable (3.0.7)


### PR DESCRIPTION
- Bump active_record-tenanted to the latest
- Bump rails to the latest
- [x] minitest: 5.25.4 -> 5.25.5
  - used by active_record-tenanted, geared_pagination, importmap-rails, jbuilder, kamal, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] json: 2.10.1 -> 2.10.2
  - used by rails_structured_logging
- [x] sentry-ruby: 5.22.4 -> 5.23.0
  - used by sentry-rails