### PR TITLE
Add avatars to event summaries

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -88,6 +88,13 @@
     display: flex;
     inline-size: calc(var(--comment-padding-inline) * 0.75);
   }
+
+  .avatar {
+    --btn-size: 1lh;
+
+    display: inline-grid;
+    vertical-align: bottom;
+  }
 }
 
 .comment__input {

--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -11,7 +11,7 @@ module AvatarsHelper
   end
 
   def avatar_tag(user, hidden_for_screen_reader: false, **options)
-    link_to user_path(user), title: user.name, class: "btn avatar", data: { turbo_frame: "_top" },
+    link_to Rails.application.routes.url_helpers.user_path(user), title: user.name, class: "btn avatar", data: { turbo_frame: "_top" },
         aria: { hidden: hidden_for_screen_reader, label: user.name },
         tabindex: hidden_for_screen_reader ? -1 : nil do
       avatar_image_tag(user, **options)
@@ -19,6 +19,6 @@ module AvatarsHelper
   end
 
   def avatar_image_tag(user, **options)
-    image_tag user_avatar_path(user), aria: { hidden: "true" }, size: 48, class: ("avatar__photo" if user.avatar.attached?), **options
+    image_tag Rails.application.routes.url_helpers.user_avatar_path(user), aria: { hidden: "true" }, size: 48, class: ("avatar__photo" if user.avatar.attached?), **options
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,4 +1,6 @@
 module EventsHelper
+  include AvatarsHelper
+
   def event_day_title(day)
     case
     when day.today?
@@ -92,6 +94,38 @@ module EventsHelper
       "#{event.creator == Current.user ? "You" : event.creator.name} removed the date on <span style='color: var(--bubble-color)'>#{ bubble_title(event.bubble) }</span>"
     when "title_changed"
       "#{event.creator == Current.user ? "You" : event.creator.name} renamed  on <span style='color: var(--bubble-color)'>#{ bubble_title(event.bubble) }</span> (was: '#{event.particulars.dig('particulars', 'old_title')})'".html_safe
+    end
+  end
+
+  def summarize_event(event)
+    case event.action
+    when "published"
+      "Added by #{event_person_tag(event.creator)}."
+    when "assigned"
+      "Assigned to #{event.assignees.map { |assignee| event_person_tag(assignee) }.join(' ').html_safe}."
+    when "unassigned"
+      "Unassigned from #{event.assignees.map { |assignee| event_person_tag(assignee) }.join(' ').html_safe}."
+    when "staged"
+      "#{event_person_tag(event.creator)} moved this to '#{event.stage_name}'."
+    when "popped"
+      "Popped by #{event_person_tag(event.creator)}"
+    when "unstaged"
+      "#{event_person_tag(event.creator)} removed this from '#{event.stage_name}'."
+    when "due_date_added"
+      "#{event_person_tag(event.creator)} set due date to #{event.particulars.dig('particulars', 'due_date').to_date.strftime('%B %-d')}."
+    when "due_date_changed"
+      "#{event_person_tag(event.creator)} changed due date to #{event.particulars.dig('particulars', 'due_date').to_date.strftime('%B %-d')}."
+    when "due_date_removed"
+      "#{event_person_tag(event.creator)} removed the date."
+    when "title_changed"
+      "#{event_person_tag(event.creator)} changed title from '#{event.particulars.dig('particulars', 'old_title')}' to '#{event.particulars.dig('particulars', 'new_title')}'."
+    end
+  end
+
+  def event_person_tag(user)
+    content_tag(:span) do
+      concat avatar_tag(user)
+      concat " #{user.name}"
     end
   end
 

--- a/app/models/event_summary.rb
+++ b/app/models/event_summary.rb
@@ -1,5 +1,5 @@
 class EventSummary < ApplicationRecord
-  include Messageable
+  include Messageable, EventsHelper
 
   has_many :events, -> { chronologically }, dependent: :delete_all, inverse_of: :summary
 
@@ -16,28 +16,7 @@ class EventSummary < ApplicationRecord
     end
 
     def summarize(event)
-      case event.action
-      when "published"
-        "Added by #{event.creator.name}."
-      when "assigned"
-        "Assigned to #{event.assignees.pluck(:name).to_sentence}."
-      when "unassigned"
-        "Unassigned from #{event.assignees.pluck(:name).to_sentence}."
-      when "staged"
-        "#{event.creator.name} moved this to '#{event.stage_name}'."
-      when "popped"
-        "Popped by #{ event.creator.name }"
-      when "unstaged"
-        "#{event.creator.name} removed this from '#{event.stage_name}'."
-      when "due_date_added"
-        "#{event.creator.name} set due date to #{event.particulars.dig('particulars', 'due_date').to_date.strftime('%B %-d')}."
-      when "due_date_changed"
-        "#{event.creator.name} changed due date to #{event.particulars.dig('particulars', 'due_date').to_date.strftime('%B %-d')}."
-      when "due_date_removed"
-        "#{event.creator.name} removed the date."
-      when "title_changed"
-        "#{event.creator.name} changed title from '#{event.particulars.dig('particulars', 'old_title')}' to '#{event.particulars.dig('particulars', 'new_title')}'."
-      end
+      ApplicationController.helpers.summarize_event(event)
     end
 
     def boosts_summary

--- a/app/views/event_summaries/_event_summary.html.erb
+++ b/app/views/event_summaries/_event_summary.html.erb
@@ -1,7 +1,7 @@
 <% unless event_summary.body.blank? %>
   <div class="comment comment__event flex full-width">
     <div class="comment__content txt-tight-lines full-width" data-controller="event-summary">
-      <%= event_summary.body %>
+      <%= event_summary.body.html_safe %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Add avatars to event summaries in the comment thread.

|Before|After|
|--|--|
|![CleanShot 2025-04-04 at 14 02 47@2x](https://github.com/user-attachments/assets/efebdc89-f5e1-485c-9f41-d01c4a26d46e)|![CleanShot 2025-04-04 at 13 32 12@2x](https://github.com/user-attachments/assets/d116fd0e-0b63-4497-a445-abe5cbfb3a63)|

**Disclaimer**: it's likely a programmer will look and this and see that it's done in a funky / not smart / dumb way! Apologies in advance if so—I had to move the content out of the model so I could use the `avatar_tag` helper, and made a few changes suggested by Copilot to get everything to work.

Tests are also failing now, which I'm at a loss at how to resolve. I tried using `assert_select` instead of `assert_equal` to ignore the avatar_tag markup, but apparently that's not possible to use in a unit test. The intricacies of testing are a bit above my head, so I'll stop messing with this in the event I break things further 😅