### PR TITLE
dep: update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/basecamp/active_record-tenanted
-  revision: 612f5e8b7f77b7076a7eb21521920630161461aa
+  revision: 2bab09d2d6ae9791b9b3e645574b3fec4b6849f3
   specs:
     active_record-tenanted (0.1.0)
       activerecord (>= 8.1.alpha)
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: bc7f77b32d7f3f26db654cae506c26a959852506
+  revision: c1d7d56e831acf0aff5f3e27a6b384f543f358d0
   branch: main
   specs:
     actioncable (8.1.0.alpha)
@@ -65,6 +65,7 @@ GIT
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
     actiontext (8.1.0.alpha)
+      action_text-trix (~> 2.1.15)
       actionpack (= 8.1.0.alpha)
       activerecord (= 8.1.0.alpha)
       activestorage (= 8.1.0.alpha)
@@ -131,6 +132,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    action_text-trix (2.1.15)
+      railties
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
@@ -139,7 +142,7 @@ GEM
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
-    bootsnap (1.18.4)
+    bootsnap (1.18.6)
       msgpack (~> 1.2)
     brakeman (7.0.2)
       racc
@@ -168,8 +171,9 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     dotenv (3.1.8)
-    drb (2.2.1)
+    drb (2.2.3)
     ed25519 (1.4.0)
+    erb (5.0.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -208,7 +212,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.11.3)
-    kamal (2.6.0)
+    kamal (2.6.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)
@@ -222,7 +226,7 @@ GEM
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.24.0)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -233,13 +237,13 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
     multipart-post (2.4.1)
     net-http (0.6.0)
       uri
-    net-imap (0.5.7)
+    net-imap (0.5.8)
       date
       net-protocol
     net-pop (0.1.2)
@@ -277,7 +281,7 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
-    psych (5.2.3)
+    psych (5.2.6)
       date
       stringio
     public_suffix (6.0.1)
@@ -285,7 +289,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.14)
+    rack (3.1.15)
     rack-contrib (2.5.0)
       rack (< 4)
     rack-session (2.1.1)
@@ -295,7 +299,7 @@ GEM
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -305,7 +309,8 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     rb_sys (0.9.106)
-    rdoc (6.13.1)
+    rdoc (6.14.0)
+      erb
       psych (>= 4.0.0)
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
@@ -348,19 +353,19 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.31.0)
+    selenium-webdriver (4.32.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.23.0)
+    sentry-rails (5.24.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.23.0)
-    sentry-ruby (5.23.0)
+      sentry-ruby (~> 5.24.0)
+    sentry-ruby (5.24.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    solid_cable (3.0.7)
+    solid_cable (3.0.8)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -430,7 +435,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.2)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   arm64-darwin


### PR DESCRIPTION
AR::Tenanted:
- from 612f5e8b7f77b7076a7eb21521920630161461aa                                                                - to 2bab09d2d6ae9791b9b3e645574b3fec4b6849f3

Rails:
- from: bc7f77b32d7f3f26db654cae506c26a959852506
- to: c1d7d56e831acf0aff5f3e27a6b384f543f358d0

Other:
- [x] drb: 2.2.1 -> 2.2.3
  - used by active_record-tenanted, geared_pagination, importmap-rails, jbuilder, kamal, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] erb:  -> 5.0.1
  - used by active_record-tenanted, importmap-rails, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] loofah: 2.24.0 -> 2.24.1
  - used by active_record-tenanted, importmap-rails, jbuilder, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] mini_portile2: 2.8.8 -> 2.8.9
  - used by active_record-tenanted, importmap-rails, jbuilder, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, sqlite3, stimulus-rails, turbo-rails
- [x] psych: 5.2.3 -> 5.2.6
  - used by active_record-tenanted, importmap-rails, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] rack: 3.1.14 -> 3.1.15
  - used by active_record-tenanted, importmap-rails, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] rails-dom-testing: 2.2.0 -> 2.3.0
  - used by active_record-tenanted, importmap-rails, jbuilder, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] rdoc: 6.13.1 -> 6.14.0
  - used by active_record-tenanted, importmap-rails, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] zeitwerk: 2.7.2 -> 2.7.3
  - used by active_record-tenanted, importmap-rails, kamal, propshaft, rails, rails_structured_logging, ruby_llm, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] action_text-trix:  -> 2.1.15
  - used by rails, rails_structured_logging
- [x] net-imap: 0.5.7 -> 0.5.8
  - used by rails, rails_structured_logging
- [x] sentry-ruby: 5.23.0 -> 5.24.0
  - used by sentry-rails