### PR TITLE
Add state volume to load balancer

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -56,3 +56,5 @@ accessories:
       publish:
         - 80:80
         - 443:443
+    volumes:
+      - load-balancer:/home/kamal-proxy/.config/kamal-proxy

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -56,3 +56,5 @@ accessories:
       publish:
         - 80:80
         - 443:443
+    volumes:
+      - load-balancer:/home/kamal-proxy/.config/kamal-proxy


### PR DESCRIPTION
We need to persist the state so the deployment won't be lost if the proxy service is restarted.