### PR TITLE
Use morphing in the stream replace the card container

### DIFF
--- a/app/controllers/concerns/card_scoped.rb
+++ b/app/controllers/concerns/card_scoped.rb
@@ -15,6 +15,6 @@ module CardScoped
     end
 
     def render_card_replacement
-      render turbo_stream: turbo_stream.replace([ @card, :card_container ], partial: "cards/container", locals: { card: @card.reload })
+      render turbo_stream: turbo_stream.replace([ @card, :card_container ], partial: "cards/container", method: :morph, locals: { card: @card.reload })
     end
 end

--- a/app/views/cards/_container.html.erb
+++ b/app/views/cards/_container.html.erb
@@ -32,10 +32,9 @@
   </div>
 
   <% if card.published? %>
-    <%# FIXME: Let's move this aside outside of the card container section so these frames don't reload/flicker when card is replaced %>
     <aside class="card-perma__actions card-perma__actions--right" role="toolbar">
-      <%= turbo_frame_tag card, :watch, src: card_watch_path(card) %>
-      <%= turbo_frame_tag card, :pin, src: card_pin_path(card) %>
+      <%= turbo_frame_tag card, :watch, src: card_watch_path(card), data: { turbo_permanent: true } %>
+      <%= turbo_frame_tag card, :pin, src: card_pin_path(card), data: { turbo_permanent: true } %>
     </aside>
 
     <%= render "cards/container/closure", card: card %>


### PR DESCRIPTION
This removes flickering in two parts:

- When reconnecting turbo frames, by flagging them as permanent.
- When replacing the avatar images.

cc @dhh 