### PR TITLE
Remove max_age for your own avatar

### DIFF
--- a/app/controllers/users/avatars_controller.rb
+++ b/app/controllers/users/avatars_controller.rb
@@ -4,7 +4,7 @@ class Users::AvatarsController < ApplicationController
   before_action :set_user
 
   def show
-    if stale? @user, cache_control: { max_age: 30.minutes, stale_while_revalidate: 1.week }
+    if stale? @user, cache_control: { max_age: cache_max_age, stale_while_revalidate: 1.week }
       render_avatar_or_initials
     end
   end
@@ -15,6 +15,14 @@ class Users::AvatarsController < ApplicationController
   end
 
   private
+    def cache_max_age
+      if Current.user == @user
+        0
+      else
+        30.minutes
+      end
+    end
+
     def set_user
       @user = Current.account.users.find(params[:user_id])
     end


### PR DESCRIPTION
To prevent the confusion it creates when you don't see it update after changing it.

We'll still leverage HTTP caching for your own avatar and keep revalidation in the background,
but the browser will always check its staleness.

https://37s.fizzy.37signals.com/buckets/693169850/bubbles/999008840
