### PR TITLE
Attachment focus states

### DIFF
--- a/app/assets/stylesheets/actiontext-lexical.css
+++ b/app/assets/stylesheets/actiontext-lexical.css
@@ -6,12 +6,14 @@
 
     figure.node--selected {
       &:not(:has(img)) {
-        box-shadow: 0 0 0 var(--focus-ring-size) var(--focus-ring-color);
+        outline: var(--focus-ring-size) solid var(--focus-ring-color);
+        outline-offset: var(--focus-ring-offset);
       }
 
       &:has(img) {
         img {
-          box-shadow: 0 0 0 var(--focus-ring-size) var(--focus-ring-color);
+          outline: var(--focus-ring-size) solid var(--focus-ring-color);
+          outline-offset: var(--focus-ring-offset);
         }
       }
     }

--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -43,6 +43,7 @@
     }
 
     :where(img, video, embed, object) {
+      inline-size: auto;
       margin-inline: auto;
       max-block-size: 32rem;
       object-fit: contain;
@@ -201,6 +202,10 @@
       inline-size: 100%;
       max-inline-size: 100%;
       text-align: center;
+
+      &:focus {
+        --focus-ring-size: 0;
+      }
 
       @supports (field-sizing: content) {
         field-sizing: content;


### PR DESCRIPTION
A couple improves for attachment focus states:

- Remove the focus ring from the caption input, re: https://fizzy.37signals.com/5986089/collections/2/cards/1077
- Add `inline-size: auto` to images so they don't stretch to full-width. Interesting how `object-fit: contain` will visually size the image properly, but keep the DOM element at 100% width.

|Before|After|
|--|--|
|<img width="2240" height="1324" alt="CleanShot 2025-07-10 at 14 06 35@2x" src="https://github.com/user-attachments/assets/4d47a2ca-8baa-4165-bcb5-a4ceb2a6a91c" />|<img width="2240" height="1324" alt="CleanShot 2025-07-10 at 14 06 00@2x" src="https://github.com/user-attachments/assets/2de35d31-466b-4ee0-a033-e24ac9cc981e" />|