### PR TITLE
Make event summaries more subtle

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -1,4 +1,7 @@
 @layer components {
+  /* Comment container
+  /* ------------------------------------------------------------------------ */
+
   .comments {
     --avatar-size: 2.33em;
     --comment-padding-block: var(--block-space);
@@ -21,6 +24,9 @@
     padding-inline: calc(var(--comment-padding-block) + var(--inline-space-double));
   }
 
+  /* Comment item
+  /* ------------------------------------------------------------------------ */
+
   .comment {
     margin-inline: auto;
     max-inline-size: var(--comment-max);
@@ -36,8 +42,21 @@
   }
 
   .comment__author {
+    display: flex;
+    align-items: center;
+    gap: 1ch;
+
     .btn {
       font-weight: inherit;
+    }
+  }
+
+  .comment__timestamp {
+    font-size: var(--text-small);
+
+    &:hover {
+      box-shadow: none;
+      opacity: 1;
     }
   }
 
@@ -51,14 +70,12 @@
   }
 
   .comment__body {
-    p {
-      &:first-child {
-        margin-block-start: 0;
-      }
+    p:first-child {
+      margin-block-start: 0;
+    }
 
-      &:last-child {
-        margin-block-end: 0;
-      }
+    p:last-child {
+      margin-block-end: 0;
     }
   }
 
@@ -80,17 +97,6 @@
     }
   }
 
-  .comment__event {
-    max-inline-size: var(--comment-max);
-
-    &::before {
-      /* Make up space for lack of avatar */
-      content: "";
-      display: flex;
-      inline-size: calc(var(--comment-padding-inline) * 0.75);
-    }
-  }
-
   .comment__input {
     --input-border-size: 0;
     --input-padding: 0;
@@ -101,6 +107,30 @@
     @supports (field-sizing: content) {
       field-sizing: content;
       min-block-size: calc(9lh + (2 * var(--comment-padding-block)));
+    }
+  }
+
+  /* Variants
+  /* ------------------------------------------------------------------------ */
+
+  .comment--event {
+    display: flex;
+    inline-size: 100%;
+    max-inline-size: var(--comment-max);
+
+    .comment__content {
+      background: none;
+      opacity: 0.66;
+      padding: 0;
+      font-size: var(--text-small);
+      font-weight: 500;
+    }
+
+    /* Make up space for lack of avatar */
+    &::before {
+      content: "";
+      display: flex;
+      inline-size: calc(var(--comment-padding-inline) * 0.75);
     }
   }
 }

--- a/app/views/comments/_body.html.erb
+++ b/app/views/comments/_body.html.erb
@@ -1,13 +1,13 @@
 <% cache comment do %>
   <%= turbo_frame_tag dom_id(comment) do %>
     <div class="comment__content flex flex-column flex-item-grow full-width">
-      <div class="comment__author flex align-center gap-half">
+      <div class="comment__author">
         <strong>
           <%= link_to comment.creator.name, user_path(comment.creator), class: "txt-ink btn btn--plain fill-transparent", data: { turbo_frame: "_top" } %>
         </strong>
 
-        <%= link_to bucket_bubble_path(comment.bubble.bucket, comment.bubble, anchor: "comment_#{comment.id}"), class: "txt-undecorated txt-uppercase" do %>
-          <%= local_datetime_tag comment.created_at, style: :shortdate, class: "txt-ink translucent" %>
+        <%= link_to bucket_bubble_path(comment.bubble.bucket, comment.bubble, anchor: "comment_#{comment.id}"), class: "comment__timestamp txt-undecorated txt-uppercase txt-ink translucent" do %>
+          <%= local_datetime_tag comment.created_at, style: :shortdate %>
         <% end %>
 
         <%= link_to edit_bucket_bubble_comment_path(comment.bubble.bucket, comment.bubble, comment),

--- a/app/views/event_summaries/_event_summary.html.erb
+++ b/app/views/event_summaries/_event_summary.html.erb
@@ -1,5 +1,5 @@
 <% unless event_summary.body.blank? %>
-  <div class="comment comment__event flex full-width">
+  <div class="comment comment--event">
     <div class="comment__content txt-tight-lines full-width" data-controller="event-summary">
       <%= event_summary.body %>
     </div>


### PR DESCRIPTION
Might be nice to push the event summaries back a bit to keep the visual focus on the conversation. @jzimdars, let me know what you think about this change when you have a minute.

|Before|After|
|--|--|
|![CleanShot 2025-04-03 at 11 59 48@2x](https://github.com/user-attachments/assets/86d55f0f-5f99-49f3-8e56-6798d799e5ed)|![CleanShot 2025-04-03 at 11 58 20@2x](https://github.com/user-attachments/assets/c6e8923f-6c11-4c1f-a231-7b376c0240a8)|