### PR TITLE
Hack for Safari sticky-footer-while-transitioning bug

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -18,7 +18,7 @@
     }
 
     &:has(.popup__footer) {
-      --panel-padding: var(--block-space) var(--block-space) 0 var(--block-space)
+      --panel-padding: var(--block-space) var(--block-space) 0 var(--block-space);
     }
 
     #header:has(&) {
@@ -37,10 +37,11 @@
     background-color: var(--color-canvas);
     border-block-start: 1px solid var(--color-ink-lighter);
     font-size: var(--text-small);
+    inset: auto 0 0;
     line-height: 1.6;
     margin-block-start: var(--block-space-half);
-    margin-inline: calc(var(--block-space) * -1);
     padding: 1.5ch;
+    position: sticky;
     text-align: center;
     z-index: 1;
   }
@@ -176,6 +177,15 @@
       transition-property: display, opacity, overlay;
     }
 
+    /* Safari doesn't position the sticky footer properly during the
+     * transition, so we need to delay the footer entrance. */
+    .popup__footer {
+      animation: safari-sticky-footer-hack 0s;
+      animation-delay: var(--dialog-duration);
+      animation-fill-mode: both;
+      inset-inline: var(--block-space);
+    }
+
     &[open] {
       opacity: 1;
       transform: scale(1) translateX(-50%);
@@ -195,5 +205,10 @@
         opacity: 0;
       }
     }
+  }
+
+  @keyframes safari-sticky-footer-hack {
+    0% { position: absolute; }
+    100% { position: sticky; }
   }
 }


### PR DESCRIPTION
Safari won't position sticky elements correctly until after its ancestor's animations/transitions have completed. The visual result for us is that the sticky footer in the Fizzy menu jumps when you open it, which looks crazy!

This hack positions the footer absolutely (which Safari renders correctly during the transition) until the popover transition is complete, then applies sticky positioning.

Here's a before/after (transitions slowed down and BG colors added to highlight the effect, but they aren't in the PR):

### Before

https://github.com/user-attachments/assets/089a338b-c3ab-44a5-bd71-271e0fe1f012

### After

https://github.com/user-attachments/assets/bd1aab43-76b6-4c4c-b0cc-bb4a2c23830a
