### PR TITLE
Don't add reserved bubble space to all columns in larger viewports

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -49,7 +49,7 @@
     flex-direction: column;
     gap: var(--cards-gap);
     justify-content: start;
-    padding: 0 var(--reserved-bubble-space) var(--cards-gap) var(--cards-gap);
+    padding: 0 var(--cards-gap) var(--cards-gap);
     position: relative;
 
     /* Make sure filter dialogs don't end up behind sticky headers */


### PR DESCRIPTION
Don't add space for bubbles on the closed column. Obviously! 🤦