### PR TITLE
Update Beamer configuration to switchable version

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -2,13 +2,10 @@ servers:
   web:
     hosts:
       - fizzy-app-101
+      - fizzy-app-102
   jobs:
     hosts:
       - fizzy-app-101
-  web-replica:
-    hosts:
-      - fizzy-app-102
-    proxy: true
 
 proxy:
   ssl: false
@@ -20,34 +17,23 @@ env:
   clear:
     RAILS_ENV: production
 
-x-beamer-accessory: &beamer-accessory
-  image: basecamp/beamer:vfs
-  registry:
-    server: registry.37signals.com
-    username: robot$harbor-bot
-    password: 
-      - BASECAMP_REGISTRY_PASSWORD
-  options:
-    user: 1000 # Match the UID of the Rails app, for volume permissions
-  volumes:
-    - fizzy:/storage
-
-
 accessories:
-  beamer-primary:
-    <<: *beamer-accessory
-    service: beamer-primary
-    cmd: beamer primary --remove-after=1h --dir=/storage --disable-tls
-    port: 5000:80
-    roles:
-      - web
-
-  beamer-replica:
-    <<: *beamer-accessory
-    service: beamer-replica
-    cmd: beamer replica --primary=http://fizzy-app-101:5000/ --dir=/storage
-    roles:
-      - web-replica
+  beamer:
+    image: basecamp/beamer:vfs
+    registry:
+      server: registry.37signals.com
+      username: robot$harbor-bot
+      password:
+        - BASECAMP_REGISTRY_PASSWORD
+    options:
+      user: 1000 # Match the UID of the Rails app, for volume permissions
+    volumes:
+      - fizzy:/home/beamer
+    cmd: beamer run --retention=1h
+    port: 5001:5001
+    hosts:
+      - fizzy-app-101
+      - fizzy-app-102
 
   load-balancer:
     image: basecamp/kamal-proxy:lb

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -2,13 +2,10 @@ servers:
   web:
     hosts:
       - fizzy-staging-app-01
+      - fizzy-staging-app-101
   jobs:
     hosts:
       - fizzy-staging-app-01
-  web-replica:
-    hosts:
-      - fizzy-staging-app-101
-    proxy: true
 
 proxy:
   ssl: false
@@ -20,34 +17,23 @@ env:
   clear:
     RAILS_ENV: staging
 
-x-beamer-accessory: &beamer-accessory
-  image: basecamp/beamer:vfs
-  registry:
-    server: registry.37signals.com
-    username: robot$harbor-bot
-    password: 
-      - BASECAMP_REGISTRY_PASSWORD
-  options:
-    user: 1000 # Match the UID of the Rails app, for volume permissions
-  volumes:
-    - fizzy:/storage
-
-
 accessories:
-  beamer-primary:
-    <<: *beamer-accessory
-    service: beamer-primary
-    cmd: beamer primary --remove-after=1h --dir=/storage --disable-tls
-    port: 5000:80
-    roles:
-      - web
-
-  beamer-replica:
-    <<: *beamer-accessory
-    service: beamer-replica
-    cmd: beamer replica --primary=http://fizzy-staging-app-01:5000/ --dir=/storage
-    roles:
-      - web-replica
+  beamer:
+    image: basecamp/beamer:vfs
+    registry:
+      server: registry.37signals.com
+      username: robot$harbor-bot
+      password:
+        - BASECAMP_REGISTRY_PASSWORD
+    options:
+      user: 1000 # Match the UID of the Rails app, for volume permissions
+    volumes:
+      - fizzy:/home/beamer
+    cmd: beamer run --retention=1h
+    port: 5001:5001
+    hosts:
+      - fizzy-staging-app-01
+      - fizzy-staging-app-101
 
   load-balancer:
     image: basecamp/kamal-proxy:lb

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -14,7 +14,7 @@ proxy:
 registry:
   server: registry.37signals.com
   username: robot$harbor-bot
-  password: 
+  password:
     - BASECAMP_REGISTRY_PASSWORD
 
 builder:
@@ -31,3 +31,4 @@ env:
 aliases:
   console: app exec -i --reuse "bin/rails console"
   ssh: app exec -i --reuse /bin/bash
+  switch: accessory exec beamer --reuse "beamer switch --primary=<%= ENV["PRIMARY"] %>"


### PR DESCRIPTION
- Updates Fizzy to use the new "switchable" version of Beamer
- Simplifies the deployment configuration: instead of two separate `web` and `web-replica` roles, we now just have the usual `web`. Aside from job configuration (which we're working on separately), the deployment of each app node is now identical.
- Beamer node configuration is now automatic. The first time the `fizzy-beamer` accessory boots, it'll init the cluster, using the hostname provided in `$KAMAL_HOST` to name it.
- There's a new Kamal alias that can be used to set or change the direction of replication:

      PRIMARY=fizzy-app-101 bin/kamal switch -d production

Note that there are two caveats to using `kamal switch` right now:
  - Until we set up a moveable job worker, replication is only valid from fizzy-app-101 -> fizzy-app-102. If you run `kamal switch` to move the primary to -102, there's nothing there to run jobs.
  - Switching doesn't currently update the load balancer either. This is because we have some funky inconsistent naming in the LB to get around the fact that it's piggybacked onto one of the app servers. We should move it to another node, and then the hosts/ports will be consistent and we can an add alias to move that too.)

/cc @flavorjones 