### PR TITLE
Cards header overlap

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -131,14 +131,16 @@
     inset-block-start: 0;
     justify-content: center;
     margin-block-start: 1px;
-    margin-inline: calc(-1 * var(--cards-gap) - var(--reserved-bubble-space) - var(--main-padding)); /* cover bubbles and cards */
+    margin-inline: -8px; /* enough to cover card shadows, but avoid overlapping bubbles */
     padding-block: var(--cards-gap);
     position: sticky;
     z-index: 2;
-    background: gold !important;
 
-    @media (min-width: 640px) {
-      margin-inline: -8px; /* enough to cover card shadows, but avoid overlapping bubbles */
+    /* Cover bubbles and cards on small viewports */
+    @media (max-width: 639px) {
+      &:not(.cards--closed &) {
+        margin-inline: calc(-1 * var(--cards-gap) - var(--reserved-bubble-space) - var(--main-padding));
+      }
     }
 
     &, .cards__filter {


### PR DESCRIPTION
On larger screens, keep the sticky header from overlapping bubbles. On mobile, make sure it overlaps bubbles.

Ideally we'd overlap the bubble completely on larger viewports as well, but it's rather tricky given the offset nature of the columns.

### Desktop

|Before|After|
|--|--|
|<img width="1386" height="440" alt="CleanShot 2025-08-20 at 14 41 29@2x" src="https://github.com/user-attachments/assets/2ad5fa2a-dc1a-46a0-ac86-37d5659471fb" />|<img width="1386" height="440" alt="CleanShot 2025-08-20 at 14 41 16@2x" src="https://github.com/user-attachments/assets/34ce0a4e-cdd0-417d-80e5-94475f22f853" />|

### Mobile

|Before|After|
|--|--|
|<img width="780" height="440" alt="CleanShot 2025-08-20 at 14 40 49@2x" src="https://github.com/user-attachments/assets/ee7aac6c-68ff-4f9f-9e98-5188ae379ef3" />|<img width="780" height="440" alt="CleanShot 2025-08-20 at 14 40 24@2x" src="https://github.com/user-attachments/assets/f26df8e7-1c8b-4935-b99d-941b2d6d0ce4" />|