### PR TITLE
dep: bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/active_record-tenanted
-  revision: f444578d6e59a1bdd65eda0ff765c9b5dac73398
+  revision: f6fca189655ae6609d10ecad7cceed61592320c4
   specs:
     active_record-tenanted (0.1.0)
       activerecord (>= 8.1.alpha)
@@ -17,28 +17,29 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/rails-structured-logging
-  revision: fc810cc48ac54a07722013149e104ceb8ec9a7e3
+  revision: 76960cb5c15fc2b6b5f7542e05d7dcc031cef9e6
   specs:
-    rails_structured_logging (0.2.0)
+    rails_structured_logging (0.2.1)
       json
       rails (>= 6.0.0)
 
 GIT
   remote: https://github.com/crmne/ruby_llm.git
-  revision: 8412d51e869f1ee8e5229831a9a0bb5e9b8f3847
+  revision: 74305703dcdcdcf8b2adefd8236184bcffc83910
   specs:
-    ruby_llm (1.2.0)
+    ruby_llm (1.3.0rc1)
       base64
       event_stream_parser (~> 1)
-      faraday (~> 2)
-      faraday-multipart (~> 1)
-      faraday-net_http (~> 3)
-      faraday-retry (~> 2)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1.0)
       zeitwerk (~> 2)
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: c1d7d56e831acf0aff5f3e27a6b384f543f358d0
+  revision: 0ac3fba6ee5f7d1680024a4925eee6069095487b
   branch: main
   specs:
     actioncable (8.1.0.alpha)
@@ -145,7 +146,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     aws-eventstream (1.3.2)
-    aws-partitions (1.1108.0)
+    aws-partitions (1.1109.0)
     aws-sdk-core (3.224.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -162,11 +163,11 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    base64 (0.2.0)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    benchmark (0.4.1)
+    bigdecimal (3.2.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     brakeman (7.0.2)
@@ -225,7 +226,7 @@ GEM
       addressable (>= 2.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashdiff (1.1.2)
+    hashdiff (1.2.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -244,7 +245,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
-    json (2.11.3)
+    json (2.12.2)
     kamal (2.6.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -256,7 +257,7 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
-    language_server-protocol (3.17.0.4)
+    language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -333,7 +334,7 @@ GEM
     psych (5.2.6)
       date
       stringio
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -356,7 +357,7 @@ GEM
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     rb_sys (0.9.106)
     rdoc (6.14.0)
       erb
@@ -371,7 +372,7 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
     rqrcode_core (2.0.0)
-    rubocop (1.75.4)
+    rubocop (1.75.8)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -389,12 +390,12 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-rails (2.31.0)
+    rubocop-rails (2.32.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
     rubocop-rails-omakase (1.1.0)
       rubocop (>= 1.72)
       rubocop-performance (>= 1.24)
@@ -405,7 +406,7 @@ GEM
       logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.32.0)
+    selenium-webdriver (4.33.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -481,7 +482,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
```
remote: https://github.com/basecamp/active_record-tenanted
-  revision: f444578d6e59a1bdd65eda0ff765c9b5dac73398
+  revision: f6fca189655ae6609d10ecad7cceed61592320c4

remote: https://github.com/basecamp/rails-structured-logging
-  revision: fc810cc48ac54a07722013149e104ceb8ec9a7e3
+  revision: 76960cb5c15fc2b6b5f7542e05d7dcc031cef9e6

remote: https://github.com/crmne/ruby_llm.git
-  revision: 8412d51e869f1ee8e5229831a9a0bb5e9b8f3847
+  revision: 74305703dcdcdcf8b2adefd8236184bcffc83910

remote: https://github.com/rails/rails.git
-  revision: c1d7d56e831acf0aff5f3e27a6b384f543f358d0
+  revision: 0ac3fba6ee5f7d1680024a4925eee6069095487b
```

- [x] base64: 0.2.0 -> 0.3.0
  - used by actiontext-lexical, active_record-tenanted, aws-sdk-s3, geared_pagination, importmap-rails, jbuilder, kamal, mission_control-jobs, platform_agent, propshaft, rails, rails_structured_logging, ruby_llm, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] benchmark: 0.4.0 -> 0.4.1
  - used by actiontext-lexical, active_record-tenanted, geared_pagination, image_processing, importmap-rails, jbuilder, kamal, mission_control-jobs, platform_agent, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] bigdecimal: 3.1.9 -> 3.2.1
  - used by actiontext-lexical, active_record-tenanted, geared_pagination, importmap-rails, jbuilder, kamal, mission_control-jobs, platform_agent, propshaft, rails, rails_structured_logging, sentry-rails, sentry-ruby, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] rake: 13.2.1 -> 13.3.0
  - used by actiontext-lexical, active_record-tenanted, importmap-rails, mission_control-jobs, propshaft, rails, rails_structured_logging, sentry-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, turbo-rails
- [x] websocket-driver: 0.7.7 -> 0.8.0
  - used by actiontext-lexical, mission_control-jobs, rails, rails_structured_logging, solid_cable
- [x] aws-partitions: 1.1108.0 -> 1.1109.0
  - used by aws-sdk-s3
- [x] public_suffix: 6.0.1 -> 6.0.2
  - used by geared_pagination
- [x] json: 2.11.3 -> 2.12.2
  - used by rails_structured_logging, ruby_llm
