### PR TITLE
Use smaller action size on mobile

### DIFF
--- a/app/assets/stylesheets/events.css
+++ b/app/assets/stylesheets/events.css
@@ -1,4 +1,13 @@
 @layer components {
+  /* Events header
+  /* ------------------------------------------------------------------------ */
+
+  .header.events-header {
+    @media (min-width: 640px) {
+      --header-actions-width: 7rem;
+    }
+  }
+
   /* Event column layout
   /* ------------------------------------------------------------------------ */
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,7 @@
   </nav>
 <% end %>
 
-<header class="header margin-block-end" style="--header-button-count: 3;">
+<header class="events-header header margin-block-end">
   <div class="header__actions header__actions--start">
     <% if collection = @filter.single_collection || Current.user.collections.ordered_by_recently_accessed.first %>
       <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link btn--circle-mobile" do %>


### PR DESCRIPTION
Reclaim the space saved when collapsing the Add Card button on mobile.

|Before|After|
|--|--|
|<img width="840" height="304" alt="CleanShot 2025-07-21 at 16 31 39@2x" src="https://github.com/user-attachments/assets/3f15b8ee-7c35-49ad-bd27-f32825a7ce86" />|<img width="840" height="304" alt="CleanShot 2025-07-21 at 16 31 24@2x" src="https://github.com/user-attachments/assets/f809f5fb-4604-4445-98ca-b397da324670" />|