### PR TITLE
Delay clearing notifications until a card is actually viewed.

### DIFF
--- a/app/javascript/controllers/beacon_controller.js
+++ b/app/javascript/controllers/beacon_controller.js
@@ -4,11 +4,17 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = { url: String }
 
-  connect() {
-    post(this.urlValue, { responseKind: "turbo-stream" })
+  visibilityChanged() {
+    this.#sendBeacon()
   }
 
   disconnect() {
-    post(this.urlValue, { responseKind: "turbo-stream" })
+    this.#sendBeacon()
+  }
+
+  #sendBeacon() {
+    if (!document.hidden) {
+      post(this.urlValue, { responseKind: "turbo-stream" })
+    }
   }
 }

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -42,7 +42,9 @@
   <% end %>
 </header>
 
-<div data-controller="beacon lightbox" data-beacon-url-value="<%= card_reading_url(@card) %>">
+<div data-controller="beacon lightbox"
+     data-action="visibilitychange@document->beacon#visibilityChanged"
+     data-beacon-url-value="<%= card_reading_url(@card) %>">
   <%= render "cards/container", card: @card %>
 
   <% if @card.published? || @card.drafted? %>


### PR DESCRIPTION
Send the "read" beacon when the card is made visible.

Also take care to only send the "disconnect" beacon if the card is visible.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/1301