### PR TITLE
Change Active Storage account slug extension to a to_prepare block

### DIFF
--- a/config/initializers/tenanting/active_storage.rb
+++ b/config/initializers/tenanting/active_storage.rb
@@ -14,6 +14,6 @@ module ActiveStorageControllerExtensions
   end
 end
 
-Rails.application.config.after_initialize do
+Rails.application.config.to_prepare do
   ActiveStorage::BaseController.include ActiveStorageControllerExtensions
 end


### PR DESCRIPTION
because it was breaking in development after a reload.

ref: http://fizzy.localhost:3006/735464785/collections/2/cards/4