### PR TITLE
Temporarily add back the 404.html page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>The page you were looking for doesn’t exist (404 Not found)</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1, width=device-width">
+    <meta name="robots" content="noindex, nofollow">
+    <style>
+      :root {
+        --color-canvas: white;
+        --color-ink: oklch(26% 0.05 264);
+        --color-accent: oklch(57.02% 0.1895 260.46);
+        --stroke-width: clamp(4px, 0.25vw, 6vw);
+        --padding: clamp(2rem, 2vw, 8rem);
+
+        --text-large: clamp(6rem, 7vw, 6vw);
+        --text-medium: clamp(3rem, 3vw, 6vw);
+        --text-normal: clamp(1rem, 1.25vw, 6vw);
+
+        @media (prefers-color-scheme: dark) {
+          --color-canvas: oklch(20% 0.0195 232.58);
+          --color-ink: oklch(96.02% 0.0034 260);
+          --color-accent: oklch(74% 0.1293 256);
+        }
+      }
+
+      *, *::before, *::after {
+        box-sizing: border-box;
+        margin: 0;
+      }
+
+      html {
+        font-size: 1.1875rem;
+      }
+
+      body {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        -webkit-text-size-adjust: none;
+        background-color: var(--color-canvas);
+        color: var(--color-ink);
+        display: grid;
+        font-family: system-ui;
+        font-size: var(--text-normal);
+        font-style: normal;
+        font-weight: 700;
+        line-height: 1.375;
+        min-height: 100vh;
+        overflow: hidden;
+        justify-content: center;
+        padding-block-start: 20dvh;
+        text-rendering: optimizeLegibility;
+        text-size-adjust: none;
+
+        /* Cool wavy striped lines */
+        &:before {
+          --mask:
+            radial-gradient(6px at 50% calc(100% + 3px), #0000 calc(99% - 2px), #000 calc(101% - 2px) 99%, #0000 101%) calc(50% - 8px) calc(50% - 3px + .5px)/16px 6px ,
+            radial-gradient(6px at 50% -3px, #0000 calc(99% - 2px), #000 calc(101% - 2px) 99%, #0000 101%) 50% calc(50% + 3px)/16px 6px ;
+          -webkit-mask: var(--mask);
+                  mask: var(--mask);
+          background: var(--color-accent);
+          content: "";
+          inset: 0;
+          opacity: 0.25;
+          position: absolute;
+        }
+      }
+
+      .error-page {
+        rotate: -8deg;
+      }
+
+      .error-page__logo {
+        --logo-size: 1.15em;
+
+        align-items: center;
+        display: flex;
+        text-align: center;
+        font-size: var(--text-medium);
+        justify-content: center;
+        margin-block-end: 0.5ch;
+
+        svg {
+          block-size: var(--logo-size);
+          inline-size: var(--logo-size);
+          display: block;
+          translate: 0 -10%;
+        }
+      }
+
+      .error-page__stamp {
+        align-items: center;
+        background-color: color-mix(in oklch, var(--color-canvas), transparent 50%);
+        border-radius: calc(var(--stroke-width) * 2);
+        border: calc(var(--stroke-width) * 1) dashed var(--color-accent);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        line-height: 1.25;
+        max-inline-size: 32ch;
+        padding: var(--padding);
+        position: relative;
+        text-align: center;
+      }
+
+      .error-page__title {
+        color: var(--color-accent);
+        font-size: var(--text-large);
+        font-weight: 900;
+        line-height: 1;
+        position: relative;
+        text-align: center;
+        text-transform: uppercase;
+
+        @supports (-webkit-text-stroke: 1px black) {
+          -webkit-text-stroke: var(--stroke-width) var(--color-accent);
+          -webkit-text-fill-color: transparent;
+        }
+      }
+
+      .error-page__subtitle {
+        color: var(--color-accent);
+        margin-block-end: 1ch;
+      }
+
+      .error-page__notes {
+        font-size: var(--text-sm);
+        font-weight: 500;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="error-page">
+      <figure class="error-page__logo">
+        <svg fill="none" height="275" viewBox="0 0 202 275" width="202" xmlns="http://www.w3.org/2000/svg"><path d="m201 258c0 11.159-44.772 16-100 16-55.2285 0-100-4.841-100-16s44.7715-16 100-16c55.228 0 100 4.841 100 16z" fill="#000" opacity=".08"/><path clip-rule="evenodd" d="m144.805 2.24222c2.294-1.843841 5.681-1.617368 7.696.56152 2.014 2.17904 1.917 5.51121-.174 7.57326l-.209.1953-.012.0117c-.009.0075-.022.0181-.039.0332-.035.0309-.087.078-.156.1397-.138.1235-.344.309-.614.5508-.54.484-1.336 1.1979-2.353 2.1152-2.033 1.835-4.952 4.4821-8.487 7.7256-7.073 6.4897-16.602 15.357-26.441 24.8759-2.543 2.4612-4.066 5.7749-4.269 9.2891-.383 6.654-.719 11.235-1.012 17.6885 27.89.2759 50.213 1.9831 62.831 3.1963l2.598.2558.018.002c7.816.8155 13.555 7.8838 12.741 15.4687l.001.001c-3.418 33.6092-7.351 63.0722-10.988 87.6142.005.178.001.359-.012.54-.03.417-.11.819-.228 1.203-3.37 24.477-6.469 42.647-8.652 56.28-2.231 13.914-13.656 24.673-28.256 25.45h-.011c-24.343 1.247-48.8273 1.346-73.2036.126l-2.3589-.122c-14.5946-.782-26.0187-11.539-28.2492-25.453-2.1836-13.632-5.2839-31.801-8.6543-56.276-.1189-.385-.1974-.789-.2278-1.208-.0133-.182-.0178-.363-.013-.542-3.6384-24.542-7.5712-54.004-10.9942-87.6112l.0009-.001c-.814-7.5854 4.9246-14.6542 12.7413-15.4697l.0179-.002c12.5608-1.2701 37.7453-3.3397 69.6834-3.4824.3004-6.6424.644-11.4215 1.0396-18.2793.3592-6.2258 3.0569-12.1147 7.5909-16.5019 9.93-9.6079 19.535-18.5451 26.654-25.0772 3.561-3.2672 6.504-5.93628 8.557-7.78905 1.027-.9262 1.831-1.64876 2.38-2.14063.274-.24594.485-.43526.628-.56249.07-.06313.124-.111.161-.14356.018-.01633.033-.02867.043-.03711.004-.00412.007-.00855.01-.01074l.003-.00195.001-.00098zm-43.801 180.81978c-19.4 0-36.6494.529-49.0474 1.058-5.7553.246-10.4622.491-13.8495.684 3.0876 22.131 5.9039 38.413 7.9281 51.05l.0726.422c1.6067 8.833 8.807 15.28 17.7176 15.757l2.319.12c22.4196 1.123 44.9546 1.111 67.4046.099l4.644-.225c9.05-.486 16.331-7.128 17.781-16.173 2.024-12.637 4.838-28.919 7.925-51.05-3.387-.193-8.094-.438-13.849-.684-12.398-.529-29.647-1.058-49.046-1.058zm-3.9481-99.0874c-31.2286.1604-55.8254 2.1836-68.0558 3.42-1.5771.1659-2.8714 1.698-2.7906 3.2392l.0119.1494.005.0489c3.2299 31.7109 6.9166 59.5089 10.3775 83.0379.0293-.002.0589-.003.0885-.005 3.4785-.201 8.5176-.468 14.7777-.735 11.3621-.485 26.7597-.968 44.1622-1.054-.0045-.387-.0095-.861-.015-1.42-.017-1.739-.0366-4.292-.0487-7.56-.0243-6.536-.0177-13.933.1084-25.385.1704-15.474.5585-32.713 1.3789-53.7364zm11.2131.0235c-.826 21.0519-1.215 38.3339-1.386 53.8319-.125 11.393-.133 18.735-.109 25.226.012 3.245.032 5.777.049 7.495.006.614.011 1.125.016 1.527 17.212.092 32.437.571 43.698 1.052 6.26.267 11.3.534 14.779.735.029.002.057.003.086.005 3.46-23.529 7.146-51.326 10.372-83.037l.005-.0498c.176-1.5891-1.149-3.2156-2.776-3.3886-11.793-1.1922-35.083-3.1168-64.734-3.3965z" fill="var(--color-ink)" fill-rule="evenodd"/><path d="m101.001 183.062c19.505 0 36.849.529 49.315 1.058 5.786.246 10.519.491 13.924.684-3.103 22.131-5.933 38.413-7.968 51.05-1.458 9.045-8.779 15.687-17.879 16.173l-4.669.225c-22.573 1.012-45.231 1.024-67.7731-.099l-2.3317-.12c-8.9591-.477-16.199-6.924-17.8145-15.757l-.073-.422c-2.0352-12.637-4.867-28.919-7.9714-51.05 3.4057-.193 8.1386-.438 13.9252-.684 12.4657-.529 29.8098-1.058 49.3155-1.058z" fill="#68abe9"/><path d="m56.6279 193.649c2.9632-.313 5.6326 1.728 6.0947 4.602l.0376.281.2601 2.344c1.2836 11.298 2.3362 16.481 4.1927 23.957.6454 2.598.9475 4.032 1.2977 5.222.0161.055.0326.106.0475.155.8538.102 2.113.162 4.2422.244 11.6052.444 23.1581.591 34.6066.001 3.073-.159 5.693 2.172 5.854 5.206.16 3.033-2.2 5.621-5.272 5.779-11.9181.615-23.8417.456-35.6199.005-2.1972-.084-4.2851-.159-5.9622-.427-1.7844-.284-3.9749-.903-5.7881-2.707-1.6614-1.653-2.3709-3.704-2.807-5.186-.4338-1.474-.8976-3.572-1.4193-5.673-1.9779-7.965-3.1089-13.606-4.441-25.321l-.269-2.427-.0238-.282c-.1652-2.905 2.0059-5.459 4.9692-5.773z" fill="#fff" opacity=".15"/></svg>
+        Fizzy
+      </figure>
+      <header class="error-page__stamp">
+        <div class="error-page__title" data-text="<%= card.closure.reason %>">404</div>
+        <div class="error-page__subtitle">Sorry, that page does‘t exist!</div>
+        <div class="error-page__notes">You may have mistyped the address or the page may have moved</div>
+      </header>
+    </header>
+
+  </body>
+</html>


### PR DESCRIPTION
Removed in 84b8bb0a, but the AR::Tenanted gem uses it.

Can be removed once https://github.com/basecamp/activerecord-tenanted/issues/167 is implemented.