### PR TITLE
Make popup group title padding more targeted

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -55,7 +55,7 @@
     inline-size: 100%;
     max-inline-size: 100%;
 
-    &:has(*:first-child:not(.popup__item)) {
+    .popup__list &:has(*:first-child:not(.popup__item)) {
       padding-inline-start: var(--inline-space-half);
     }
 


### PR DESCRIPTION
Make sure the padding for popup group titles only applies when inside a list. Fixes an issue where the hotkey buttons in the Fizzy menu were misaligned.