### PR TITLE
Enable Active Record load_async

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module Fizzy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # enable load_async
+    config.active_record.async_query_executor = :global_thread_pool
   end
 end


### PR DESCRIPTION
Use of load_async was introduced in 49ef811d, but the feature has not been enabled until this change.