### PR TITLE
Patch for cards missing description

### DIFF
--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -26,6 +26,10 @@ export default class extends Controller {
     }
   }
 
+  reset() {
+    this.#timer = null
+  }
+
   // Private
 
   #scheduleSave() {

--- a/app/views/cards/container/_title.html.erb
+++ b/app/views/cards/container/_title.html.erb
@@ -10,7 +10,8 @@
     </div>
   <% end %>
 <% else %>
-  <%= form_with model: card, url: collection_card_path(card.collection, card), id: "card_form", class: "card__content", data: { controller: "autoresize auto-save" } do |form| %>
+  <%= form_with model: card, url: collection_card_path(card.collection, card), id: "card_form", class: "card__content", data: {
+        controller: "autoresize auto-save", action: "turbo:morph@window->auto-save#reset" } do |form| %>
     <h1 class="card__title autoresize__wrapper" data-autoresize-target="wrapper" data-autoresize-clone-value="">
       <%= form.text_area :title, placeholder: "Name it…",
             class: "input input--textarea full-width borderless txt-align-start autoresize__textarea",


### PR DESCRIPTION
The problem was that after redirecting back with morphing, the autosave mechanism would trigger an autosave call with an empty content.

This is a first patch. The editor shouldn't be triggering these "change" events in the first place when loading the editor.