### PR TITLE
Link to home page instead of browser history

### DIFF
--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -160,6 +160,6 @@
       Fizzy
     </figure>
     <%= yield %>
-    <a href="javascript:window.history.back();">&larr; <span>Go back</span></a>
+    <%= link_to "&larr; Back home".html_safe, root_url %>
   </body>
 </html>


### PR DESCRIPTION
On error pages, it's better to link to the rool url rather than the browser history