### PR TITLE
Add close dialog button to fizzy menu

### DIFF
--- a/app/assets/stylesheets/fizzy-menu.css
+++ b/app/assets/stylesheets/fizzy-menu.css
@@ -38,6 +38,12 @@
     }
   }
 
+  .fizzy-dialog__close {
+    @media (any-hover: hover) {
+      display: none;
+    }
+  }
+
   .fizzy-menu__hotkeys {
     --gap: 8px;
 

--- a/app/views/cards/index/_header.html.erb
+++ b/app/views/cards/index/_header.html.erb
@@ -31,7 +31,7 @@
         <div class="flex gap">
           <%= text_field_tag :search, nil, placeholder: "Filter…", class: "input input--transparent txt-small", autofocus: true,
                 type: "search", autocorrect: "off", autocomplete: "off", data: { "1p-ignore": "true", filter_target: "input", action: "input->filter#filter" } %>
-          <button class="btn borderless txt-small" data-action="dialog#close">
+          <button class="fizzy-dialog__close btn borderless txt-small" data-action="dialog#close">
             <%= icon_tag "close" %>
             <span class="for-screen-reader">Close menu</span>
           </button>

--- a/app/views/cards/show/_header.html.erb
+++ b/app/views/cards/show/_header.html.erb
@@ -31,7 +31,7 @@
         <div class="flex gap">
           <%= text_field_tag :search, nil, placeholder: "Filter…", class: "input input--transparent txt-small", autofocus: true,
                 type: "search", autocorrect: "off", autocomplete: "off", data: { "1p-ignore": "true", filter_target: "input", action: "input->filter#filter" } %>
-          <button class="btn borderless txt-small" data-action="dialog#close">
+          <button class="fizzy-dialog__close btn borderless txt-small" data-action="dialog#close">
             <%= icon_tag "close" %>
             <span class="for-screen-reader">Close menu</span>
           </button>

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -31,7 +31,7 @@
 		<div class="flex gap">
 			<%= text_field_tag :search, nil, placeholder: "Filter…", class: "input input--transparent txt-small flex-item-grow", autofocus: true,
 						type: "search", autocorrect: "off", autocomplete: "off", data: { "1p-ignore": "true", filter_target: "input", action: "input->filter#filter" } %>
-			<button class="btn borderless txt-small" data-action="dialog#close">
+			<button class="fizzy-dialog__close btn borderless txt-small" data-action="dialog#close">
 				<%= icon_tag "close" %>
 				<span class="for-screen-reader">Close menu</span>
 			</button>


### PR DESCRIPTION
Adds a close button to the Fizzy menu, but only on touch devices. This is helpful since you can't hit ESC on a touch device, and tapping outside the menu isn't really an option on tiny viewports.

|Before|After|
|--|--|
|<img width="960" height="440" alt="CleanShot 2025-08-20 at 14 06 32@2x" src="https://github.com/user-attachments/assets/1432da91-5d01-4096-b123-f650cd5e361a" />|<img width="960" height="440" alt="CleanShot 2025-08-20 at 14 06 20@2x" src="https://github.com/user-attachments/assets/abdae9f9-2369-4206-81cd-f667c38bbbe7" />|