### PR TITLE
Add circle-on-mobile button class

### DIFF
--- a/app/assets/stylesheets/buttons.css
+++ b/app/assets/stylesheets/buttons.css
@@ -80,6 +80,18 @@
     }
   }
 
+  /* Make a normal button circular on mobile */
+  @media (max-width: 640px) {
+    .btn--circle-mobile {
+      aspect-ratio: 1;
+      padding: 0.5em;
+
+      span:last-of-type {
+        display: none;
+      }
+    }
+  }
+
   .btn--negative {
     --btn-background: var(--color-negative);
     --btn-border-color: var(--color-negative);

--- a/app/views/cards/index.html.erb
+++ b/app/views/cards/index.html.erb
@@ -9,9 +9,9 @@
 <header class="header" style="--header-actions-width: 7rem;">
   <div class="header__actions header__actions--start">
     <% if collection = @filter.single_collection || Current.user.collections.first %>
-      <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link" do %>
+      <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link btn--circle-mobile" do %>
         <%= icon_tag "add" %>
-        Add a card
+        <span>Add a card</span>
       <% end %>
     <% end %>
   </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -11,7 +11,7 @@
 <header class="header margin-block-end" style="--header-button-count: 3;">
   <div class="header__actions header__actions--start">
     <% if collection = @filter.single_collection || Current.user.collections.first %>
-      <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link" do %>
+      <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link btn--circle-mobile" do %>
         <%= icon_tag "add" %>
         <span>Add a card</span>
       <% end %>


### PR DESCRIPTION
This is for both the Home and Collection pages. It's also a generic button class, so just add `btn--circle-mobile` to any button with an icon to have it transform to a circle button on mobile.

|Desktop|Mobile|
|--|--|
|![CleanShot 2025-07-09 at 10 45 59@2x](https://github.com/user-attachments/assets/43cda290-db7d-41e1-8ffd-555e5df86b2f)|![CleanShot 2025-07-09 at 10 45 50@2x](https://github.com/user-attachments/assets/dce0f250-6bc9-4eb2-8383-24cb45bb8457)|