### PR TITLE
Prefer Account#slug to Account.script_name

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -3,10 +3,8 @@ class Account < ApplicationRecord
 
   has_many_attached :uploads
 
-  class << self
-    def script_name
-      @script_name ||= "/#{sole.queenbee_id}"
-    end
+  def slug
+    "/#{queenbee_id}"
   end
 
   def setup_basic_template

--- a/app/models/card/promptable.rb
+++ b/app/models/card/promptable.rb
@@ -29,7 +29,7 @@ module Card::Promptable
       * Collection id: #{collection_id}
       * Collection name: #{collection.name}
       * Number of comments: #{comments.count}
-      * Path: #{collection_card_path(collection, self, script_name: Account.script_name)}
+      * Path: #{collection_card_path(collection, self, script_name: Account.sole.slug)}
 
       #{comments.last(MAX_COMMENTS).collect(&:to_prompt).join("\n")}
       END OF CARD #{id}

--- a/app/models/comment/promptable.rb
+++ b/app/models/comment/promptable.rb
@@ -20,7 +20,7 @@ module Comment::Promptable
         * Card title: #{card.title}
         * Created by: #{creator.name}}
         * Created at: #{created_at}}
-        * Path: #{collection_card_path(card.collection, card, anchor: ActionView::RecordIdentifier.dom_id(self), script_name: Account.script_name)}
+        * Path: #{collection_card_path(card.collection, card, anchor: ActionView::RecordIdentifier.dom_id(self), script_name: Account.sole.slug)}
         END OF COMMENT #{id}
       PROMPT
   end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -1,4 +1,8 @@
 require "test_helper"
 
 class AccountTest < ActiveSupport::TestCase
+  test "slug" do
+    account = Account.sole
+    assert_equal "/#{account.queenbee_id}", account.slug
+  end
 end


### PR DESCRIPTION
Caching the script name in a class instance variable seemed like a bug to me.