### PR TITLE
Make room for pin clear button when dialog is expanded

### DIFF
--- a/app/assets/stylesheets/trays.css
+++ b/app/assets/stylesheets/trays.css
@@ -354,6 +354,14 @@
       max-inline-size: unset;
     }
 
+    .workflow-stage--current {
+      transition: translate 150ms ease-out;
+
+      [open] & {
+        translate: -2em;
+      }
+    }
+
     .card__meta-grid {
       margin-inline-start: 0;
     }


### PR DESCRIPTION
Nudge workflow stages over to make room for the "Remove pin" button