### PR TITLE
Don't lose editing context as you assign users

### DIFF
--- a/app/controllers/cards/assignments_controller.rb
+++ b/app/controllers/cards/assignments_controller.rb
@@ -6,6 +6,7 @@ class Cards::AssignmentsController < ApplicationController
 
   def create
     @card.toggle_assignment @collection.users.active.find(params[:assignee_id])
-    render_card_replacement
+
+    render turbo_stream: turbo_stream.replace([ @card, :assignees ], partial: "cards/display/perma/assignees", locals: { card: @card.reload })
   end
 end

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -1,8 +1,6 @@
 <%= turbo_frame_tag @card, :edit do %>
   <%= form_with model: @card, url: collection_card_path(@card.collection, @card),
-        data: { controller: "autoresize form local-save",
-                local_save_key_value: "card-#{@card.id}",
-                action: "turbo:submit-end->local-save#submit" } do |form| %>
+        data: { controller: "autoresize form local-save", local_save_key_value: "card-#{@card.id}", action: "turbo:submit-end->local-save#submit" } do |form| %>
     <h1 class="card__title flex align-start gap-half">
       <%= form.label :title, class: "flex flex-column align-center autoresize__wrapper", data: { autoresize_target: "wrapper", autoresize_clone_value: "" } do %>
         <%= form.text_area :title, class: "card-field__title input input--textarea hide-focus-ring full-width borderless txt-align-start autoresize__textarea",

--- a/test/controllers/cards/assignments_controller_test.rb
+++ b/test/controllers/cards/assignments_controller_test.rb
@@ -13,12 +13,17 @@ class Cards::AssignmentsControllerTest < ActionDispatch::IntegrationTest
   test "create" do
     assert_changes "cards(:logo).assigned_to?(users(:david))", from: false, to: true do
       post card_assignments_path(cards(:logo)), params: { assignee_id: users(:david).id }, as: :turbo_stream
-      assert_card_container_rerendered(cards(:logo))
+      assert_assignees_replaced(cards(:logo))
     end
 
     assert_changes "cards(:logo).assigned_to?(users(:david))", from: true, to: false do
       post card_assignments_path(cards(:logo)), params: { assignee_id: users(:david).id }, as: :turbo_stream
-      assert_card_container_rerendered(cards(:logo))
+      assert_assignees_replaced(cards(:logo))
     end
   end
+
+  private
+    def assert_assignees_replaced(card)
+      assert_turbo_stream action: :replace, target: dom_id(card, :assignees)
+    end
 end


### PR DESCRIPTION
- Save description field as you type so that it will be there if you don't save but reload the page or something.
- Use a stream when selecting an assignee, so that you keep the editing context in place

https://fizzy.37signals.com/5986089/collections/2/cards/1479