### PR TITLE
Remove tray padding around comments

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -8,13 +8,11 @@
 
     display: flex;
     flex-direction: column;
+    margin-inine: auto;
+    gap: var(--inline-space);
     padding-inline: var(--inline-space);
     place-items: center;
     text-align: center;
-
-    @media (min-width: 160ch) {
-      padding-inline: var(--tray-size);
-    }
   }
 
   .comments__subscribers {
@@ -23,17 +21,12 @@
   }
 
   .comment {
+    align-items: flex-start;
+    display: flex;
+    inline-size: 100%;
     margin-inline: auto;
     max-inline-size: var(--comment-max);
     position: relative;
-
-    house-md-toolbar {
-      margin-block-start: calc(var(--comment-padding-block) * -0.5);
-    }
-
-    .house-md-content {
-      padding: var(--comment-padding-block) 0 0;
-    }
   }
 
   .comment__author {

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,7 +1,7 @@
 module MessagesHelper
   def messages_tag(card, &)
     turbo_frame_tag dom_id(card, :messages),
-      class: "comments gap center",
+      class: "comments",
       style: "--card-color: #{card.color}",
       role: "group", aria: { label: "Messages" },
       data: {

--- a/app/views/cards/comments/_comment.html.erb
+++ b/app/views/cards/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <% cache comment do %>
   <%= turbo_frame_tag comment do %>
-    <div class="comment flex align-start full-width <%= "comment--system" if comment.creator.system? %>" data-creator-id="<%= comment.creator_id %>" data-created-by-current-user-target="creation">
+    <div class="comment <%= "comment--system" if comment.creator.system? %>" data-creator-id="<%= comment.creator_id %>" data-created-by-current-user-target="creation">
       <figure class="comment__avatar flex-item-no-shrink" aria-hidden="true">
         <%= avatar_tag comment.creator, hidden_for_screen_reader: true %>
       </figure>

--- a/app/views/cards/comments/edit.html.erb
+++ b/app/views/cards/comments/edit.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag @comment do %>
-  <div class="comment flex align-start full-width">
+  <div class="comment">
     <figure class="comment__avatar flex-item-no-shrink" aria-hidden="true">
       <%= avatar_tag @comment.creator, hidden_for_screen_reader: true %>
     </figure>


### PR DESCRIPTION
This removes the extra padding around comments that was being applied on larger viewports. Looks like the original idea was to keep the comment content tucked safely between the tray cards, which makes sense! But this effectively makes the comment section pretty narrow from about 1280–1580px, and it actually gets wider on viewports under 1280px.

Instead, we can just set a max width on comments and not account for the tray cards. There will be a bit of content overlap here, but it's not much and you just need to scroll down an extra 24-ish px at most. Seems like a profitable trade-off.

|Before|After|
|--|--|
|![CleanShot 2025-06-02 at 15 14 36@2x](https://github.com/user-attachments/assets/2b937a70-3340-48e0-a713-e91c20fee94a)|![CleanShot 2025-06-02 at 15 14 54@2x](https://github.com/user-attachments/assets/ad640b8b-3e84-4ede-8f53-e55363804847)|