### PR TITLE
Bump dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/file_repository
-  revision: 17e90fc35ccb9f0a0dae1ed8623f01386696002d
+  revision: 8c8d1594f3ec7e8c0938e6a7f7def521692344e4
   specs:
-    file_repository (1.4.5)
+    file_repository (1.4.6)
 
 GIT
   remote: https://github.com/basecamp/kamal
@@ -41,7 +41,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/portfolio
-  revision: 26dd0ccbe4aad5a5c539f90c00e82b6175443636
+  revision: 34b48dd3c6dc78abd162ef26481971a228084d04
   specs:
     portfolio (5.2.0)
       activesupport
@@ -82,7 +82,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/signal_id
-  revision: 8908b2550ff55325b04c108146e00b4408a64e93
+  revision: 32758d0bff9f17e938905ff5bec53fff359e21b0
   branch: rails4
   specs:
     signal_id (4.3.2)
@@ -227,18 +227,18 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1119.0)
-    aws-sdk-core (3.226.0)
+    aws-partitions (1.1124.0)
+    aws-sdk-core (3.226.2)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.105.0)
+    aws-sdk-kms (1.106.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.190.0)
+    aws-sdk-s3 (1.192.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -291,11 +291,11 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-multipart (1.1.0)
+    faraday-multipart (1.1.1)
       multipart-post (~> 2.0)
-    faraday-net_http (3.4.0)
+    faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    faraday-retry (2.3.1)
+    faraday-retry (2.3.2)
       faraday (~> 2.0)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
@@ -331,7 +331,7 @@ GEM
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
     json (2.12.2)
-    jwt (2.10.1)
+    jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -345,7 +345,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    matrix (0.4.2)
+    matrix (0.4.3)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -394,7 +394,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
-    ostruct (0.6.1)
+    ostruct (0.6.2)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -457,7 +457,7 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
     rqrcode_core (2.0.0)
-    rubocop (1.75.8)
+    rubocop (1.77.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -465,10 +465,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.44.0, < 2.0)
+      rubocop-ast (>= 1.45.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.1)
+    rubocop-ast (1.45.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-performance (1.25.0)
@@ -486,25 +486,25 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.3)
+    ruby-vips (2.2.4)
       ffi (~> 1.12)
       logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.33.0)
+    selenium-webdriver (4.34.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.25.0)
+    sentry-rails (5.26.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.25.0)
-    sentry-ruby (5.25.0)
+      sentry-ruby (~> 5.26.0)
+    sentry-ruby (5.26.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    solid_cable (3.0.8)
+    solid_cable (3.0.11)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)


### PR DESCRIPTION
Rails:
- from: 53a9a3181a59f4e6dff73ba9453734edd7f7e076
- to: 58a2187f7b2ac391eba841e9ec6bb1a6d4e486dd

Others:
- aws-partitions: 1.1119.0 -> 1.1124.0
  - used by aws-sdk-s3
- aws-sdk-core: 3.226.0 -> 3.226.2
  - used by aws-sdk-s3
- aws-sdk-kms: 1.105.0 -> 1.106.0
  - used by aws-sdk-s3
- ruby-vips: 2.2.3 -> 2.2.4
  - used by image_processing
- ostruct: 0.6.1 -> 0.6.2
  - used by kamal
- file_repository: 1.4.5 -> 1.4.6
  - used by portfolio, signal_id
- faraday-multipart: 1.1.0 -> 1.1.1
  - used by ruby_llm
- faraday-net_http: 3.4.0 -> 3.4.1
  - used by ruby_llm
- faraday-retry: 2.3.1 -> 2.3.2
  - used by ruby_llm
- sentry-ruby: 5.25.0 -> 5.26.0
  - used by sentry-rails
- jwt: 2.10.1 -> 3.1.2
  - used by signal_id