### PR TITLE
Tweak the header actions width

### DIFF
--- a/app/assets/stylesheets/events.css
+++ b/app/assets/stylesheets/events.css
@@ -4,7 +4,7 @@
 
   .header--events {
     @media (min-width: 640px) {
-      --header-actions-width: 7rem !important;
+      --header-actions-width: 7.25rem !important;
     }
   }
 


### PR DESCRIPTION
The header actions width was a touch too small, which made the Add a Card button on the home screen bunched up on Firefox. A reminder why magic numbers are smelly, although in this case perhaps the best option.