### PR TITLE
Ensure settings panels don't expand too much

### DIFF
--- a/app/assets/stylesheets/settings.css
+++ b/app/assets/stylesheets/settings.css
@@ -21,6 +21,7 @@
     flex-direction: column;
     gap: var(--settings-spacer);
     min-block-size: 100%;
+    min-inline-size: 0;
 
     @media (min-width: 960px) {
       --panel-padding: calc(var(--settings-spacer) * 2);


### PR DESCRIPTION
Ensure column size doesn't go hog-wild when children are extra wide