### PR TITLE
Max height for media in comments

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -61,6 +61,18 @@
         margin-block-end: 0;
       }
     }
+
+    img,
+    video,
+    embed,
+    object {
+      max-block-size: 32rem;
+
+      /* Links should hug media contained within */
+      a:has(&) {
+        display: inline-block;
+      }
+    }
   }
 
   .comment__content {


### PR DESCRIPTION
Rather arbitrarily picked 32rem as the max height (similar to what we have in BC).

Right now, media is laid out with `inline-block`, which means portrait-format images (or stuff that's just really small), will sit side-by-side. Might be nice to have a more robust grid mechanism sort of like we have in BC or KIA, but this at least solves the immediate problem.

|Before|After|
|--|--|
|![CleanShot 2025-05-14 at 13 38 56@2x](https://github.com/user-attachments/assets/e614601d-85cf-4867-b63d-4e7fa12457b5)|![CleanShot 2025-05-14 at 13 38 41@2x](https://github.com/user-attachments/assets/600378e6-5dc4-4485-a634-47712fa33d98)|