### PR TITLE
Ensure checks are visible for tags and assignments

### DIFF
--- a/app/assets/stylesheets/buttons.css
+++ b/app/assets/stylesheets/buttons.css
@@ -124,28 +124,27 @@
   /* ------------------------------------------------------------------------ */
 
   .btn {
-    :is(input[type=radio], input[type=checkbox]) {
-      appearance: none;
-      border-radius: var(--btn-border-radius);
-      cursor: pointer;
-      display: flex;
-      inset: 0;
-      margin: 0;
-      padding: 0;
-      position: absolute;
+    &:has(input[type=radio], input[type=checkbox]) {
+      position: relative;
 
-      &:focus-visible {
-        outline: none;
+      :is(input[type=radio], input[type=checkbox]) {
+        appearance: none;
+        border-radius: var(--btn-border-radius);
+        cursor: pointer;
+        display: flex;
+        inset: 0;
+        margin: 0;
+        padding: 0;
+        position: absolute;
+
+        &:focus-visible {
+          outline: none;
+        }
       }
-    }
 
-    .checked {
-      display: none;
-    }
-
-    &:has(input:focus-visible)  {
-      outline: var(--focus-ring-size) solid var(--focus-ring-color);
-      outline-offset: var(--focus-ring-offset);
+      .checked {
+        display: none;
+      }
     }
 
     &:has(input:checked)  {
@@ -157,6 +156,11 @@
       .checked {
         display: block;
       }
+    }
+
+    &:has(input:focus-visible)  {
+      outline: var(--focus-ring-size) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
     }
   }
 


### PR DESCRIPTION
Scope `.checked` visibility within buttons to only buttons that have a checkbox or radio. This makes sure that icons with the `checked` class show up properly when there aren't inputs within the button (like assignments and tags).