### PR TITLE
Fix: add card adding cards to the wrong collection

### DIFF
--- a/app/models/user/filtering.rb
+++ b/app/models/user/filtering.rb
@@ -3,7 +3,7 @@ class User::Filtering
 
   attr_reader :user, :filter, :expanded
 
-  delegate :as_params, :any?, to: :filter
+  delegate :as_params, :any?, :single_collection, to: :filter
   delegate :only_closed?, to: :filter
 
   def initialize(user, filter, expanded: false)

--- a/app/views/cards/index/_add_card_button.html.erb
+++ b/app/views/cards/index/_add_card_button.html.erb
@@ -1,4 +1,4 @@
-<% if @filter.collection_ids.one? && collection = user_filtering.collections.first %>
+<% if collection = user_filtering.single_collection %>
   <div class="card card--new">
     <%= button_to collection_cards_path(collection), method: :post, class: "btn" do %>
       <%= icon_tag "add" %>

--- a/app/views/filters/menu/_add_card_button.html.erb
+++ b/app/views/filters/menu/_add_card_button.html.erb
@@ -1,5 +1,5 @@
 <div class="header__actions header__actions--start">
-  <% if collection = user_filtering.collections.first %>
+  <% if collection = user_filtering.single_collection %>
     <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link btn--circle-mobile" do %>
       <%= icon_tag "add" %>
       <span>Add a card</span>


### PR DESCRIPTION
Make sure we only show the "add card" button when there is a single collection selected, and that it adds to that  collection.

https://fizzy.37signals.com/5986089/collections/2/cards/1439

cc @jzimdars 