### PR TITLE
Don't run solid queue in dev by default

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -4,5 +4,9 @@ echo "Access with david@37signals.com / secret123456 on http://37signals.fizzy.l
 echo "Access with david@37signals.com / secret123456 on http://honcho.fizzy.localhost:3006"
 echo "Access first run on http://first-run.fizzy.localhost:3006"
 
-export SOLID_QUEUE_IN_PUMA=1
+if [ -f tmp/solid-queue.txt ]; then
+  # see also config/environments/development.rb
+  export SOLID_QUEUE_IN_PUMA=1
+fi
+
 exec ./bin/rails server -p 3006

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,8 +75,10 @@ Rails.application.configure do
   # Allow all hosts in development
   config.hosts = nil
 
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  if Rails.root.join("tmp/solid-queue.txt").exist?
+    config.active_job.queue_adapter = :solid_queue
+    config.solid_queue.connects_to = { database: { writing: :queue } }
+  end
 
   if Rails.root.join("tmp/structured-logging.txt").exist?
     config.structured_logging.logger = ActiveSupport::Logger.new("log/structured-development.log")


### PR DESCRIPTION
Don't run solid queue in dev by default, but allow it to be turned on by touching `tmp/solid-queue.txt`

Related to #447 and #469 

cc @brunoprietog 