### PR TITLE
Cards' "stalled" metric is reset when reconsidered

### DIFF
--- a/app/models/card/engageable.rb
+++ b/app/models/card/engageable.rb
@@ -44,6 +44,7 @@ module Card::Engageable
     transaction do
       reopen
       engagement&.destroy
+      activity_spike&.destroy
       touch_last_active_at
     end
   end


### PR DESCRIPTION
Specifically, reconsidering removes the existing activity spike (if one exists). This happens whether the card is reconsidered by entropy or manually by a user.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/916