### PR TITLE
Don't justify content for avatar buttons to make FF happy

### DIFF
--- a/app/assets/stylesheets/avatars.css
+++ b/app/assets/stylesheets/avatars.css
@@ -22,11 +22,6 @@
       max-inline-size: 100%;
       object-fit: cover;
     }
-
-    /* FF fix */
-    &.btn {
-      justify-content: normal;
-    }
   }
 
   .avatar__form {

--- a/app/assets/stylesheets/buttons.css
+++ b/app/assets/stylesheets/buttons.css
@@ -73,6 +73,7 @@
     block-size: var(--btn-size);
     display: grid;
     inline-size: var(--btn-size);
+    justify-content: normal; /* FF fix */
     place-items: center;
 
     > * {


### PR DESCRIPTION
Firefox is making images within `.btn--circle` elements have zero width when `justify: center` is present. That rule is inherited from `.btn`, and we don't need it in `.btn--circle` anyway, so simply unsetting that here fixes the issue.

This is probably a FF bug.

|Before|After|
|--|--|
|<img width="840" height="144" alt="CleanShot 2025-07-21 at 16 54 51@2x" src="https://github.com/user-attachments/assets/c07a7cd4-f6ce-45c1-8b43-0e321bb04dad" />|<img width="840" height="144" alt="CleanShot 2025-07-21 at 16 54 59@2x" src="https://github.com/user-attachments/assets/55a714fd-cd8c-4bcb-a4d3-f20bc375e71b" />|