### PR TITLE
Don't allow horizontal scrolling on the body element

### DIFF
--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -23,7 +23,6 @@
     font-family: var(--font-sans);
     interpolate-size: allow-keywords;
     line-height: 1.375;
-    overflow: unset;
     scroll-behavior: auto;
     text-rendering: optimizeLegibility;
     text-size-adjust: none;


### PR DESCRIPTION
There's an `overflow-x: hidden` rule in the reset layer, so removing the `unset` value here makes sure the body can't scroll horizontally. I don't quite remember why I originally added `unset` to begin with, so we'll see if something funny crops up.