### PR TITLE
Fix caching issue with cards

### DIFF
--- a/app/views/bubbles/_card.html.erb
+++ b/app/views/bubbles/_card.html.erb
@@ -1,4 +1,4 @@
-<% cache bubble do %>
+<% cache [ bubble, previewing_card? ] do %>
   <article class="card shadow border flex flex-column position-relative txt-align-start full-width border-radius"
         style="--bubble-color: <%= bubble.color %>; view-transition-name: <%= dom_id(bubble, :ticket) %>;"
         id="<%= dom_id(bubble, :ticket) %>">


### PR DESCRIPTION
I introduced this problem with the performance tweaks to avoid an explosion of turbo frame requests when rendering frames.

This fix is partial: at least, we won't break the stage picker in the cards permas. In the lists, we'll still miss the stages. I'll fix that separately.

CC @jzimdars