### PR TITLE
Use the right display prop when unhiding the delete button

### DIFF
--- a/app/assets/stylesheets/reactions.css
+++ b/app/assets/stylesheets/reactions.css
@@ -73,7 +73,7 @@
     translate: 0.25em;
 
     .expanded & {
-      display: flex;
+      display: grid;
     }
   }
 


### PR DESCRIPTION
When unhiding the reaction delete button, make sure to use the correct display property.

Rant: I wish there was a dedicated `hide` property in CSS so you could set the display you want once and not have to worry about keeping track of it when you toggle visibility.