### PR TITLE
Move media size to markdown-content

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -61,18 +61,6 @@
         margin-block-end: 0;
       }
     }
-
-    img,
-    video,
-    embed,
-    object {
-      max-block-size: 32rem;
-
-      /* Links should hug media contained within */
-      a:has(&) {
-        display: inline-block;
-      }
-    }
   }
 
   .comment__content {

--- a/app/assets/stylesheets/markdown-content.css
+++ b/app/assets/stylesheets/markdown-content.css
@@ -97,5 +97,14 @@
       border-block-end-width: 3px;
       font-weight: 700;
     }
+
+    :where(img, video, embed, object) {
+      max-block-size: 32rem;
+
+      /* Links should hug media contained within */
+      a:has(&) {
+        display: inline-block;
+      }
+    }
   }
 }


### PR DESCRIPTION
Moves the CSS for media sizing into `.markdown-content` so it applies to comments and card info.