### PR TITLE
Use vanilla CRUD resources for handling notifications

### DIFF
--- a/app/controllers/notifications/bulk_readings_controller.rb
+++ b/app/controllers/notifications/bulk_readings_controller.rb
@@ -1,0 +1,5 @@
+class Notifications::BulkReadingsController < ApplicationController
+  def create
+    Current.user.notifications.unread.read_all
+  end
+end

--- a/app/controllers/notifications/readings_controller.rb
+++ b/app/controllers/notifications/readings_controller.rb
@@ -1,19 +1,11 @@
 class Notifications::ReadingsController < ApplicationController
   def create
-    @notification = Current.user.notifications.find(params[:id])
+    @notification = Current.user.notifications.find(params[:notification_id])
     @notification.read
   end
 
   def destroy
-    @notification = Current.user.notifications.find(params[:id])
+    @notification = Current.user.notifications.find(params[:notification_id])
     @notification.unread
-  end
-
-  def create_all
-    Current.user.notifications.unread.read_all
-    respond_to do |format|
-      format.html { redirect_to notifications_path }
-      format.turbo_stream { } # No action needed, readings will have been broadcast
-    end
   end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -38,7 +38,7 @@ module NotificationsHelper
 
   def notification_toggle_read_button(notification)
     if notification.read?
-      button_to read_notification_path(notification),
+      button_to notification_reading_path(notification),
           method: :delete,
           class: "card__notification-unread-indicator btn btn--circle borderless",
           title: "Mark as unread",
@@ -48,7 +48,7 @@ module NotificationsHelper
         concat(tag.span("Mark as unread", class: "for-screen-reader"))
       end
     else
-      button_to read_notification_path(notification),
+      button_to notification_reading_path(notification),
           class: "card__notification-unread-indicator btn btn--circle borderless",
           title: "Mark as read",
           data: { action: "form#submit:stop badge#update:stop", form_target: "submit" },

--- a/app/views/notifications/_tray.html.erb
+++ b/app/views/notifications/_tray.html.erb
@@ -28,7 +28,7 @@
         <% end %>
       </div>
 
-      <%= button_to read_all_notifications_path,
+      <%= button_to bulk_reading_path,
             class: "btn borderless tray__clear-notifications",
             title: "Mark all notifications as read",
             data: { action: "dialog#close badge#clear", turbo_frame: "notifications" },

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -19,7 +19,7 @@
     <% if @unread.any? %>
       <div class="flex align-center justify-space-between margin-block-start margin-block-end-half">
         <h2 class="txt-medium txt-uppercase txt-alert">New for you</h2>
-        <%= button_to "Mark all as read", read_all_notifications_path, class: "btn txt-small", form: { data: { turbo: false } }, data: { action: "badge#clear" } %>
+        <%= button_to "Mark all as read", bulk_reading_path, class: "btn txt-small", form: { data: { turbo: false } }, data: { action: "badge#clear" } %>
       </div>
     <% else %>
       <div class="notifications-list__empty-message pad border-radius border translucent" style="--border-style: dashed; --border-color: var(--color-ink); --border-radius: 0.2em;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,9 +60,11 @@ Rails.application.routes.draw do
     scope module: :notifications do
       get "tray", to: "trays#show", on: :collection
 
-      post "readings", to: "readings#create_all", on: :collection, as: :read_all
-      post "reading", to: "readings#create", on: :member, as: :read
-      delete "reading", to: "readings#destroy", on: :member
+      collection do
+        resource :bulk_reading, only: :create
+      end
+
+      resource :reading, only: %i[ create destroy ]
     end
   end
 

--- a/test/controllers/notifications/bulk_readings_controller_test.rb
+++ b/test/controllers/notifications/bulk_readings_controller_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class Notifications::BulkReadingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as :kevin
+  end
+
+  test "create" do
+    assert_changes -> { notifications(:logo_published_kevin).reload.read? }, from: false, to: true do
+      assert_changes -> { notifications(:layout_commented_kevin).reload.read? }, from: false, to: true do
+        post bulk_reading_path
+      end
+    end
+  end
+end

--- a/test/controllers/notifications/readings_controller_test.rb
+++ b/test/controllers/notifications/readings_controller_test.rb
@@ -7,7 +7,7 @@ class Notifications::ReadingsControllerTest < ActionDispatch::IntegrationTest
 
   test "create" do
     assert_changes -> { notifications(:logo_published_kevin).reload.read? }, from: false, to: true do
-      post read_notification_path(notifications(:logo_published_kevin), format: :turbo_stream)
+      post notification_reading_path(notifications(:logo_published_kevin), format: :turbo_stream)
       assert_response :success
     end
   end
@@ -17,17 +17,8 @@ class Notifications::ReadingsControllerTest < ActionDispatch::IntegrationTest
     notification.read # Mark as read first
 
     assert_changes -> { notification.reload.read? }, from: true, to: false do
-      delete read_notification_path(notification, format: :turbo_stream)
+      delete notification_reading_path(notification, format: :turbo_stream)
       assert_response :success
-    end
-  end
-
-  test "create all" do
-    assert_changes -> { notifications(:logo_published_kevin).reload.read? }, from: false, to: true do
-      assert_changes -> { notifications(:layout_commented_kevin).reload.read? }, from: false, to: true do
-        post read_all_notifications_path
-        assert_redirected_to notifications_path
-      end
     end
   end
 end


### PR DESCRIPTION
Use resources and crud for handling read/unread notifications.

This creates a separated resource for bulk readings.