### PR TITLE
Update to AR::Tenanted with the extracted tenant resolver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ git_source(:bc) { |repo| "https://github.com/basecamp/#{repo}" }
 ruby file: ".ruby-version"
 
 gem "rails", github: "rails/rails", branch: "main"
-gem "active_record-tenanted", bc: "active_record-tenanted", branch: "fizzy-temporary"
+gem "active_record-tenanted", bc: "active_record-tenanted", branch: "fizzy-temporary-2"
 
 # Assets & front end
 gem "importmap-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/basecamp/active_record-tenanted
-  revision: 8728b0ea622dfbc15dc27f9ec9086a12ef873430
-  branch: fizzy-temporary
+  revision: dcb9ee57eebfa85ed5a521c40266a0caaecc4a58
+  branch: fizzy-temporary-2
   specs:
     active_record-tenanted (0.1.0)
       activerecord (>= 8.1.alpha)

--- a/config/initializers/tenanting.rb
+++ b/config/initializers/tenanting.rb
@@ -1,6 +1,10 @@
-Rails.application.configure do |config|
-  # uuugh this resolver proc is so gross.
-  config.middleware.use ActiveRecord::Tenanted::TenantSelector, "ApplicationRecord", ->(request) { request.subdomain.split(".").first }
+Rails.application.config.after_initialize do
+  Rails.application.config.active_record_tenanted.tenant_resolver = ->(request) do
+    # in production, we're using a two-level subdomain like "tenant.fizzy.37signals.com", but in
+    # development and beta it's only a single-level subdomain.
+    tld_length = request.domain == "37signals.com" ? 2 : 1
+    request.subdomain(tld_length)
+  end
 end
 
 ActiveSupport.on_load(:action_controller_base) do


### PR DESCRIPTION
With this update:

- we no longer need to explicitly add the TenantSelector middleware
- and we can set up a properly-articulated tenant resolver proc that's used by both TenantSelector and Action Cable connections

ref: https://37s.fizzy.37signals.com/buckets/693169862/bubbles/999008671
