### PR TITLE
Configure tenanted Action Mailer URL helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/basecamp/active_record-tenanted
-  revision: c05d80d4f3f0cd674c04fa8e36dc401485e460b8
+  revision: 499a1d4ef76a50b3e479bbf882a15cabb21ee485
   specs:
     active_record-tenanted (0.1.0)
       activerecord (>= 8.1.alpha)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Set host to be used by links generated in mailer templates.
+  config.action_mailer.default_url_options = { host: "%{tenant}.example.com", port: 3006 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,9 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  # Set host to be used by links generated in mailer templates.
+  config.action_mailer.default_url_options = { host: "%{tenant}.fizzy.37signals.com" }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Set host to be used by links generated in mailer templates.
+  config.action_mailer.default_url_options = { host: "%{tenant}.example.com" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
and update AR::Tenanted to a version that supports it.

ref: [AR::Tenanted integration with Action Mailer](https://37s.fizzy.37signals.com/buckets/693169862/bubbles/999008724)