### PR TITLE
Fix card creation hanging

### DIFF
--- a/app/views/commands/_terminal.html.erb
+++ b/app/views/commands/_terminal.html.erb
@@ -19,7 +19,7 @@
       dialog_target: "dialog",
       dialog_modal_value: "true",
       action: "keydown.esc->dialog#close click@document->dialog#closeOnClickOutside" } do %>
-    <%= turbo_frame_tag nil, refresh: :morph, data: { terminal_target: "modalTurboFrame" }, target: "_top" %>
+    <%= turbo_frame_tag "terminal-turbo-frame", refresh: :morph, data: { terminal_target: "modalTurboFrame" }, target: "_top" %>
   <% end %>
 
   <%= render "commands/form" %>


### PR DESCRIPTION
Fixes https://fizzy.37signals.com/5986089/collections/2/cards/1388

After a card is created the redirect simply hangs and renders a blank screen.

The problem was that Turbo Morph would crash because it encountered a blank ID attribute on the terminal's turbo frame