### PR TITLE
Fix notification rendering on card closure events

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -10,7 +10,12 @@ module NotificationsHelper
     name = event.creator.name
 
     case event_notification_action(event)
-    when "card_closed" then "Closed as “#{event.card.closure.reason}” by #{name}"
+    when "card_closed"
+      if event.card.closure
+        "Closed as “#{event.card.closure.reason}” by #{name}"
+      else
+        "Closed by #{name}"
+      end
     when "card_reopened" then "Reopened by #{name}"
     when "card_published" then "Added by #{name}"
     when "comment_created" then comment_notification_body(event)


### PR DESCRIPTION
... where the closure no longer exists, possibly due to being reopened.

Previously, fragment caching generally prevented any problems, but if the cache is busted for any reason (like Andy did in c7eeb56c), then the previous logic would raise an exception like "undefined method 'reason' for nil".

So, if the closure no longer exists, let's just note that it was closed, and by who.