### PR TITLE
Center figure attachments and use normal size for Save Changes button

### DIFF
--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -21,7 +21,7 @@
     :where(h6) { font-size: 0.67em; }
 
     :where(p, ul, ol, dl, blockquote, figure, .attachment) {
-      margin-block: var(--block-margin);
+      margin-block: 0 var(--block-margin);
 
       &:not(lexxy-editor &) {
         overflow-wrap: break-word;
@@ -171,13 +171,22 @@
     margin-inline: 0;
     max-inline-size: 100%;
 
-    &:is(figure) img,
-    &:is(figure) video {
-      block-size: auto;
-      display: block;
+    &:is(figure) {
+      inline-size: fit-content;
       margin-inline: auto;
-      max-inline-size: 100%;
-      user-select: none;
+      display: block;
+
+      img, video {
+        block-size: auto;
+        display: block;
+        margin-inline: auto;
+        max-inline-size: 100%;
+        user-select: none;
+      }
+
+      > a {
+        display: block;
+      }
     }
 
     :where(progress) {

--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -79,6 +79,7 @@
   .half-width { inline-size: 50%; }
   .max-width { max-inline-size: 100%; }
   .min-content { inline-size: min-content; }
+  .fit-content { inline-size: fit-content; }
   .max-inline-size { max-inline-size: 100%; }
 
   /* Overflow */

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -14,7 +14,7 @@
       <%= general_prompts(@card.collection) %>
     <% end %>
 
-    <%= form.button "Save changes", type: :submit, class: "btn btn--reversed", style: "--btn-background: #{@card.color}" %>
+    <%= form.button "Save changes", type: :submit, class: "btn btn--reversed fit-content", style: "--btn-background: #{@card.color}" %>
     <%= link_to "Close editor and discard changes", collection_card_path(@card.collection, @card), data: { form_target: "cancel" }, hidden: true %>
   <% end %>
 <% end %>


### PR DESCRIPTION
- Image/video attachments are now centered, both when editing and viewing.
- Image/video attachments now fit the width of their content. The effect is that if you have an image that doesn't take up the full width of the container, the click area for the lightbox is now just the image/video—before, you could click anywhere on the sides of the lightbox to open it, which felt not great.
- The "Save Changes" button is now a normal size instead of stretching to be full-width.

|Before|After|
|--|--|
|<img width="2078" height="2038" alt="CleanShot 2025-08-26 at 15 32 47@2x" src="https://github.com/user-attachments/assets/a5d7ce64-e8dc-4031-884d-7d1ee00ba963" /><img width="2078" height="2038" alt="CleanShot 2025-08-26 at 15 32 39@2x" src="https://github.com/user-attachments/assets/83ea4e64-370e-4e47-9cbe-79e827702b57" />|<img width="2078" height="2038" alt="CleanShot 2025-08-26 at 15 33 00@2x" src="https://github.com/user-attachments/assets/e4d87d37-c626-43ea-9dc3-11199f62ecda" /><img width="2078" height="2038" alt="CleanShot 2025-08-26 at 15 33 07@2x" src="https://github.com/user-attachments/assets/8243512c-1170-4c14-b259-7ad22633f70b" />|