### PR TITLE
Read a card should dismiss all notifications

### DIFF
--- a/app/controllers/cards/readings_controller.rb
+++ b/app/controllers/cards/readings_controller.rb
@@ -2,7 +2,7 @@ class Cards::ReadingsController < ApplicationController
   include CardScoped
 
   def create
-    @notification = Current.user.notifications.find_by(card: @card)
-    @notification.read
+    Current.user.notifications.unread.where(card: @card).read_all
+    @notifications = Current.user.notifications.unread.ordered.limit(20)
   end
 end

--- a/app/views/cards/readings/create.turbo_stream.erb
+++ b/app/views/cards/readings/create.turbo_stream.erb
@@ -1,1 +1,3 @@
-<%= turbo_stream.remove @notification %>
+<%= turbo_stream.update "notifications" do %>
+  <%= render collection: @notifications, partial: "notifications/notification" %>
+<% end %>


### PR DESCRIPTION
Previous code assumed that there was a single notification to dismiss for that card, but in practice there can be zero or many. If it's zero, we need to avoid the crash. If it's many, we should dismiss them all.

Also re-rendering the notification stack after dismissing enables us to remove all the removed cards, as well as reveal any older ones that were previously outside the visible page size.