### PR TITLE
Use the bucket name as part of the card cache key

### DIFF
--- a/app/models/bubble.rb
+++ b/app/models/bubble.rb
@@ -28,6 +28,10 @@ class Bubble < ApplicationRecord
     end
   end
 
+  def cache_key
+    [ super, bucket&.name ].compact.join("/")
+  end
+
   private
     def track_due_date_change
       if due_on.present?


### PR DESCRIPTION
ref: https://37s.fizzy.37signals.com/buckets/693169850/bubbles/999008709

@kevinmcconnell I added the bucket name to the card cache key, to avoid invalidating the cache when non-relevant changes to the bucket are made (e.g., "all access" is toggled). If you have a preference to do it another way, please let me know.