### PR TITLE
Hide placeholder when list is inserted

### DIFF
--- a/app/assets/stylesheets/actiontext-lexical.css
+++ b/app/assets/stylesheets/actiontext-lexical.css
@@ -18,8 +18,11 @@
       }
     }
 
+    /* Lexical still uses the `lexical-editor--empty` class if you have a list
+       started with no other characters. Here, we won't show the placeholder if
+       you've clicked the List button in the toolbar. */
     &.lexical-editor--empty {
-      .lexical-editor__content::before {
+      .lexical-editor__content:not(:has(ul, ol))::before {
         content: attr(placeholder);
         color: currentColor;
         cursor: text;


### PR DESCRIPTION
The `lexical-editor--empty` class controls the visibility of the placeholder. Right now, the placeholder is visible when there aren't characters. Since an empty list is just a DOM element without characters, the placeholder is still visible.

Here, I'm amending the CSS to show the placeholder only if lists aren't present. This works well, although a better solution might be for Lexical to only add the `--empty` class at the right time.

|Before|After|
|--|--|
|<img width="1150" height="632" alt="CleanShot 2025-07-22 at 15 02 15@2x" src="https://github.com/user-attachments/assets/8fd66c1f-4c44-4e7c-a1f0-b357bca91c39" />|<img width="1148" height="630" alt="CleanShot 2025-07-22 at 15 01 43@2x" src="https://github.com/user-attachments/assets/45ae6183-3c6c-4f23-a0d8-49548c2fbdd8" />|