### PR TITLE
dep: update rack to 3.1.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,7 +345,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-contrib (2.5.0)
       rack (< 4)
     rack-session (2.1.1)


### PR DESCRIPTION
Addresses:

  Name: rack
  Version: 3.1.15
  CVE: CVE-2025-49007
  GHSA: GHSA-47m2-26rw-j2jw
  Criticality: Unknown
  URL: https://github.com/rack/rack/security/advisories/GHSA-47m2-26rw-j2jw
  Title: ReDoS Vulnerability in Rack::Multipart handle_mime_head