### PR TITLE
Tie etag to sessions

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -8,6 +8,8 @@ module Authentication
     before_action :require_authentication
     helper_method :authenticated?
 
+    etag { Current.session.id if authenticated? }
+
     include LoginHelper
   end
 


### PR DESCRIPTION
So that we don't get CSRF token issues if sharing sessions in the same browser

cc @flavorjones 