### PR TITLE
Introduce a recursive descent parser for the Fizzy Do command line

### DIFF
--- a/lib/do/abstract_parser.rb
+++ b/lib/do/abstract_parser.rb
@@ -1,0 +1,95 @@
+module Do
+  class MissingTokenError < StandardError
+  end
+
+  class AbstractParser
+    # A custom enumerator around the list of tokens. This allows us to implement "maybe" with a
+    # simple transation/rollback construct.
+    class TokenEnumerator
+      class Rollback < StandardError
+      end
+
+      attr_reader :tokens, :index
+
+      def initialize(tokens)
+        @tokens = tokens.to_a
+        @index = 0
+      end
+
+      def next
+        peek.tap { @index += 1 }
+      end
+
+      def peek
+        @tokens[@index]
+      end
+
+      def transaction
+        saved = @index
+        yield
+      rescue Rollback
+        @index = saved
+        nil
+      end
+    end
+
+    attr_reader :tokens
+
+    def initialize(tokens)
+      @tokens = TokenEnumerator.new(tokens)
+    end
+
+    private
+
+    def consume(*values, case_insensitive: false)
+      result =
+        values.map do |value|
+        case [ value, tokens.peek ]
+        in [Class, token] if token.is_a?(value)
+          tokens.next
+        in [_, token]
+          raise MissingTokenError, "Expected #{value} but got #{token.inspect}"
+        end
+      end
+
+      result.size == 1 ? result.first : result
+    end
+
+    def consume_whitespace
+      while tokens.peek.is_a?(WhitespaceToken)
+        tokens.next
+      end
+    end
+
+    def maybe
+      tokens.transaction do
+        yield
+      rescue MissingTokenError
+        raise TokenEnumerator::Rollback
+      end
+    end
+
+    def options
+      value = yield
+      raise MissingTokenError, "Expected one of many to match" if value.nil?
+
+      value
+    end
+
+    def one_or_more
+      items = []
+
+      consume_whitespace
+      items << yield
+
+      loop do
+        consume_whitespace
+        if (item = maybe { yield })
+          items << item
+        else
+          return items
+        end
+      end
+    end
+  end
+end

--- a/lib/do/parser.rb
+++ b/lib/do/parser.rb
@@ -1,0 +1,105 @@
+module Do
+  class Parser < AbstractParser
+    def parse
+      command
+    end
+
+    private
+
+    def command
+      options do
+        maybe { help_command } ||
+        maybe { goto_command } ||
+        maybe { filter_tag_command } ||
+        maybe { assign_card_command } ||
+        maybe { tag_card_command } ||
+        maybe { close_card_command } ||
+        maybe { search_command }
+      end
+    end
+
+    def help_command
+      command = options do
+        maybe { consume_command_name("?") } ||
+        maybe { consume_command_name("help") } ||
+        maybe { consume_command_name("man") }
+      end
+      HelpCommand.new(command:)
+    end
+
+    def goto_command
+      options do
+        maybe { Do::GotoCommand.new(value: consume(PersonReferenceToken)) } ||
+        maybe { Do::GotoCommand.new(value: consume_card_reference) }
+      end
+    end
+
+    def filter_tag_command
+      tags = one_or_more { consume(TagNameToken) }
+      FilterTagCommand.new(tags:)
+    end
+
+    def assign_card_command
+      command = options do
+        maybe { consume_command_name("assign") } ||
+        maybe { consume_command_name("assignto") }
+      end
+      consume_whitespace
+      people = one_or_more { consume(PersonReferenceToken) }
+      AssignCardCommand.new(command:, people:)
+    end
+
+    def tag_card_command
+      command = consume_command_name("tag")
+      consume_whitespace
+      tags = one_or_more do
+        options do
+          maybe { consume(TagNameToken) } || maybe { consume(StringToken) }
+        end
+      end
+      TagCardCommand.new(command:, tags:)
+    end
+
+    def close_card_command
+      command = consume_command_name("close")
+      consume_whitespace
+      cards = one_or_more { consume_card_reference }
+      reason = maybe { consume(StringToken) }
+      CloseCardCommand.new(command:, cards:, reason:)
+    end
+
+    def search_command
+      terms = one_or_more { consume(StringToken) }
+      SearchCommand.new(terms:)
+    end
+
+    # We could detect integers in the tokenizer, but right now the grammar only treats it as a card
+    # reference if it's the first and only token, so I'm doing that check here instead of
+    # introducing an IntegerToken that ends up getting treated like a string if it's not in the
+    # first position.
+    def consume_card_reference
+      result = consume(StringToken)
+      raise MissingTokenError unless result.value =~ /\A\d+\z/
+
+      CardReference.new(value: Integer(result.value))
+    end
+
+    def consume_command_name(name)
+      result = consume(CommandNameToken)
+      raise MissingTokenError unless result.value == name
+
+      result
+    end
+  end
+
+  # --- AST nodes ---
+  CardReference = Struct.new(:value)
+
+  AssignCardCommand = Struct.new(:command, :people)
+  CloseCardCommand  = Struct.new(:command, :cards, :reason)
+  FilterTagCommand  = Struct.new(:command, :tags)
+  GotoCommand       = Struct.new(:command, :value)
+  HelpCommand       = Struct.new(:command)
+  SearchCommand     = Struct.new(:command, :terms)
+  TagCardCommand    = Struct.new(:command, :tags)
+end

--- a/lib/do/tokenizer.rb
+++ b/lib/do/tokenizer.rb
@@ -1,0 +1,119 @@
+module Do
+  class Tokenizer
+    # Used to communicate between tokenization algorithms.
+    class State
+      attr_reader :value, :index
+
+      def initialize(value, index)
+        @value = value
+        @index = index
+      end
+    end
+
+    WHITESPACE = "[\r\n\t ]"
+
+    attr_reader :source, :errors
+
+    def initialize(source)
+      @source = source
+      @errors = []
+    end
+
+    def tokenize
+      Enumerator.new do |enum|
+        index = 0
+
+        while index < source.length
+          state = consume_token(index)
+
+          enum << state.value
+          index = state.index
+        end
+
+        enum << EOFToken.new
+      end
+    end
+
+    private
+
+    def consume_token(index)
+      case source[index..]
+      when %r{\A/}
+        consume_command_name(index + 1)
+      when /\A#/
+        consume_tag_name(index + 1)
+      when /\A@/
+        consume_person_reference(index + 1)
+      when /\A#{WHITESPACE}+/o
+        State.new(WhitespaceToken.new, index + ::Regexp.last_match(0).length)
+      else
+        consume_string(index)
+      end
+    end
+
+    def consume_command_name(index)
+      value = +""
+      while source[index] && !whitespace?(source[index])
+        value << source[index]
+        index += 1
+      end
+      State.new(CommandNameToken.new(value: value), index)
+    end
+
+    def consume_person_reference(index)
+      value = +""
+      while source[index] && !whitespace?(source[index])
+        value << source[index]
+        index += 1
+      end
+      State.new(PersonReferenceToken.new(value: value), index)
+    end
+
+    def consume_tag_name(index)
+      value = +""
+      while source[index] && !whitespace?(source[index])
+        value << source[index]
+        index += 1
+      end
+      State.new(TagNameToken.new(value: value), index)
+    end
+
+    def consume_string(index)
+      value = +""
+      if %q('").include?(source[index])
+        quote = source[index]
+        index += 1
+
+        while source[index] && source[index] != quote
+          value << source[index]
+          index += 1
+        end
+
+        if source[index] == quote
+          index += 1
+        else
+          errors << ParseError.new("unterminated string at #{start}")
+        end
+      else
+        while source[index] && !whitespace?(source[index])
+          value << source[index]
+          index += 1
+        end
+      end
+
+      State.new(StringToken.new(value: value), index)
+    end
+
+    def whitespace?(char)
+      /#{WHITESPACE}/o.match?(char)
+    end
+  end
+
+  class EOFToken; end
+  class WhitespaceToken; end
+
+  CommandNameToken = Struct.new(:value)
+  PersonReferenceToken = Struct.new(:value)
+  StringToken = Struct.new(:value)
+  TagNameToken = Struct.new(:value)
+end

--- a/test/lib/do/parser_test.rb
+++ b/test/lib/do/parser_test.rb
@@ -1,0 +1,164 @@
+require "test_helper"
+
+# This test file uses Ruby's pattern matching to make assertions on the structure of the AST parsed
+# from the "Fizzy Do" command line.
+
+class DoParserTest < ActiveSupport::TestCase
+  test "text search" do
+    parse("activity feed performance") do |ast|
+      ast => Do::SearchCommand(
+        terms: [
+          Do::StringToken(value: "activity"),
+          Do::StringToken(value: "feed"),
+          Do::StringToken(value: "performance"),
+        ]
+      )
+    end
+
+    parse('"activity feed" performance') do |ast|
+      ast => Do::SearchCommand(
+        terms: [
+          Do::StringToken(value: "activity feed"),
+          Do::StringToken(value: "performance"),
+        ]
+      )
+    end
+
+    parse("'activity feed' performance") do |ast|
+      ast => Do::SearchCommand(
+        terms: [
+          Do::StringToken(value: "activity feed"),
+          Do::StringToken(value: "performance"),
+        ]
+      )
+    end
+  end
+
+  test "navigate to person" do
+    parse("@mike") { |ast| ast => Do::GotoCommand(value: Do::PersonReferenceToken(value: "mike")) }
+    parse("@") { |ast| ast => Do::GotoCommand(value: Do::PersonReferenceToken(value: "")) }
+  end
+
+  test "navigate to card" do
+    parse("1234") { |ast| ast => Do::GotoCommand(value: Do::CardReference(value: 1234)) }
+  end
+
+  test "filter by tag" do
+    parse("#low-pri") do |ast|
+      ast => Do::FilterTagCommand(tags: [ Do::TagNameToken(value: "low-pri") ])
+    end
+    parse("#low-pri #quick-win") do |ast|
+      ast => Do::FilterTagCommand(
+        tags: [ Do::TagNameToken(value: "low-pri"), Do::TagNameToken(value: "quick-win") ],
+      )
+    end
+  end
+
+  test "assign card" do
+    # One or more people
+    parse("/assign @mike") do |ast|
+      ast => Do::AssignCardCommand(
+        command: Do::CommandNameToken(value: "assign"),
+        people: [ Do::PersonReferenceToken(value: "mike") ],
+      )
+    end
+    parse("/assign @mike @jz") do |ast|
+      ast => Do::AssignCardCommand(
+        command: Do::CommandNameToken(value: "assign"),
+        people: [ Do::PersonReferenceToken(value: "mike"), Do::PersonReferenceToken(value: "jz") ],
+      )
+    end
+
+    # Alias "assignto"
+    parse("/assignto @mike") do |ast|
+      ast => Do::AssignCardCommand(
+        command: Do::CommandNameToken(value: "assignto"),
+        people: [ Do::PersonReferenceToken(value: "mike") ],
+      )
+    end
+
+    assert_raise(Do::MissingTokenError) { parse("/assignxxx @mike") }
+    assert_raise(Do::MissingTokenError) { parse("/assign") }
+    assert_raise(Do::MissingTokenError) { parse("/assign asdf") }
+    assert_raise(Do::MissingTokenError) { parse("/assign 1234") }
+  end
+
+  test "close card" do
+    parse("/close 1234") do |ast|
+      ast => Do::CloseCardCommand(
+        command: Do::CommandNameToken(value: "close"),
+        cards: [ Do::CardReference(value: 1234) ],
+      )
+    end
+    parse("/close 1234 2345") do |ast|
+      ast => Do::CloseCardCommand(
+        command: Do::CommandNameToken(value: "close"),
+        cards: [ Do::CardReference(value: 1234), Do::CardReference(value: 2345) ],
+      )
+    end
+    parse("/close 1234 2345 Duplicate") do |ast|
+      ast => Do::CloseCardCommand(
+        command: Do::CommandNameToken(value: "close"),
+        cards: [ Do::CardReference(value: 1234), Do::CardReference(value: 2345) ],
+        reason: Do::StringToken(value: "Duplicate"),
+      )
+    end
+    parse('/close 1234 2345 "Maybe later"') do |ast|
+      ast => Do::CloseCardCommand(
+        command: Do::CommandNameToken(value: "close"),
+        cards: [ Do::CardReference(value: 1234), Do::CardReference(value: 2345) ],
+        reason: Do::StringToken(value: "Maybe later"),
+      )
+    end
+
+    assert_raise(Do::MissingTokenError) { parse("/close") }
+    assert_raise(Do::MissingTokenError) { parse("/closexxx 1234") }
+  end
+
+  test "tag card" do
+    # One or more tags
+    parse("/tag #low-pri") do |ast|
+      ast => Do::TagCardCommand(
+        command: Do::CommandNameToken(value: "tag"),
+        tags: [ Do::TagNameToken(value: "low-pri") ],
+      )
+    end
+    parse("/tag #low-pri #small-batch") do |ast|
+      ast => Do::TagCardCommand(
+        command: Do::CommandNameToken(value: "tag"),
+        tags: [ Do::TagNameToken(value: "low-pri"), Do::TagNameToken(value: "small-batch") ],
+      )
+    end
+
+    # Treat normal strings as tags in this context
+    parse("/tag low-pri small-batch") do |ast|
+      ast => Do::TagCardCommand(
+        command: Do::CommandNameToken(value: "tag"),
+        tags: [ Do::StringToken(value: "low-pri"), Do::StringToken(value: "small-batch") ],
+      )
+    end
+
+    assert_raise(Do::MissingTokenError) { parse("/tag") }
+    assert_raise(Do::MissingTokenError) { parse("/tagxxx #low-pri") }
+  end
+
+  test "help" do
+    parse("/help") { |ast| ast => Do::HelpCommand(command: Do::CommandNameToken(value: "help")) }
+    parse("/man") { |ast| ast => Do::HelpCommand(command: Do::CommandNameToken(value: "man")) }
+    parse("/?") { |ast| ast => Do::HelpCommand(command: Do::CommandNameToken(value: "?")) }
+
+    assert_raise(Do::MissingTokenError) { parse("/helpxxx") }
+  end
+
+  private
+
+    def parse(input, debug: false)
+      tokens = Do::Tokenizer.new(input).tokenize
+      pp(tokens.to_a) if debug
+
+      ast = Do::Parser.new(tokens).parse
+      pp(ast) if debug
+
+      assert_pattern { yield ast }
+    end
+end

--- a/test/lib/do/tokenizer_test.rb
+++ b/test/lib/do/tokenizer_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class DoTokenizerTest < ActiveSupport::TestCase
+  test "tokenize string" do
+    parse("hello") { |tok| tok => [Do::StringToken(value: "hello"), Do::EOFToken] }
+
+    # Special characters are allowed.
+    parse("👋áçöñ☕") { |tok| tok => [Do::StringToken(value: "👋áçöñ☕"), Do::EOFToken] }
+
+    # Note that numbers aren't treated differently by the tokenizer, though the parser will check if
+    # an initial string token is a number.
+    parse("1234") { |tok| tok => [Do::StringToken(value: "1234"), Do::EOFToken] }
+
+    # Multiple words are allowed
+    parse("hello world") do |tokens|
+      tokens => [
+        Do::StringToken(value: "hello"),
+        Do::WhitespaceToken,
+        Do::StringToken(value: "world"),
+        Do::EOFToken,
+      ]
+    end
+
+    # Quoted strings are treated as a single string
+    parse('load "activity feed" performance') do |tokens|
+      tokens => [
+        Do::StringToken(value: "load"),
+        Do::WhitespaceToken,
+        Do::StringToken(value: "activity feed"),
+        Do::WhitespaceToken,
+        Do::StringToken(value: "performance"),
+        Do::EOFToken,
+      ]
+    end
+    parse("load 'activity feed' performance") do |tokens|
+      tokens => [
+        Do::StringToken(value: "load"),
+        Do::WhitespaceToken,
+        Do::StringToken(value: "activity feed"),
+        Do::WhitespaceToken,
+        Do::StringToken(value: "performance"),
+        Do::EOFToken,
+      ]
+    end
+  end
+
+  test "tokenize person reference" do
+    parse("@mike") { |tok| tok => [Do::PersonReferenceToken(value: "mike"), Do::EOFToken] }
+
+    parse("abc @mike xyz") do |tok|
+      tok => [
+        Do::StringToken(value: "abc"),
+        Do::WhitespaceToken,
+        Do::PersonReferenceToken(value: "mike"),
+        Do::WhitespaceToken,
+        Do::StringToken(value: "xyz"),
+        Do::EOFToken,
+      ]
+    end
+
+    # An @ sign by itself is an empty reference, not a bare string.
+    parse("@") { |tok| tok => [Do::PersonReferenceToken(value: ""), Do::EOFToken] }
+  end
+
+  test "tag reference" do
+    parse("#low-pri") { |tok| tok => [ Do::TagNameToken(value: "low-pri"), Do::EOFToken ] }
+    parse("#👋áçöñ☕") { |tok| tok => [ Do::TagNameToken(value: "👋áçöñ☕"), Do::EOFToken ] }
+    parse("#") { |tok| tok => [ Do::TagNameToken(value: ""), Do::EOFToken ] }
+  end
+
+  private
+
+    def parse(input, debug: false)
+      tokens = Do::Tokenizer.new(input).tokenize.to_a
+      pp(tokens) if debug
+
+      assert_pattern { yield tokens }
+    end
+end


### PR DESCRIPTION
Using a hand-written recursive descent parser instead of a LALR parser generator (like lex/yacc or rex/racc) because IMHO it's easier to understand, extend, and debug. It also allows us to be a bit more error-tolerant where we need to.

The AST I'm introducing here is pretty simple, and I'm not tracking token location because my assumption is that the parsed strings are all going to be short.

I'll also note that this approach, and some of the API patterns, borrow from the Ruby "syntax tree" projects, see https://github.com/ruby-syntax-tree for other living examples.

ref: https://3.basecamp.com/2914079/buckets/37331921/documents/8608517933

---

I'm pushing this PR to get feedback on this approach; if nobody is opposed, then next steps would probably be:

- implement the remaining pieces of the syntax/grammar
- make the parse error reporting clearer (e.g., when the CLI command is incomplete or there are additional tokens that can't be parsed)
