### PR TITLE
Use px so help Windows out

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -37,7 +37,7 @@
     }
 
     .card & {
-      inline-size: 28ch;
+      inline-size: 260px;
     }
   }
 


### PR DESCRIPTION
The default font on Windows uses a pretty narrow `ch` width, which makes the tag popover width quite different between Mac/Windows. Instead, we can use pixel units so the popover ends up at the same size.