### PR TITLE
Perma cards should not always be 100% width

### DIFF
--- a/app/views/bubbles/cards/_perma.html.erb
+++ b/app/views/bubbles/cards/_perma.html.erb
@@ -1,5 +1,5 @@
 <% cache bubble do %>
-  <article class="card shadow border flex flex-column position-relative txt-align-start full-width border-radius"
+  <article class="card shadow border flex flex-column position-relative txt-align-start border-radius"
       style="--bubble-color: <%= bubble.color %>; view-transition-name: <%= dom_id(bubble, :ticket) %>;"
       id="<%= dom_id(bubble, :ticket) %>">
     <header class="card__header flex align-center gap min-width">


### PR DESCRIPTION
We had a utility class on perma cards set to 100% width, and component-level CSS adding a custom size. To get the cards sized correctly, we just need to remove the utility class.