### PR TITLE
Ensure that a "reconsidered" card gets an updated timestamp

### DIFF
--- a/app/models/card/engageable.rb
+++ b/app/models/card/engageable.rb
@@ -49,6 +49,7 @@ module Card::Engageable
     transaction do
       reopen
       engagement&.destroy
+      touch(:last_active_at)
     end
   end
 end

--- a/test/models/card/engageable_test.rb
+++ b/test/models/card/engageable_test.rb
@@ -48,6 +48,8 @@ class Card::EngageableTest < ActiveSupport::TestCase
   end
 
   test "auto_reconsider_all_stagnated" do
+    travel_to Time.current
+
     cards(:logo, :shipping).each(&:engage)
 
     cards(:logo).update!(last_active_at: 1.day.ago - Card::Engageable::STAGNATED_AFTER)
@@ -59,5 +61,6 @@ class Card::EngageableTest < ActiveSupport::TestCase
 
     assert cards(:shipping).reload.doing?
     assert cards(:logo).reload.considering?
+    assert_equal Time.current, cards(:logo).last_active_at
   end
 end


### PR DESCRIPTION
so that it's not closed by the subsequent Card::AutoCloseAllDueJob

ref: https://37s.fizzy.37signals.com/collections/693169850/cards/999009030