### PR TITLE
Handle collections that do not auto close

### DIFF
--- a/app/models/card/closeable.rb
+++ b/app/models/card/closeable.rb
@@ -34,7 +34,7 @@ module Card::Closeable
   end
 
   def closing_soon?
-    considering? && Time.current >= auto_close_at - AUTO_CLOSE_REMINDER_BEFORE
+    considering? && auto_closing? && Time.current >= auto_close_at - AUTO_CLOSE_REMINDER_BEFORE
   end
 
   def closed?


### PR DESCRIPTION
Currently they error while trying to calculate `closing_soon?`

ref: https://37s.fizzy.37signals.com/collections/693169850/cards/999009065