### PR TITLE
Ensure sanitizer config applies to ActionText in production

### DIFF
--- a/config/initializers/sanitization.rb
+++ b/config/initializers/sanitization.rb
@@ -1,4 +1,7 @@
 Rails.application.config.after_initialize do
   Rails::HTML5::SafeListSanitizer.allowed_tags.merge(%w[ s table tr td th thead tbody details summary video source])
   Rails::HTML5::SafeListSanitizer.allowed_attributes.merge(%w[ data-turbo-frame controls type width data-action data-lightbox-target data-lightbox-url-value ])
+
+  ActionText::ContentHelper.allowed_tags = Rails::HTML5::SafeListSanitizer.allowed_tags
+  ActionText::ContentHelper.allowed_attributes = Rails::HTML5::SafeListSanitizer.allowed_attributes
 end


### PR DESCRIPTION
In production, eager loading prevents the default sanitizer config from applying to Action Text. Let's explicitly set it.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/1123

cc @jzimdars 