### PR TITLE
Activity column fix

### DIFF
--- a/app/assets/stylesheets/events.css
+++ b/app/assets/stylesheets/events.css
@@ -79,7 +79,7 @@
 
   .events__column-header {
     background-color: var(--color-canvas);
-    grid-row-start: 2;
+    grid-row-start: 1;
     inset-block-start: calc(var(--events-gap) * -2);
     margin-block-end: var(--events-gap);
     padding-block: calc(var(--events-gap) * 3) var(--events-gap);


### PR DESCRIPTION
Things looked off because an extra grid column was getting introduced on the right. Seems like the browser didn't know what column to put the column headers in some cases (not sure why some and not all cases, though), so it created another column to drop it in.

We currently place grid positions on all the cards, but not on the headers. To fix this, we just need to be explicit about what column the headers go in.

|Before|After|
|--|--|
|![CleanShot 2025-05-21 at 01 11 06@2x](https://github.com/user-attachments/assets/293b8a6a-1722-4d2a-98ae-a2e6afc3f216)|![CleanShot 2025-05-21 at 01 13 08@2x](https://github.com/user-attachments/assets/0e236a29-cb71-4e4b-8e52-d9735c678c4f)|