### PR TITLE
Prevent default when handling keyboard shortcuts

### DIFF
--- a/app/javascript/controllers/hotkey_controller.js
+++ b/app/javascript/controllers/hotkey_controller.js
@@ -3,6 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   click(event) {
     if (this.#isClickable && !this.#shouldIgnore(event)) {
+      event.preventDefault()
       this.element.click()
     }
   }

--- a/app/views/commands/_form.html.erb
+++ b/app/views/commands/_form.html.erb
@@ -4,7 +4,7 @@
       data: {
         controller: "form",
         terminal_target: "form",
-        action: "turbo:submit-start->terminal#commandSubmitted turbo:submit-end->terminal#focus keydown.meta+k@document->terminal#focus keydown.ctrl+k@document->terminal#focus keydown.enter->terminal#executeCommand keydown.esc->terminal#hideMenus turbo:submit-end->terminal#handleCommandResponse"
+        action: "turbo:submit-start->terminal#commandSubmitted turbo:submit-end->terminal#focus keydown.meta+k@document->terminal#focus:prevent keydown.ctrl+k@document->terminal#focus:prevent keydown.enter->terminal#executeCommand keydown.esc->terminal#hideMenus turbo:submit-end->terminal#handleCommandResponse"
       } do %>
   <label class="terminal__label txt-nowrap" for="fizzy_do">Fizzy do &gt;</label>
 
@@ -22,4 +22,3 @@
 
   <%=  hidden_field_tag "confirmed", nil, data: { terminal_target: "confirmation" } %>
 <% end %>
-


### PR DESCRIPTION
Without this, any default action would still happen. With Chrome on Linux, that was causing some browser features to be triggered alongside our CTRL+J and CTRL+K actions.

/cc @jzimdars 