### PR TITLE
Remove the "mirror" storage service

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -19,9 +19,3 @@ purestorage:
   region: us-east-1 # default region required for signer
   access_key_id: <%= Rails.application.credentials.dig(:active_storage, :purestorage_service, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:active_storage, :purestorage_service, :secret_access_key) %>
-
-# TODO: remove this after we update existing blobs' service names to purestorage.
-mirror:
-  service: Mirror
-  primary: purestorage
-  mirrors: [ local ]


### PR DESCRIPTION
because we've updated all the blobs in production to point to "purestorage"