### PR TITLE
Use black for completed card color

### DIFF
--- a/app/assets/stylesheets/_global.css
+++ b/app/assets/stylesheets/_global.css
@@ -159,6 +159,7 @@
 
   /* Colors: Cards */
   --color-card-default: oklch(var(--lch-blue-dark));
+  --color-card-complete: var(--color-ink);
   --color-card-1: oklch(var(--lch-ink-medium));
   --color-card-2: oklch(var(--lch-uncolor-medium));
   --color-card-3: oklch(var(--lch-yellow-medium));

--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -266,7 +266,7 @@
 
     .card:has(&),
     .card-perma:has(&) {
-      --card-color: var(--card-color-1) !important;
+      --card-color: var(--color-card-complete) !important;
     }
   }
 


### PR DESCRIPTION
Whoops, missed the card color for completed items.

|Before|After|
|--|--|
|![CleanShot 2025-05-06 at 13 36 11@2x](https://github.com/user-attachments/assets/4e912632-b742-475e-9cbb-cfd22d68f0fe)|![CleanShot 2025-05-06 at 13 36 04@2x](https://github.com/user-attachments/assets/7376bf73-5bdb-442f-a286-cd468ccbff65)|