### PR TITLE
Fix up hotkey labels

### DIFF
--- a/app/helpers/hotkeys_helper.rb
+++ b/app/helpers/hotkeys_helper.rb
@@ -8,7 +8,7 @@ module HotkeysHelper
         platform.mac? ? "return" : "enter"
       else
         key
-      end
-    end.join()
+      end.capitalize
+    end.join("+").gsub(/⌘\+/, "⌘")
   end
 end

--- a/test/helpers/hotkeys_helper_test.rb
+++ b/test/helpers/hotkeys_helper_test.rb
@@ -12,31 +12,31 @@ class HotkeysHelperTest < ActionView::TestCase
   test "linux modifier key" do
     emulate_linux
 
-    assert_equal "ctrlJ", hotkey_label([ "ctrl", "J" ])
+    assert_equal "Ctrl+J", hotkey_label([ "ctrl", "J" ])
   end
 
   test "mac enter" do
     emulate_mac
 
-    assert_equal "returnJ", hotkey_label([ "enter", "J" ])
+    assert_equal "Return+J", hotkey_label([ "enter", "J" ])
   end
 
   test "linux enter" do
     emulate_linux
 
-    assert_equal "enterJ", hotkey_label([ "enter", "J" ])
+    assert_equal "Enter+J", hotkey_label([ "enter", "J" ])
   end
 
   test "mac hyper" do
     emulate_mac
 
-    assert_equal "hyperJ", hotkey_label([ "hyper", "J" ])
+    assert_equal "Hyper+J", hotkey_label([ "hyper", "J" ])
   end
 
   test "linux hyper" do
     emulate_linux
 
-    assert_equal "hyperJ", hotkey_label([ "hyper", "J" ])
+    assert_equal "Hyper+J", hotkey_label([ "hyper", "J" ])
   end
 
   private


### PR DESCRIPTION
On mac, it will still say "⌘K" but Linux will say "Ctrl+K".

I also added unit tests so we can make sure we understand how these look on all platforms.
