### PR TITLE
Keep card columns from expanding too much

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -56,6 +56,7 @@
     flex-direction: column;
     gap: var(--cards-gap);
     justify-content: start;
+    min-inline-size: 0;
     padding: 0 var(--cards-gap) var(--cards-gap);
     position: relative;
 


### PR DESCRIPTION
Ensure card columns stay the same size even when their children want to be wider