### PR TITLE
dep: Revert jbuilder upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "geared_pagination", "~> 1.2"
 gem "rqrcode"
 gem "redcarpet"
 gem "rouge"
-gem "jbuilder"
+gem "jbuilder", "~> 2.13.0" # pin until I figure out why 2.14 breaks structured logging
 gem "actiontext-lexical", bc: "actiontext-lexical"
 gem "image_processing", "~> 1.14"
 gem "platform_agent"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,9 +334,9 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.0)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
+    jbuilder (2.13.0)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
     jmespath (1.6.2)
     json (2.13.2)
     jwt (3.1.2)
@@ -610,7 +610,7 @@ DEPENDENCIES
   geared_pagination (~> 1.2)
   image_processing (~> 1.14)
   importmap-rails
-  jbuilder
+  jbuilder (~> 2.13.0)
   kamal!
   mission_control-jobs
   mocha


### PR DESCRIPTION
because it breaks structured logging.