### PR TITLE
Show notification X on card hover

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -459,7 +459,7 @@
     }
 
     @media (hover: hover) {
-      &:hover {
+      .card:hover & {
         --btn-background: transparent;
 
         &:before { opacity: 0; }


### PR DESCRIPTION
In the notifications tray, show the X button when you hover over the card. Before you had you hover over the tiny 20px area in the corner to see the X.