### PR TITLE
No need to delegate `Card#auto_closing?` anymore

### DIFF
--- a/app/models/card/entropy.rb
+++ b/app/models/card/entropy.rb
@@ -10,7 +10,7 @@ module Card::Entropy
     scope :stagnated,        -> { doing.where(last_active_at: ..AUTO_RECONSIDER_PERIOD.ago) }
     scope :due_to_be_closed, -> { considering.in_auto_closing_collection.where("last_active_at <= DATETIME('now', '-' || auto_close_period || ' seconds')") }
 
-    delegate :auto_closing?, :auto_close_period, to: :collection
+    delegate :auto_close_period, to: :collection
   end
 
   class_methods do

--- a/test/models/card/closeable_test.rb
+++ b/test/models/card/closeable_test.rb
@@ -18,12 +18,4 @@ class Card::CloseableTest < ActiveSupport::TestCase
     assert cards(:logo).closed?
     assert_equal users(:kevin), cards(:logo).closed_by
   end
-
-  test "autoclose_at infers the period from the collection" do
-    freeze_time
-
-    collections(:writebook).update! auto_close_period: 123.days
-    cards(:logo).update! last_active_at: 2.day.ago
-    assert_equal (123-2).days.from_now, cards(:logo).auto_close_at
-  end
 end

--- a/test/models/card/entropy_test.rb
+++ b/test/models/card/entropy_test.rb
@@ -5,6 +5,14 @@ class Card::EntropyTest < ActiveSupport::TestCase
     Current.session = sessions(:david)
   end
 
+  test "auto_close_at infers the period from the collection" do
+    freeze_time
+
+    collections(:writebook).update! auto_close_period: 123.days
+    cards(:layout).update! last_active_at: 2.day.ago
+    assert_equal (123-2).days.from_now, cards(:layout).auto_close_at
+  end
+
   test "auto close all due" do
     cards(:logo, :shipping).each(&:reconsider)
 
@@ -49,11 +57,9 @@ class Card::EntropyTest < ActiveSupport::TestCase
   end
 
   test "entropy_cleaned_at returns when the entropy will be cleaned" do
-    cards(:logo).reconsider
-    assert_equal cards(:logo).auto_close_at, cards(:logo).entropy_cleaned_at
-    assert_not_nil cards(:logo).entropy_cleaned_at
+    assert_equal cards(:layout).auto_close_at, cards(:layout).entropy_cleaned_at
+    assert_not_nil cards(:layout).entropy_cleaned_at
 
-    cards(:logo).engage
     assert_equal cards(:logo).auto_reconsider_at, cards(:logo).entropy_cleaned_at
     assert_not_nil cards(:logo).entropy_cleaned_at
   end


### PR DESCRIPTION
And fix tests that break as a result of that change (because they're in the wrong engagement state, possibly due to a need to reload).

Related to #568

cc @jorgemanrubia 