### PR TITLE
Always overflow pre tags even without data-language

### DIFF
--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -74,6 +74,7 @@
       margin-block: var(--block-margin);
       padding: 0.1em 0.3em;
 
+      &:is(pre),
       &[data-language] {
         border-radius: 0.5em;
         display: block;


### PR DESCRIPTION
Ensures that all `<pre>` tags overflow correctly. Right now, we only do that if the `data-language` attribute exists, but there's no reason to do this even if that attribute (for whatever reason) isn't there.

|Before|After|
|--|--|
|<img width="1824" height="534" alt="CleanShot 2025-08-19 at 11 38 24@2x" src="https://github.com/user-attachments/assets/b2f9a1b9-be88-4348-9913-d482e4b8e3f3" />|<img width="1822" height="532" alt="CleanShot 2025-08-19 at 11 38 04@2x" src="https://github.com/user-attachments/assets/c4d9e579-5723-41f3-afb0-a727183e9a05" />|