### PR TITLE
Load past activity when collections list is quite long

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -22,6 +22,7 @@
     <div id="activity" class="events__index flex flex-column">
       <%= render "events/day", activity_day: @activity_day, next_day: @next_day, events: @events %>
     </div>
+    <%= event_next_page_link(@next_day) %>
   </div>
 
   <div class="txt-align-start">
@@ -49,5 +50,3 @@
     </div>
   </div>
 </div>
-
-<%= event_next_page_link(@next_day) %>


### PR DESCRIPTION
ref: https://37s.fizzy.37signals.com/buckets/693169850/bubbles/999008733

This moves the "fetch-on-visible" link to right after the "div#activity" to which it will append, so that it immediately triggers if the first day's grid is short.

The link previously was at the end of the page, meaning that a long list of Collections would push it out of the viewport, requiring a scroll before loading the next day.