### PR TITLE
Improve multi-account behavior of the PWA

### DIFF
--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "Fizzy",
+  "name": "<%= [ Account.sole.name, "Fizzy", Rails.env.production? ? nil : Rails.env ].compact.join(" - ") %>",
   "icons": [
     {
       "src": "/app-icon-192.png",
@@ -20,7 +20,7 @@
   ],
   "start_url": "<%= root_path %>",
   "display": "standalone",
-  "scope": "/",
+  "scope": "<%= root_path %>",
   "description": "Card-up the biggest issues in your projects",
   "categories": ["bugs", "business", "productivity"],
   "shortcuts": [


### PR DESCRIPTION
- PWA manifest:
  - declares slugged scope
  - includes the account name (and non-prod environment name) in the title

So we can have one PWA installed for each account (in each environment) and links should get routed properly.

ref: https://3.basecamp.com/2914079/buckets/37331921/todos/8827769164