### PR TITLE
Render the "last active at" timestamp in the card meta

### DIFF
--- a/app/views/cards/display/common/_meta.html.erb
+++ b/app/views/cards/display/common/_meta.html.erb
@@ -13,7 +13,7 @@
         &nbsp;
       <% else %>
         Updated
-        <%= local_datetime_tag(card.updated_at, style: :daysago) %>
+        <%= local_datetime_tag(card.last_active_at, style: :daysago) %>
       <% end %>
     </span>
     <span class="card__meta-item card__meta-item--reported overflow-ellipsis">


### PR DESCRIPTION
because this is what the "closing soon" bubbles et al are triggered on, and we should be consistent. If the two dates ever diverge, it's going to be confusing for users.