### PR TITLE
Fix wonky notification position

### DIFF
--- a/app/assets/stylesheets/trays.css
+++ b/app/assets/stylesheets/trays.css
@@ -57,14 +57,13 @@
       block-size: var(--footer-height);
       pointer-events: none;
 
-      /* On desktop, when there aren't items, tweak the position so the hat
-         doesn't look like it's coming from the bottom of the viewport */
+      /* On desktop, when there aren't items, tweak the hat so it doesn't look
+         like it's coming from the bottom of the viewport */
       @media (min-width: 800px) {
-        &:has(.tray__hat:last-child) {
-          inset-block-end: calc(var(--footer-height) / 2);
-
-          .tray__hat {
+        &:not(:has(.tray__item--notification)) {
+          .tray__item--hat {
             margin-block-end: 0;
+            opacity: 0;
           }
         }
       }
@@ -111,7 +110,7 @@
       }
 
       /* Show a red dot if there are items to show */
-      .tray__dialog:not([open]):has(.tray__item:not(.tray__hat)) ~ &:after {
+      .tray__dialog:not([open]):has(.tray__item--notification) ~ &:after {
         background: oklch(var(--lch-red-medium));
         block-size: 1ch;
         border-radius: 50%;
@@ -125,7 +124,7 @@
     /* On desktop… */
     @media (min-width: 800px) {
       /* Hide the UI when collapsed, but only if there are items */
-      .tray__dialog:not([open]):has(.tray__item:not(.tray__hat)) ~ & {
+      .tray__dialog:not([open]):has(.tray__item--notification) ~ & {
         opacity: 0;
       }
     }
@@ -162,10 +161,10 @@
       margin-block-end: var(--tray-item-margin);
       transition: var(--tray-duration) var(--tray-timing-function);
       transition-delay: var(--tray-item-delay);
-      transition-property: margin, scale;
+      transition-property: margin, opacity, scale;
 
 
-      &:not(.tray__hat) {
+      &:not(.tray__item--hat) {
         z-index: var(--tray-item-z);
       }
 
@@ -209,7 +208,7 @@
     }
   }
 
-  .tray__hat {
+  .tray__item--hat {
     --tray-hat-bg: var(--color-canvas);
     --tray-item-scale: 1;
 
@@ -477,7 +476,7 @@
         z-index: calc(var(--tray-item-z) + 2);
 
         .card,
-        .tray__hat & .btn {
+        .tray__item--hat & .btn {
           border-radius: 0.25ch;
           outline: var(--focus-ring-size) solid var(--focus-ring-color);
           outline-offset: var(--focus-ring-offset);

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -25,7 +25,7 @@ module NotificationsHelper
   end
 
   def notification_tag(notification, &)
-    tag.div id: dom_id(notification), class: "tray__item", data: { navigable_list_target: "item" } do
+    tag.div id: dom_id(notification), class: "tray__item tray__item--notification", data: { navigable_list_target: "item" } do
       concat(
         link_to(notification,
           class: [ "card card--notification", { "card--closed": notification.card.closed? }, { "unread": !notification.read? } ],

--- a/app/views/my/pins/_pin.html.erb
+++ b/app/views/my/pins/_pin.html.erb
@@ -1,4 +1,4 @@
-<div class="tray__item" id="<%= dom_id pin %>" data-navigable-list-target="item">
+<div class="tray__item tray__item--pin" id="<%= dom_id pin %>" data-navigable-list-target="item">
   <%= render "cards/display/preview", card: pin.card %>
   <%= button_to card_pin_path(pin.card), method: :delete, class: "tray__remove-pin-btn btn btn--circle borderless" do %>
     <%= icon_tag "pinned" %> <span class="for-screen-reader">Un-pin this card</span>

--- a/app/views/notifications/_tray.html.erb
+++ b/app/views/notifications/_tray.html.erb
@@ -9,7 +9,7 @@
       data-action="keydown->navigable-list#navigate dialog:show@document->navigable-list#reset turbo-visit->navigable-list#reset keydown.esc->dialog#close:stop click@document->dialog#closeOnClickOutside">
     <%= turbo_frame_tag "notifications", src: tray_notifications_path, refresh: "morph" %>
 
-    <div class="tray__item tray__hat txt-x-small gap-half">
+    <div class="tray__item tray__item--hat txt-x-small gap-half">
       <div data-navigable-list-target="item" class="full-width">
         <%= link_to settings_notifications_path,
               class: "btn borderless tray__notification-settings",


### PR DESCRIPTION
Fixes the wonky position of notifications. This was a regression introduced in https://github.com/basecamp/fizzy/pull/934 where I was using `.tray__hat:last-child` to check if there were no notifications in the tray. That, however, turns out to always be true since the hat isn't a sibling of notifications. In any case: using a different selector does the trick!