### PR TITLE
Autolinking shouldn't include final punctuation.

### DIFF
--- a/app/helpers/html_helper.rb
+++ b/app/helpers/html_helper.rb
@@ -34,7 +34,16 @@ module HtmlHelper
 
     def auto_link_urls(linked_content)
       linked_content.gsub!(URL_REGEXP) do |match|
-        %(<a href="#{match}" rel="noreferrer">#{match}</a>)
+        url, trailing_punct = extract_url_and_punctuation(match)
+        %(<a href="#{url}" rel="noreferrer">#{url}</a>#{trailing_punct})
+      end
+    end
+
+    def extract_url_and_punctuation(url_match)
+      if url_match.end_with?(".", "?", ",", ":")
+        [ url_match[..-2], url_match[-1] ]
+      else
+        [ url_match, "" ]
       end
     end
 

--- a/test/helpers/html_helper_test.rb
+++ b/test/helpers/html_helper_test.rb
@@ -5,6 +5,30 @@ class HtmlHelperTest < ActionView::TestCase
     assert_equal_html \
       %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a></p>),
       format_html("<p>Check this: https://example.com</p>")
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com/" rel="noreferrer">https://example.com/</a></p>),
+      format_html("<p>Check this: https://example.com/</p>")
+  end
+
+  test "does not include punctuation in URL autolinking" do
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a>!</p>),
+      format_html("<p>Check this: https://example.com!</p>")
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a>.</p>),
+      format_html("<p>Check this: https://example.com.</p>")
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a>?</p>),
+      format_html("<p>Check this: https://example.com?</p>")
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a>,</p>),
+      format_html("<p>Check this: https://example.com,</p>")
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a>:</p>),
+      format_html("<p>Check this: https://example.com:</p>")
+    assert_equal_html \
+      %(<p>Check this: <a href="https://example.com" rel="noreferrer">https://example.com</a>;</p>),
+      format_html("<p>Check this: https://example.com;</p>")
   end
 
   test "respect existing links" do


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/54378a9b-9b0c-42be-b603-e5aea1c23829)
