### PR TITLE
Refresh local time target when morphed

### DIFF
--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -1,5 +1,5 @@
 module TimeHelper
   def local_datetime_tag(datetime, style: :time, **attributes)
-    tag.time **attributes, datetime: datetime.iso8601, data: { local_time_target: style }
+    tag.time **attributes, datetime: datetime.iso8601, data: { local_time_target: style, action: "turbo:morph-element->local-time#refreshTarget" }
   end
 end

--- a/app/javascript/controllers/local_time_controller.js
+++ b/app/javascript/controllers/local_time_controller.js
@@ -37,6 +37,12 @@ export default class extends Controller {
     })
   }
 
+  refreshTarget(event) {
+    const target = event.target;
+    const targetName = target.dataset.localTimeTarget
+    this.#formatTime(this[`${targetName}Formatter`], target)
+  }
+
   timeTargetConnected(target) {
     this.#formatTime(this.timeFormatter, target)
   }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   </head>
 
-  <body data-controller="lightbox local-time timezone-cookie" data-action="turbo:morph@window->local-time#refreshAll turbo:frame-load->local-time#refreshAll">
+  <body data-controller="lightbox local-time timezone-cookie" data-action="turbo:morph@window->local-time#refreshAll">
     <header id="header">
       <a href="#main-content" class="skip-navigation btn">Skip to main content</a>
       <%= yield :header %>


### PR DESCRIPTION
We replace cards with a turbo stream that uses morphing for the replacement. This will make sure that the local times get refreshed when the corresponding target is morphed. 

Alternative to https://github.com/basecamp/fizzy/pull/486 that will remove any flickering. That was working as a side effect of having turbo-frames being reloaded, but the problem wasn't related to turbo frames. Also, this will only refresh the changed target, instead of reloading all the local time targets in the page. 

cc @flavorjones 