### PR TITLE
Fix typo in the card recovery message

### DIFF
--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -5,7 +5,7 @@
   <% if @card.creating? && @card.can_recover_abandoned_creation? %>
     <div class="fill-selected position-sticky flex align-center gap-half justify-center border-block margin-block-end"
           style="view-transition-name: draft-banner; --card-color: <%= @card.color %>;">
-      You have an unsaved work. Would you like to continue where you left off?
+      You have an unsaved card. Would you like to continue where you left off?
       <%= button_to card_recover_path(@card), class: "btn btn--reversed", data: { turbo_action: "replace" } do %>
         <span>Restore</span>
       <% end %>


### PR DESCRIPTION
Fixes a typo in the restore card ribbon

| Before | After |
|-|-|
| <img width="852" height="228" alt="image" src="https://github.com/user-attachments/assets/30d3793e-95bc-4420-a03d-41aee4847654" /> | <img width="827" height="229" alt="image" src="https://github.com/user-attachments/assets/a61f308e-d893-4169-941e-18b63d526635" /> |