### PR TITLE
Remove the search option from the nav

### DIFF
--- a/app/views/filters/menu/_places.html.erb
+++ b/app/views/filters/menu/_places.html.erb
@@ -3,6 +3,5 @@
   <%= filter_place_menu_item user_path(Current.user), "My Profile", "person" %>
   <%= filter_place_menu_item notifications_path, "Notifications", "bell" %>
   <%= filter_place_menu_item notifications_settings_path, "Notification Settings", "settings" %>
-  <%= filter_place_menu_item search_path, "Search", "search" %>
   <%= filter_place_menu_item workflows_path, "Workflows", "bolt" %>
 <% end %>


### PR DESCRIPTION
The search page isn't meant to be used standalone, so this removes the option from the nav menu.
https://fizzy.37signals.com/5986089/cards/1811