### PR TITLE
Reduce specificity of base tray__item class

### DIFF
--- a/app/assets/stylesheets/trays.css
+++ b/app/assets/stylesheets/trays.css
@@ -21,7 +21,7 @@
     position: fixed;
     z-index: var(--z-tray);
 
-    .tray__item {
+    :where(.tray__item) {
       --tray-item-delay: calc((var(--tray-item-index) - 1) * 10ms);
       --tray-item-y: calc((var(--tray-item-index) - 1) * (var(--tray-item-offset) * -1) - var(--tray-bottom-padding));
       --tray-item-index: 1;


### PR DESCRIPTION
Fixes an issue where the base `tray__item` styles were overriding some classes further down. They were too strong! We need the parent `.tray` scope here to create distinct styles for the tray vs the standalone notifications page.

|Before|After|
|--|--|
|![CleanShot 2025-05-21 at 10 12 30@2x](https://github.com/user-attachments/assets/b84995e4-cf10-465f-a2ae-1325b284b72e)|![CleanShot 2025-05-21 at 10 14 26@2x](https://github.com/user-attachments/assets/0c9c110a-bf6c-49c4-b550-838a6644f70b)|