### PR TITLE
Ensure dates are re-formatted on turbo frame load

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   </head>
 
-  <body data-controller="lightbox local-time timezone-cookie" data-action="turbo:morph@window->local-time#refreshAll">
+  <body data-controller="lightbox local-time timezone-cookie" data-action="turbo:morph@window->local-time#refreshAll turbo:frame-load->local-time#refreshAll">
     <header id="header">
       <a href="#main-content" class="skip-navigation btn">Skip to main content</a>
       <%= yield :header %>


### PR DESCRIPTION
ref: https://37s.fizzy.37signals.com/collections/693169850/cards/999009063

I'm not at all sure that this is the _optimal_ fix -- I can still see a flash-of-unformatted-dates -- but it at least makes sure we're displaying the dates properly after, e.g., updating the workflow stage on a card perma.

(See the card linked above for a video demo of what's going wrong)