### PR TITLE
Only render bubbles for cards in auto-closing collections

### DIFF
--- a/app/views/cards/display/_preview.html.erb
+++ b/app/views/cards/display/_preview.html.erb
@@ -29,10 +29,12 @@
 
     <%= render "cards/display/common/background", card: card %>
 
-    <% if card.considering? %>
-      <%= render "cards/display/preview/bubble", card: card, style: "closing" %>
-    <% elsif card.doing? %>
-      <%= render "cards/display/preview/bubble", card: card, style: "considering" %>
+    <% if card.auto_closing? %>
+      <% if card.considering? %>
+        <%= render "cards/display/preview/bubble", card: card, style: "closing" %>
+      <% elsif card.doing? %>
+        <%= render "cards/display/preview/bubble", card: card, style: "considering" %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
This is a quick fix. Will clean it up in a follow-up commit that simplifies the view templates and the Card model.