### PR TITLE
Make all pagination start on a new line

### DIFF
--- a/app/views/cards/index/engagement/_closed.html.erb
+++ b/app/views/cards/index/engagement/_closed.html.erb
@@ -5,7 +5,9 @@
     <%= render partial: "cards/display/preview", collection: page.records, as: :card, cached: true %>
 
     <% unless page.last? %>
-      <%= cards_next_page_link "closed-cards", page: page, filter: filter, fetch_on_visible: true %>
+      <div class="full-width">
+        <%= cards_next_page_link "closed-cards", page: page, filter: filter, fetch_on_visible: true %>
+      </div>
     <% end %>
   <% else %>
     <p class="txt-medium translucent">Nothing here</p>

--- a/app/views/cards/index/engagement/_considering.html.erb
+++ b/app/views/cards/index/engagement/_considering.html.erb
@@ -7,7 +7,9 @@
     <%= render partial: "cards/display/preview", collection: page.records, as: :card, locals: { draggable: true }, cached: true %>
 
     <% unless page.last? %>
-      <%= cards_next_page_link "considering-cards", page: page, filter: filter %>
+      <div class="full-width">
+        <%= cards_next_page_link "considering-cards", page: page, filter: filter %>
+      </div>
     <% end %>
   <% else %>
     <p class="txt-medium translucent">Nothing here</p>

--- a/app/views/cards/index/engagement/_doing.html.erb
+++ b/app/views/cards/index/engagement/_doing.html.erb
@@ -11,7 +11,9 @@
       <%= render partial: "cards/display/preview", collection: page.records, as: :card, locals: { draggable: true }, cached: ->(card) { cacheable_preview_parts_for(card) } %>
 
       <% unless page.last? %>
-        <%= cards_next_page_link "doing-cards", page: page, filter: filter %>
+        <div class="full-width">
+          <%= cards_next_page_link "doing-cards", page: page, filter: filter %>
+        </div>
       <% end %>
     <% else %>
       <p class="txt-medium translucent">Nothing here</p>

--- a/app/views/cards/index/engagement/_on_deck.html.erb
+++ b/app/views/cards/index/engagement/_on_deck.html.erb
@@ -7,7 +7,9 @@
     <%= render partial: "cards/display/preview", collection: page.records, as: :card, locals: { draggable: true }, cached: true %>
 
     <% unless page.last? %>
-      <%= cards_next_page_link "on-deck-cards", page: page, filter: filter %>
+      <div class="full-width">
+        <%= cards_next_page_link "on-deck-cards", page: page, filter: filter %>
+      </div>
     <% end %>
   <% else %>
     <p class="txt-medium translucent">Nothing here</p>

--- a/app/views/public/collections/show/_closed.html.erb
+++ b/app/views/public/collections/show/_closed.html.erb
@@ -3,7 +3,9 @@
     <%= render partial: "cards/display/public_preview", collection: page.records, as: :card, cached: true %>
 
     <% unless page.last? %>
-      <%= public_collection_cards_next_page_link collection, "closed-cards", fetch_on_visible: true, page: page %>
+      <div class="full-width">
+        <%= public_collection_cards_next_page_link collection, "closed-cards", fetch_on_visible: true, page: page %>
+      </div>
     <% end %>
   <% else %>
     <p class="txt-medium translucent">Nothing here</p>

--- a/app/views/public/collections/show/_considering.html.erb
+++ b/app/views/public/collections/show/_considering.html.erb
@@ -7,7 +7,9 @@
     <%= render partial: "cards/display/public_preview", collection: page.records, as: :card, cached: true %>
 
     <% unless page.last? %>
-      <%= public_collection_cards_next_page_link collection, "considering-cards", page: page %>
+      <div class="full-width">
+        <%= public_collection_cards_next_page_link collection, "considering-cards", page: page %>
+      </div>
     <% end %>
   <% else %>
     <p class="txt-medium translucent">Nothing here</p>

--- a/app/views/public/collections/show/_doing.html.erb
+++ b/app/views/public/collections/show/_doing.html.erb
@@ -7,7 +7,9 @@
     <%= render partial: "cards/display/public_preview", collection: page.records, as: :card, cached: ->(card) { cacheable_preview_parts_for(card) } %>
 
     <% unless page.last? %>
-      <%= public_collection_cards_next_page_link collection, "doing-cards", page: page %>
+      <div class="full-width">
+        <%= public_collection_cards_next_page_link collection, "doing-cards", page: page %>
+      </div>
     <% end %>
   <% else %>
     <p class="txt-medium translucent">Nothing here</p>


### PR DESCRIPTION
Fixes the layout of pagination buttons.

|Before|After|
|--|--|
|<img width="1372" height="570" alt="CleanShot 2025-08-18 at 15 28 04@2x" src="https://github.com/user-attachments/assets/d8cf9757-3b9e-4545-8667-ebdf5911d818" />|<img width="1372" height="570" alt="CleanShot 2025-08-18 at 15 27 50@2x" src="https://github.com/user-attachments/assets/bcbf9729-5580-4734-9243-84c77f990b6f" />|