### PR TITLE
Don't render HTML stripping the tags for comment bodies, use to_plain_text instead

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -85,7 +85,7 @@ module NotificationsHelper
 
     def comment_notification_body(event)
       comment = event.eventable
-      strip_tags(comment.body.to_s).truncate(200)
+      comment.body.to_plain_text.truncate(200)
     end
 
     def card_notification_title(card)


### PR DESCRIPTION
This will prevent error when generating notification bundles such as:

```
Type	ActionView::Template::Error
Message	undefined method 'rails_blob_path' for an instance of #<Class:0x00007fbb7e0c2a88>
```

Since you can't use _path helpers from mailers. We could just use the _url variant in the template, but this feels better nevertheless

cc @jzimdars @kevinmcconnell in case I'm missing something with this change. Maybe we were not using "to_plain_text" before because we started with House?