### PR TITLE
Give light terminal its own color

### DIFF
--- a/app/assets/stylesheets/_global.css
+++ b/app/assets/stylesheets/_global.css
@@ -78,7 +78,7 @@
   --lch-ink-medium: 66% 0.008 258;
   --lch-ink-light: 84% 0.005 256;
   --lch-ink-lighter: 92% 0.003 254;
-  --lch-ink-lightest: 98% 0.002 252;
+  --lch-ink-lightest: 96% 0.002 252;
 
   --lch-uncolor-darkest: 26% 0.018 40;
   --lch-uncolor-darker: 40.04% 0.0376 50.06;
@@ -185,7 +185,7 @@
   --color-selected-dark: oklch(var(--lch-blue-light));
   --color-highlight: oklch(var(--lch-yellow-lighter));
   --color-marker: oklch(var(--lch-red-medium));
-  --color-terminal-bg: var(--color-ink-lightest);
+  --color-terminal-bg: oklch(98% 0.002 252);
   --color-terminal-text: var(--color-ink);
   --color-terminal-text-light: var(--color-ink-lighter);
   --color-golden: oklch(89.1% 0.178 95.7);


### PR DESCRIPTION
The original change caused the Fizzy bar to be the same color as comments which was confusing when scrolling

BEFORE
<img width="1434" height="990" alt="image" src="https://github.com/user-attachments/assets/7962b71a-5f64-4664-a7b6-1b22e9077595" />

AFTER
<img width="1434" height="990" alt="image" src="https://github.com/user-attachments/assets/a634ce94-4bd0-46ae-93bc-080f5387a8d1" />
