### PR TITLE
Show Notification page link when no notifications exist

### DIFF
--- a/app/assets/stylesheets/trays.css
+++ b/app/assets/stylesheets/trays.css
@@ -89,7 +89,7 @@
       transform: translateY(0);
     }
 
-    .tray:not(:has(.tray__item)) & {
+    .tray:not(:has(.tray__item:not(.tray__item--overflow))) & {
       opacity: 1;
       scale: 1;
       transform: none;


### PR DESCRIPTION
Another fix from the tray updates. Since the overflow link now has the `tray__item` class, we need to be more specific about what defines an empty tray.

|Before|After|
|--|--|
|![CleanShot 2025-05-21 at 10 47 41@2x](https://github.com/user-attachments/assets/51c30024-49ab-4cde-bff8-194ec42360a7)|![CleanShot 2025-05-21 at 10 47 31@2x](https://github.com/user-attachments/assets/1afe832d-3bbd-4f1b-8804-e61cc8fa3227)|