### PR TITLE
Fix the PWA manifest to use slugged URLs

### DIFF
--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -18,7 +18,7 @@
   <%= tenanted_action_cable_meta_tag %>
   <%= yield :head %>
 
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.png" type="image/png">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -18,7 +18,7 @@
       "purpose": "maskable"
     }
   ],
-  "start_url": "/",
+  "start_url": "<%= root_url %>",
   "display": "standalone",
   "scope": "/",
   "description": "Card-up the biggest issues in your projects",
@@ -27,13 +27,13 @@
     {
       "name": "Notifications",
       "description": "Catch up on recent notifications",
-      "url": "/notifications",
+      "url": "<%= notifications_path %>",
       "icons": [{ "src": "<%= image_url("bell.svg") %>", "sizes": "any" }]
     },
     {
       "name": "Latest Activity",
       "description": "See what’s new",
-      "url": "/",
+      "url": "<%= root_url %>",
       "icons": [{ "src": "<%= image_url("activity.svg") %>", "sizes": "any" }]
     }
   ],


### PR DESCRIPTION
I'm matching what BC4 does here.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/991