### PR TITLE
Fix tray item position

### DIFF
--- a/app/assets/stylesheets/trays.css
+++ b/app/assets/stylesheets/trays.css
@@ -26,7 +26,7 @@
       inline-size: var(--tray-size);
       outline: 0;
       pointer-events: none;
-      position: absolute;
+      position: absolute !important; /* tmp fix; ideally should remove the position-relative class from tray__item */
       scale: var(--scale);
       transform: translateY(var(--offset));
       transform-origin: center;


### PR DESCRIPTION
Another instance where we're doubling up on styles with utility classes. I couldn't find where the `position-relative` class is being applied, so I'm stomping over it here with `!important` for the time being.