### PR TITLE
Sticky activity headers2

### DIFF
--- a/app/assets/stylesheets/events.css
+++ b/app/assets/stylesheets/events.css
@@ -29,16 +29,6 @@
     position: sticky;
     z-index: var(--z-events-day-header);
 
-    /* A blank strip to hide content as it scrolls beneath */
-    /* &:before {
-      background: var(--color-canvas);
-      block-size: calc((var(--events-day-header-height) - 1px) / 2);
-      content: "";
-      inset: 0 1px auto;
-      position: absolute;
-      translate: 0 -100%;
-    } */
-
     time {
       align-items: center;
       background-color: var(--color-ink);
@@ -98,7 +88,7 @@
   .events__column-header {
     background-color: var(--color-canvas);
     grid-row-start: 1;
-    inset-block-start: calc(var(--events-day-header-height) / 2);
+    inset-block-start: 0;
     margin-block-end: var(--events-gap);
     padding-block: calc(var(--events-gap) * 3) var(--events-gap);
     position: sticky;
@@ -153,6 +143,7 @@
     --panel-size: auto;
 
     margin: var(--inline-space);
+    min-inline-size: 0;
     overflow: clip;
     position: relative;
 


### PR DESCRIPTION
Make the day headers sticky!

This isn't quite as pixel-parfect as I'd like (the day headers are too close to the column headers when in sticky mode), but the current design makes getting this dialed in pretty much impossible. I tried 2/3 different approaches, and this was the one with the least jank.