### PR TITLE
Disable access switch for current user

### DIFF
--- a/app/views/collections/_access_toggle.erb
+++ b/app/views/collections/_access_toggle.erb
@@ -9,7 +9,7 @@
   <%= icon_tag "check", class: "toggler__visible-when-on margin-inline-end" %>
 
   <label class="switch toggler__visible-when-off flex-item-no-shrink">
-    <%= check_box_tag "user_ids[]", user.id, selected, class: "switch__input", id: nil %>
+    <%= check_box_tag "user_ids[]", user.id, selected, class: "switch__input", id: nil, disabled: Current.user == user %>
     <span class="switch__btn round"></span>
     <span class="for-screen-reader">Give <%= user.name %> access</span>
   </label>


### PR DESCRIPTION
Current users shouldn't be able to remove themselves from a collection. It just feels weird to have the ability to lock yourself out of a collection. This also addresses the edge case where you could uncheck _everybody_ from a collection, which would require a support call to let anyone have access again.

- https://fizzy.37signals.com/5986089/collections/2/cards/644
- https://fizzy.37signals.com/5986089/collections/2/cards/738