### PR TITLE
Start MySQL container in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,6 +6,10 @@ puts "== Installing dependencies =="
 system("gem install bundler --conservative")
 system("bundle check") || system!("bundle install")
 
+puts "\n== Starting MySQL =="
+system!("git -C ~/Work/basecamp/shipyard pull || true")
+system!("~/Work/basecamp/shipyard/app-dev/setup mysql80")
+
 puts "\n== Preparing database =="
 if ARGV.include?("--reset")
   system! "bin/rails db:drop db:create db:schema:load db:prepare"


### PR DESCRIPTION
Ensure that the MySQL container is running development, since `bin/setup` may need to populate the SignalId database. (Similar to what we do in other apps.)

/cc @flavorjones 