### PR TITLE
Max size for bubble number to prevent FF bug

### DIFF
--- a/app/assets/stylesheets/bubble.css
+++ b/app/assets/stylesheets/bubble.css
@@ -44,7 +44,7 @@
 
   .bubble__number {
     display: grid;
-    font-size: 50cqi;
+    font-size: clamp(10px, 50cqi, 26px); /* FF bug: https://fizzy.37signals.com/5986089/collections/2/cards/1373 */
     font-weight: 900;
     inset: 0;
     place-content: center;


### PR DESCRIPTION
https://fizzy.37signals.com/5986089/collections/2/cards/1373

Clamp the font size for the bubble number to prevent a flash-of-too-big-of-text (FOTBOT, a term I just coined) on Firefox Windows.