### PR TITLE
Don't position the toggle button on top of the dialog

### DIFF
--- a/app/assets/stylesheets/trays.css
+++ b/app/assets/stylesheets/trays.css
@@ -80,7 +80,6 @@
     display: block;
     padding: 0;
     transition: opacity 100ms ease-out;
-    z-index: calc(var(--z-tray) + 1);
 
     .icon {
       color: var(--color-ink);


### PR DESCRIPTION
The tray toggle was appearing on top of the dialog content. TBH, I'm not sure why this is an issue now  since this z-index line has been in place for a while.