### PR TITLE
bump dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/portfolio
-  revision: ecf5bf98b638c3169e8ec0913bbcaefb9c0efd79
+  revision: 86411a53d19a42ce44705a50ebe7c22828597991
   specs:
     portfolio (5.2.0)
       activesupport
@@ -81,7 +81,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/signal_id
-  revision: 0b18e9665f8a9295b84a18d329ff272f494a2249
+  revision: d6c2a5ceed7bb57bf7dcdebdb439e7cd526fca09
   branch: rails4
   specs:
     signal_id (4.3.2)


### PR DESCRIPTION
- brakeman 7.0.2 → 7.1.0
- update propshaft 1.2.0 → 1.2.1
- update rouge 4.5.2 → 4.6.0
- update importmap-rails 2.1.0 → 2.2.2
- update puma 6.6.0 → 6.6.1
- update aws-sdk-s3 1.193.0 → 1.196.1
- update signal_id and portfolio
