### PR TITLE
Untenanted access in authenticated controllers should request auth

### DIFF
--- a/test/controllers/controller_authentication_test.rb
+++ b/test/controllers/controller_authentication_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ControllerAuthenticationTest < ActionDispatch::IntegrationTest
+  test "access without an account slug redirects to launchpad" do
+    integration_session.default_url_options[:script_name] = "" # no tenant
+
+    get cards_path
+
+    assert_redirected_to Launchpad.login_url(product: true)
+  end
+
+  test "access with an account slug but no session redirects to launchpad" do
+    get cards_path
+
+    assert_redirected_to Launchpad.login_url(product: true, account: Account.sole)
+  end
+
+  test "access with an account slug and a session allows functional access" do
+    sign_in_as :kevin
+
+    get cards_path
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
This will prevent us from getting 500s when people hit the root path like https://fizzy.37signals.com/, as well as providing users an easy way to find the account they want.