### PR TITLE
Better truncation for header__titles

### DIFF
--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -39,6 +39,7 @@
     font-size: var(--text-large);
     font-weight: 900;
     margin: 0 auto;
+    min-inline-size: 0;
     text-align: center;
   }
 }

--- a/app/views/cards/index.html.erb
+++ b/app/views/cards/index.html.erb
@@ -21,8 +21,8 @@
       <% end %>
     <% end %>
   </div>
-  <h1 class="header__title" style="view-transistion-name: card-collection-title">
-    <span class="overflow-ellipsis"><%= filter_title @filter %></span>
+  <h1 class="header__title overflow-ellipsis" style="view-transistion-name: card-collection-title">
+    <%= filter_title @filter %>
   </h1>
   <div class="header__actions header__actions--end">
     <% if collection = @filter.single_collection %>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -35,7 +35,7 @@
 
 <header class="header card-perma__collection-header">
   <%= link_to cards_path(collection_ids: [ @card.collection ]), class: "header__title btn borderless txt-large", style: "--btn-padding: 0.25ch 1ch 0.25ch 0.75ch; view-transistion-name: card-collection-title;", data: { controller: "hotkey", action: "keydown.esc@document->hotkey#click" } do %>
-    <span>
+    <span class="overflow-ellipsis">
       &larr;
       <strong class="font-black"><%= @card.collection.name %></strong>
     </span>

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -6,7 +6,7 @@
       <%= link_to_back fallback_path: cards_path(collection_ids: [ @bbucket ]) %>
     </div>
 
-    <h1 class="header__title"><%= @page_title %></h1>
+    <h1 class="header__title overflow-ellipsis"><%= @page_title %></h1>
 
     <div class="header__actions header__actions--end"></div>
   </nav>

--- a/app/views/public/cards/show.html.erb
+++ b/app/views/public/cards/show.html.erb
@@ -15,7 +15,7 @@
 <% content_for :header do %>
   <header class="header card-perma__collection-header">
   <%= link_to published_collection_url(@card.collection), class: "header__title btn borderless txt-large", style: "--btn-padding: 0.25ch 1ch 0.25ch 0.75ch; view-transistion-name: card-collection-title;", data: { controller: "hotkey", action: "keydown.esc@document->hotkey#click" } do %>
-    <span>
+    <span class="overflow-ellipsis">
       &larr;
       <strong class="font-black"><%= @card.collection.name %></strong>
     </span>
@@ -45,4 +45,4 @@
       </footer>
     <% end %>
   </div>
-</section> 
+</section>


### PR DESCRIPTION
- Allow header titles to shrink in flex context
- Add missing `overflow-ellipsis` classes on titles (when title has a `btn` class, `overflow-ellipsis` goes on a span inside)