### PR TITLE
Add a sort order to represent "staleness"

### DIFF
--- a/app/models/bubble.rb
+++ b/app/models/bubble.rb
@@ -20,6 +20,7 @@ class Bubble < ApplicationRecord
   scope :indexed_by, ->(index) do
     case index
     when "most_active"    then ordered_by_activity
+    when "most_stale"     then ordered_by_staleness
     when "most_discussed" then ordered_by_comments
     when "most_boosted"   then ordered_by_boosts
     when "newest"         then reverse_chronologically

--- a/app/models/filter/fields.rb
+++ b/app/models/filter/fields.rb
@@ -1,7 +1,7 @@
 module Filter::Fields
   extend ActiveSupport::Concern
 
-  INDEXES = %w[ most_discussed most_boosted newest oldest popped ]
+  INDEXES = %w[ most_discussed most_boosted most_stale newest oldest popped ]
 
   delegate :default_value?, to: :class
 

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -110,6 +110,9 @@ class FilterTest < ActiveSupport::TestCase
 
     filters(:jz_assignments).update!(stages: [], assignees: [], tags: [], buckets: [ buckets(:writebook) ])
     assert_equal "Most discussed in Writebook", filters(:jz_assignments).summary
+
+    filters(:jz_assignments).update!(indexed_by: "most_stale")
+    assert_equal "Most stale in Writebook", filters(:jz_assignments).summary
   end
 
   test "params without a key-value pair" do


### PR DESCRIPTION
Adds a way to sort bubbles by "staleness", and exposes it in the filters.

Staleness is defined here as "the amount of activity score lost". We're effectively considering two things:
- how highly it ranked (in terms of activity) at the time of its last event
- how highly it ranks now

The larger the difference between those two scores, the more "stale" it is.

Once we get a feel for this in practice, there are a couple of things we might want to adjust:
- There's a factor used for the decay curve when calculating the above. It's set to 0.9 which should make the decay close to linear. Lowering that factor should emphasize recent changes more, i.e. items will start to seem stale more quickly. So we can try changing this to see if it helps or hurts.
- We're comparing the score at the time of the items last event, which should mean that if a stale items gets some minor action (like a boost), it doesn't change much. However it's possible we'll want to emphasize an initial burst of activity more, in the face of a trickle of fairly minor activity later. If this seems to be a problem we might want to use something like the highest score the bubble ever had, rather than the more recent (or some blend of the two).

I think we'll just need to try it out for a while to know, though.