### PR TITLE
Clean up beacon on-visibility-change handling

### DIFF
--- a/app/javascript/controllers/beacon_controller.js
+++ b/app/javascript/controllers/beacon_controller.js
@@ -4,12 +4,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = { url: String }
 
-  visibilityChanged() {
+  connect() {
     this.#sendBeacon()
+    this.onVisibilityChange = this.#sendBeacon.bind(this);
+    document.addEventListener("visibilitychange", this.onVisibilityChange)
   }
 
   disconnect() {
     this.#sendBeacon()
+    document.removeEventListener("visibilitychange", this.onVisibilityChange)
   }
 
   #sendBeacon() {

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -42,9 +42,7 @@
   <% end %>
 </header>
 
-<div data-controller="beacon lightbox"
-     data-action="visibilitychange@document->beacon#visibilityChanged"
-     data-beacon-url-value="<%= card_reading_url(@card) %>">
+<div data-controller="beacon lightbox" data-beacon-url-value="<%= card_reading_url(@card) %>">
   <%= render "cards/container", card: @card %>
 
   <% if @card.published? || @card.drafted? %>


### PR DESCRIPTION
The previous version was not posting the beacon when the page was loaded and visible.