### PR TITLE
Completed text outline

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -251,7 +251,6 @@
     color: var(--card-color);
     display: flex;
     flex-direction: column;
-    font-family: var(--font-mono);
     font-weight: bold;
     inset: auto var(--block-space) var(--block-space-double) auto;
     justify-content: center;
@@ -260,7 +259,6 @@
     mix-blend-mode: multiply;
     padding: 1ch;
     position: absolute;
-    text-transform: uppercase;
     transform: rotate(-10deg);
 
     @media (prefers-color-scheme: dark) {
@@ -274,24 +272,17 @@
   }
 
   .card__closed-title {
-    -webkit-text-stroke: 0.3ch var(--card-color);
-    color: var(--color-ink-inverted);
-    font-family: var(--font-sans);
     font-size: 1.5em;
-    font-weight: 600;
-    letter-spacing: 0.05ch;
+    font-weight: 900;
     line-height: 1.2;
     position: relative;
     text-align: center;
+    text-transform: uppercase;
+  }
 
-    /* Lay a copy of the text on top to make up for the center-aligned stroke */
-    &:after {
-      -webkit-text-stroke: 0;
-      color: var(--color-canvas);
-      content: attr(data-text);
-      inset: 0;
-      position: absolute;
-    }
+  .card__closed-date {
+    font-family: var(--font-mono);
+    text-transform: uppercase;
   }
 
   .card__closed-by {

--- a/app/views/cards/display/common/_background.html.erb
+++ b/app/views/cards/display/common/_background.html.erb
@@ -5,7 +5,7 @@
 <% if card.closed? %>
   <div class="card__closed">
     <span class="card__closed-title" data-text="<%= card.closure.reason %>"><%= card.closure.reason %></span>
-    <strong class="txt-uppercase"><%= card.closed_at.strftime("%b %d, %Y") %></strong>
+    <strong class="card__closed-date"><%= card.closed_at.strftime("%b %d, %Y") %></strong>
     <span>by <span class="card__closed-by"><%= card.closed_by.familiar_name %></span></span>
   </div>
 <% end %>


### PR DESCRIPTION
Uses the `text-stroke` property for outlined text instead of layering multiple `text-shadows`. You can especially see the difference with letters that have straight terminals (W, T, etc.).

I also tweaked the other text to make it a little more stamp-like. Lemme know what you think, @jzimdars!

|Before|After|
|--|--|
|![CleanShot 2025-05-07 at 10 59 20@2x](https://github.com/user-attachments/assets/957dda97-9efa-4687-9485-a86b65abad4d)|![CleanShot 2025-05-07 at 10 58 12@2x](https://github.com/user-attachments/assets/33c17e22-f56f-4e88-be4c-3f80a8e98b3c)|
|![CleanShot 2025-05-07 at 10 59 40@2x](https://github.com/user-attachments/assets/e0327411-51a6-4078-a45a-4cd051120e1d)|![CleanShot 2025-05-07 at 10 58 37@2x](https://github.com/user-attachments/assets/8c03349f-d19f-4ee7-8097-bcac1d4426d6)|