### PR TITLE
Cache needs to include publication key

### DIFF
--- a/app/helpers/cards_helper.rb
+++ b/app/helpers/cards_helper.rb
@@ -67,6 +67,6 @@ module CardsHelper
   end
 
   def cacheable_preview_parts_for(card, *options)
-    [ card, card.workflow, card.collection.entropy_configuration, *options ]
+    [ card, card.workflow, card.collection.entropy_configuration, card.collection.publication, *options ]
   end
 end


### PR DESCRIPTION
Fixes an issue where cards had a different publication token than the collection in production.
<img width="1068" height="394" alt="image" src="https://github.com/user-attachments/assets/be5e306b-af6f-4929-b044-b46864866ae1" />
<img width="995" height="484" alt="image" src="https://github.com/user-attachments/assets/9024fa1d-1e32-4adc-a4a1-515a3404e8dd" />
