### PR TITLE
Use consistent rem margins

### DIFF
--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -1,6 +1,6 @@
 @layer components {
   .rich-text-content {
-    --block-margin: 0.65lh;
+    --block-margin: 1rem;
 
     :where(h1, h2, h3, h4, h5, h6) {
       display: block;
@@ -102,7 +102,7 @@
     .attachment__figure {
       --hover-size: 0;
     }
-    
+
     .attachment--file {
       align-items: center;
       display: inline-flex;


### PR DESCRIPTION
Use a fixed value for rich text margins that isn't based on font size.

It's a pretty subtle change, TBH! Even so, I think it does hold content together a bit better, especially for H1 elements which feel a bit too far away from other content at the moment.

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/f3dc70ce-1357-4dcc-a02a-e52f32235af7)|![image](https://github.com/user-attachments/assets/1a990642-a0c7-4a8d-96ef-966bb33bc70e)|

![image](https://github.com/user-attachments/assets/7911f42b-61ad-4a64-b774-90f3fe96a14b)
