### PR TITLE
Ensure that cards with an empty title aren't mysterious in notifs

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,9 +1,9 @@
 module NotificationsHelper
   def event_notification_title(event)
     case event_notification_action(event)
-    when "comment_created" then "RE: " + event.eventable.card.title
-    when "card_assigned" then "Assigned to #{event.assignees.pluck(:name).to_sentence}: " + event.eventable.title
-    else event.eventable.title
+    when "comment_created" then "RE: #{card_notification_title(event.eventable.card)}"
+    when "card_assigned" then "Assigned to #{event.assignees.pluck(:name).to_sentence}: #{card_notification_title(event.eventable)}"
+    else card_notification_title(event.eventable)
     end
   end
 
@@ -58,5 +58,9 @@ module NotificationsHelper
     def comment_notification_body(event)
       comment = event.eventable
       "#{strip_tags(comment.body_html).blank? ? "#{event.creator.name} replied" : "#{event.creator.name}:" } #{strip_tags(comment.body_html).truncate(200)}"
+    end
+
+    def card_notification_title(card)
+      card.title.presence || "Card #{card.id}"
     end
 end


### PR DESCRIPTION
Use something like "Card 55" instead of it being blank or raising an exception.

Example [exception in sentry](https://basecamp.sentry.io/issues/6567761497/?project=4508093839179776&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0)