### PR TITLE
Truncate long commands

### DIFF
--- a/app/assets/stylesheets/terminals.css
+++ b/app/assets/stylesheets/terminals.css
@@ -38,7 +38,12 @@
     --btn-color: var(--color-terminal-text);
 
     font-weight: normal;
+    overflow: hidden;
     transition: unset;
+
+    span:first-letter {
+      text-transform: capitalize;
+    }
   }
 
   .terminal__container {
@@ -54,7 +59,7 @@
     inline-size: auto;
     inset: 50% auto auto 50%;
     max-inline-size: 90vw;
-    
+
     padding: calc(var(--block-space) * 1.5) var(--block-space-double);
     position: fixed;
     transform: translate(-50%, -50%);

--- a/app/views/commands/_command.html.erb
+++ b/app/views/commands/_command.html.erb
@@ -1,8 +1,10 @@
 <%= tag.li class: "min-width full-width flex gap-half terminal__item justify-start", tabindex: 0, data: {
       action: "keydown.enter->terminal#restoreCommand:prevent keydown.enter->toggle-class#remove:prevent",
       navigable_list_target: "item" } do %>
-  <%= button_tag command.title, type: "button", class: "btn btn--plain overflow-ellipsis terminal__command flex-item-grow justify-start",
-        data: { action: "toggle-class#remove terminal#restoreCommand", line: command.line }, tabindex: -1 %>
+  <%= button_tag type: "button", class: "btn btn--plain terminal__command flex-item-grow justify-start",
+        data: { action: "toggle-class#remove terminal#restoreCommand", line: command.line }, tabindex: -1 do %>
+      <span class="overflow-ellipsis"><%= command.title %></span>
+  <% end %>
 
   <% if command.undoable? %>
     <%= button_to "Undo", command_undo_path(command), class: "btn btn--plain terminal__button flex-item-justify-end",


### PR DESCRIPTION
Truncate commands properly and capitalize the first character of each line.
https://fizzy.37signals.com/5986089/collections/2/cards/1033

|Before|After|
|--|--|
|<img width="1224" height="344" alt="CleanShot 2025-07-10 at 14 41 40@2x" src="https://github.com/user-attachments/assets/aff743df-d193-45d0-8c36-540894f1797b" />|<img width="1224" height="344" alt="CleanShot 2025-07-10 at 14 43 52@2x" src="https://github.com/user-attachments/assets/3a04146e-42cd-49f1-bfb8-408dcd0b8dce" />|