### PR TITLE
Configure action_controller.default_url_options

### DIFF
--- a/config/environments/beta.rb
+++ b/config/environments/beta.rb
@@ -3,7 +3,8 @@ require_relative "production"
 Rails.application.configure do
   config.action_mailer.smtp_settings[:domain] = "fizzy-beta.37signals.com"
   config.action_mailer.smtp_settings[:address] = "smtp-outbound-staging"
-  config.action_mailer.default_url_options = { host: "fizzy-beta.37signals.com", protocol: "https" }
+  config.action_mailer.default_url_options     = { host: "fizzy-beta.37signals.com", protocol: "https" }
+  config.action_controller.default_url_options = { host: "fizzy-beta.37signals.com", protocol: "https" }
 
   # Let's keep beta on local disk. See https://github.com/basecamp/fizzy/pull/557 for context.
   config.active_storage.service = :local

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,9 +39,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "%{tenant}.example.com", port: 3006 }
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -81,8 +78,9 @@ Rails.application.configure do
 
   config.hosts = %w[ fizzy.localhost localhost 127.0.0.1 ]
 
-  # Host to be used in links rendered from ActionMailer
-  config.action_mailer.default_url_options = { host: config.hosts.first, port: 3006 }
+  # Set host to be used by links generated in mailer and notification view templates.
+  config.action_controller.default_url_options = { host: config.hosts.first, port: 3006 }
+  config.action_mailer.default_url_options     = { host: config.hosts.first, port: 3006 }
 
   if Rails.root.join("tmp/solid-queue.txt").exist?
     config.active_job.queue_adapter = :solid_queue

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,8 +73,9 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "fizzy.37signals.com", protocol: "https" }
+  # Set host to be used by links generated in mailer and notification view templates.
+  config.action_controller.default_url_options = { host: "fizzy.37signals.com", protocol: "https" }
+  config.action_mailer.default_url_options     = { host: "fizzy.37signals.com", protocol: "https" }
 
   config.action_mailer.smtp_settings = { domain: "fizzy.37signals.com", address: "smtp-outbound", port: 25, enable_starttls_auto: false }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,5 +3,6 @@ require_relative "production"
 Rails.application.configure do
   config.action_mailer.smtp_settings[:domain] = "fizzy.37signals-staging.com"
   config.action_mailer.smtp_settings[:address] = "smtp-outbound-staging"
-  config.action_mailer.default_url_options = { host: "fizzy.37signals-staging.com", protocol: "https" }
+  config.action_mailer.default_url_options     = { host: "fizzy.37signals-staging.com", protocol: "https" }
+  config.action_controller.default_url_options = { host: "fizzy.37signals-staging.com", protocol: "https" }
 end


### PR DESCRIPTION
so that using url helpers will work in turbo stream notifications sent by background jobs.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/1469

cc @jorgemanrubia related to 93c9855a