### PR TITLE
Make Fizzy Ask respond with an error message when a response fails to generate

### DIFF
--- a/app/jobs/conversation/message/response_generator_job.rb
+++ b/app/jobs/conversation/message/response_generator_job.rb
@@ -1,6 +1,6 @@
 class Conversation::Message::ResponseGeneratorJob < ApplicationJob
   discard_on StandardError do |job, error|
-    Rails.error.report(error)
+    Rails.error.report(error, severity: :error)
 
     if conversation = job.arguments.first.try(:conversation)
       conversation.respond("Something went wrong. Please try again in a moment.")


### PR DESCRIPTION
Sometimes the response job will fail for expected or unexpected reasons.

We should communicate to the user that an error happened instead of leaving the user's conversation stuck in the thinking state with no feedback.

This PR adds some error handling to the response generator job which, in case an error occurs, responds to the user to let them know that their question wasn't processed and that they should try again. This also unlocks the conversation so that they can ask another question if they'd like.

<img width="755" height="216" alt="image" src="https://github.com/user-attachments/assets/e799c04a-f301-470f-b63f-0f324b2ed3b6" />


The error messages differ slightly. For rate-limit and service availability error I've made Fizzy respond with a message saying that it's too busy at the moment. And for all other errors I made it respond with the Rails classic "Something went wrong". Both errors instruct the user to try again.