### PR TITLE
Clean up the cable meta tag

### DIFF
--- a/app/helpers/tenanting_helper.rb
+++ b/app/helpers/tenanting_helper.rb
@@ -2,6 +2,6 @@ module TenantingHelper
   def tenanted_action_cable_meta_tag
     tag "meta",
         name: "action-cable-url",
-        content: [ request.script_name, ActionCable.server.config.mount_path ].join("/")
+        content: "#{request.script_name}#{ActionCable.server.config.mount_path}"
   end
 end


### PR DESCRIPTION
to avoid a "//" appearing in the path.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/993