### PR TITLE
Use magic number to position bottom notch on card perma

### DIFF
--- a/app/assets/stylesheets/card-perma.css
+++ b/app/assets/stylesheets/card-perma.css
@@ -192,11 +192,13 @@
   }
 
   .card-perma__notch--bottom {
+    --half-btn-height: 1.25rem;
+
     grid-area: notch-bottom;
 
-    /* Translate the buttons instead of the container to allow for wrapping */
-    .btn {
-      translate: 0 -50%;
+    /* Overlap the card BG by half the button height */
+    &:has(.btn) {
+      translate: 0 calc(-1 * var(--half-btn-height));
     }
 
     &:has([open]) {
@@ -227,6 +229,5 @@
 
   .card-perma__closure-message {
     color: var(--card-color);
-    translate: 0 -100%;
   }
 }


### PR DESCRIPTION
This fixes a regression introduced here: https://github.com/basecamp/fizzy/pull/957. I was originally trying to avoid using magic numbers to get the buttons in the bottom notch to sit halfway over the card background, but this proved to be rather tricky since there are things other than buttons in the bottom notch.

Instead, it's much easier to just use a magic number and shift the whole bottom notch up.

|Before|After|
|--|--|
|<img width="1166" height="262" alt="CleanShot 2025-08-25 at 10 48 49@2x" src="https://github.com/user-attachments/assets/7cab7f5d-192f-4675-8790-aabf61bcd91d" />|<img width="1166" height="262" alt="CleanShot 2025-08-25 at 10 48 31@2x" src="https://github.com/user-attachments/assets/b9cefc5a-5267-449d-9b93-55fb29e38e63" />|