### PR TITLE
Needs to override `mark`'s inherent coloring

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -403,6 +403,7 @@
     .card__notification-mentioner {
       background-color: var(--color-highlight);
       border-radius: 0.7em 0.2em 0.7em 0.2em;
+      color: inherit;
       display: inline-flex;
       padding: 0.1em 0.3em;
     }


### PR DESCRIPTION
<img width="523" height="577" alt="image" src="https://github.com/user-attachments/assets/8ea87ed9-c18d-4383-a8f0-e81925915c88" />
