### PR TITLE
SQLiteBackupsJob explicitly uses db_config.database_path

### DIFF
--- a/app/jobs/sqlite_backups_job.rb
+++ b/app/jobs/sqlite_backups_job.rb
@@ -92,7 +92,7 @@ class SQLiteBackupsJob < ApplicationJob
     end
 
     def db_path(tenant)
-      db_config.database
+      db_config.database_path
     end
 
     def db_config


### PR DESCRIPTION
because using db_config.database will give us the sqlite file URL with query params, and that's not what we mean.

This should restore nightly backups.