### PR TITLE
Separate auto-close from close events

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -94,6 +94,8 @@ module EventsHelper
       "#{h event_creator_name(event) } unassigned #{ h(event.assignees.include?(Current.user) ? "yourself" : event.assignees.pluck(:name).to_sentence) } from <span style='color: var(--card-color)'>#{h title }</span>".html_safe
     when "card_published"
       "#{h event_creator_name(event) } added <span style='color: var(--card-color)'>#{h title }</span>".html_safe
+    when "card_auto_closed"
+      "<span style='color: var(--card-color)'>#{h title }</span> was auto-closed".html_safe
     when "card_closed"
       "#{h event_creator_name(event) } closed <span style='color: var(--card-color)'>#{h title }</span>".html_safe
     when "card_reopened"

--- a/app/helpers/webhooks_helper.rb
+++ b/app/helpers/webhooks_helper.rb
@@ -1,6 +1,7 @@
 module WebhooksHelper
   ACTION_LABELS = {
     card_assigned: "Card assigned",
+    card_auto_closed: "Card auto-closed",
     card_closed: "Card closed",
     card_collection_changed: "Card collection changed",
     card_due_date_added: "Card due date added",

--- a/app/models/card/closeable.rb
+++ b/app/models/card/closeable.rb
@@ -28,11 +28,11 @@ module Card::Closeable
     closure&.created_at
   end
 
-  def close(user: Current.user, reason: Closure::Reason.default)
+  def close(user: Current.user, reason: Closure::Reason.default, event: :closed)
     unless closed?
       transaction do
         create_closure! user: user, reason: reason
-        track_event :closed, creator: user
+        track_event event, creator: user
       end
     end
   end

--- a/app/models/card/entropic.rb
+++ b/app/models/card/entropic.rb
@@ -32,7 +32,7 @@ module Card::Entropic
   class_methods do
     def auto_close_all_due
       due_to_be_closed.find_each do |card|
-        card.close(user: User.system, reason: "Closed")
+        card.close(user: User.system, reason: "Closed", event: :auto_closed)
       end
     end
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -8,6 +8,7 @@ class Webhook < ApplicationRecord
   PERMITTED_SCHEMES = %w[ http https ].freeze
   PERMITTED_ACTIONS = %w[
     card_assigned
+    card_auto_closed
     card_closed
     card_collection_changed
     card_due_date_added

--- a/test/models/card/entropic_test.rb
+++ b/test/models/card/entropic_test.rb
@@ -53,7 +53,9 @@ class Card::EntropicTest < ActiveSupport::TestCase
     end
 
     assert cards(:logo).reload.closed?
+    assert cards(:logo).events.last.action.card_auto_closed?
     assert_not cards(:shipping).reload.closed?
+    assert_not cards(:shipping).events.last.action.card_auto_closed?
   end
 
   test "auto close all due using entropy configuration defined at the collection level" do


### PR DESCRIPTION
JF asked me to add the ability to trigger webhooks when a card gets auto-closed vs regular closures.

I decided to separate regular close events from auto-close events.
To me, these are separate things, and having them separate makes the implementation for the Webhooks triggers simpler.