### PR TITLE
Don't choke when a card is missing its stage

### DIFF
--- a/app/helpers/cards_helper.rb
+++ b/app/helpers/cards_helper.rb
@@ -66,6 +66,6 @@ module CardsHelper
   end
 
   def cacheable_preview_parts_for(card, *options)
-    [ card, card.collection.workflow, card.collection.entropy_configuration, *options ]
+    [ card, card.workflow, card.collection.entropy_configuration, *options ]
   end
 end

--- a/app/models/card/staged.rb
+++ b/app/models/card/staged.rb
@@ -13,6 +13,10 @@ module Card::Staged
     stage&.workflow
   end
 
+  def staged?
+    stage.present?
+  end
+
   def change_stage_to(new_stage)
     transaction do
       update! stage: new_stage

--- a/app/views/cards/display/_preview.html.erb
+++ b/app/views/cards/display/_preview.html.erb
@@ -7,7 +7,7 @@
         <%= render "cards/display/preview/collection", card: card %>
         <%= render "cards/display/preview/tags", card: card %>
 
-        <% if workflow = card.collection.workflow %>
+        <% if card.staged? %>
           <span class="btn justify-start workflow-stage workflow-stage--current txt-uppercase min-width max-width">
             <span class="overflow-ellipsis "><%= card.stage.name %></span>
           </span>

--- a/app/views/cards/display/preview/_stages.html.erb
+++ b/app/views/cards/display/preview/_stages.html.erb
@@ -1,6 +1,4 @@
-<% workflow = card.collection.workflow %>
-
-<% if workflow %>
+<% if workflow = card.workflow %>
   <div class="card__stages">
     <% workflow.stages.each do |stage| %>
       <%= tag.span stage.name, class: ["overflow-ellipsis btn justify-start workflow-stage txt-uppercase", { "workflow-stage--current": stage == card.stage }] %>

--- a/app/views/cards/display/public_preview/_stages.html.erb
+++ b/app/views/cards/display/public_preview/_stages.html.erb
@@ -1,4 +1,4 @@
-<% if workflow = card.collection.workflow %>
+<% if workflow = card.workflow %>
   <div id="<%= dom_id(card, :stages) %>" class="card__stages">
     <% workflow.stages.each do |stage| %>
       <%= tag.div stage.name,


### PR DESCRIPTION
This can happen if the stage was destroyed

There was already a `Card#workflow` method that will return nil if the stage doesn't exist.