### PR TITLE
Nicer center-to-left transition for Fizzy do placeholder

### DIFF
--- a/app/assets/stylesheets/_global.css
+++ b/app/assets/stylesheets/_global.css
@@ -56,6 +56,9 @@
   /* Dialogs */
   --dialog-duration: 150ms;
 
+  /* Easing functions from https://easingwizard.com/ */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+
   @media (max-width: 799px) {
     --tray-size: var(--footer-height);
   }

--- a/app/assets/stylesheets/terminals.css
+++ b/app/assets/stylesheets/terminals.css
@@ -118,26 +118,28 @@
     &.lexical-editor--empty {
       overflow: hidden;
       text-align: center;
-      text-overflow: ellipsis; 
+      text-overflow: ellipsis;
       white-space: nowrap;
 
       &:focus-within {
         text-align: start;
 
         .lexical-editor__content::before {
-          inset: 0;
-          transform: translateX(0);
+          inset-inline-start: 0;
+          translate: 0 -50%;
         }
       }
 
       .lexical-editor__content::before {
         color: var(--color-ink);
-        inline-size: 100%;
-        inset: 0 0 0 50%;
+        inset: 50% auto auto 50%;
         opacity: 0.5;
-        transform: translateX(-50%);
-        transform-origin: start start;
-        transition: inset 150ms ease-in;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        transition: 200ms var(--ease-out-expo);
+        transition-property: inset-inline-start, translate;
+        translate: -50% -50%;
+        white-space: nowrap;
 
         @starting-style {
           inset: 0 0 0 50%;


### PR DESCRIPTION
Make the Fizzy Do placeholder transition less jumpy on focus.

### Before

https://github.com/user-attachments/assets/45e1466c-d824-41f9-b12c-8891972489ba

### After

https://github.com/user-attachments/assets/5dedfb7c-903e-4488-a63a-dba3ea6abea4