### PR TITLE
Style tweaks to bar placeholder

### DIFF
--- a/app/assets/stylesheets/bar.css
+++ b/app/assets/stylesheets/bar.css
@@ -41,12 +41,18 @@
   }
 
   .bar__placeholder {
+    color: var(--color-ink-medium);
     font-weight: 500;
-    opacity: 0.66;
 
     .btn--plain {
-      font-weight: 500;
+      color: inherit;
+      font-weight: inherit;
+      padding-inline: 1ch;
       white-space: nowrap;
+
+      &:hover {
+        color: oklch(var(--lch-blue-dark));
+      }
     }
   }
 }

--- a/app/helpers/hotkeys_helper.rb
+++ b/app/helpers/hotkeys_helper.rb
@@ -11,7 +11,7 @@ module HotkeysHelper
         else
           key
         end
-      }.join("+")
+      }.join()
     else
       hotkey.split(",").first if hotkey
     end

--- a/app/views/bar/_bar.html.erb
+++ b/app/views/bar/_bar.html.erb
@@ -6,7 +6,7 @@
         bar_search_url_value: search_path,
         bar_ask_url_value: conversation_path
       } do %>
-  <div class="flex justify-center gap bar__placeholder" data-bar-target="buttonsContainer">
+  <div class="flex justify-center bar__placeholder" data-bar-target="buttonsContainer">
     <%= tag.button \
           class: "btn btn--plain",
           data: {
@@ -14,7 +14,7 @@
             action: "
             bar#search
             keydown.meta+k@document->hotkey#click keydown.ctrl+k@document->hotkey#click" } do %>
-      <span>Search [<%= hotkey_label(["ctrl", "K"]) %>]</span>
+      <span>Search (<%= hotkey_label(["ctrl", "K"]) %>)</span>
     <% end %>
     <span>or</span>
     <%= tag.button \
@@ -24,7 +24,7 @@
             action: "
             bar#ask
             keydown.meta+a@document->hotkey#click keydown.ctrl+a@document->hotkey#click" } do %>
-      <span>Ask [<%= hotkey_label(["ctrl", "A"]) %>]</span>
+      <span>Ask (<%= hotkey_label(["ctrl", "A"]) %>)</span>
     <% end %>
   </div>
 


### PR DESCRIPTION
@jzimdars, here are a couple suggested tweaks to the bar placeholder. Nothing super important, so feel free to discard if you're not into it.

- For hotkeys, use parentheses instead of brackets and nix the `+`—to me, it's just a bit easier to read
- Add a hover state to the Search & Ask buttons, and make the click area a tad larger

|Before|After|
|--|--|
|<img width="974" height="116" alt="CleanShot 2025-08-25 at 11 07 23@2x" src="https://github.com/user-attachments/assets/106517c6-2cd7-4353-88ab-8923721c7910" />|<img width="972" height="116" alt="CleanShot 2025-08-25 at 11 06 18@2x" src="https://github.com/user-attachments/assets/00775b0c-230f-4562-a37a-182d86d98a96" />|