### PR TITLE
Broadcast when all notifications are cleared

### DIFF
--- a/app/controllers/notifications/readings_controller.rb
+++ b/app/controllers/notifications/readings_controller.rb
@@ -6,6 +6,9 @@ class Notifications::ReadingsController < ApplicationController
 
   def create_all
     Current.user.notifications.unread.read_all
-    redirect_to notifications_path
+    respond_to do |format|
+      format.html { redirect_to notifications_path }
+      format.turbo_stream { } # No action needed, readings will have been broadcast
+    end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,7 +13,7 @@ class Notification < ApplicationRecord
   delegate :card, to: :source
 
   def self.read_all
-    update!(read_at: Time.current)
+    all.each { |notification| notification.read }
   end
 
   def read


### PR DESCRIPTION
Then make the turbo response to clearing all notifications a no-op.

This has the bonus side effect of properly clearing the notifications tray on all open pages.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/796