### PR TITLE
Fix Stream workflow stage BG

### DIFF
--- a/app/helpers/columns_helper.rb
+++ b/app/helpers/columns_helper.rb
@@ -4,7 +4,7 @@ module ColumnsHelper
       tag.span(column.name, class: "overflow-ellipsis"),
       card_triage_path(card, column_id: column),
       method: :post,
-      class: [ "btn justify-start workflow-stage txt-uppercase", { "workflow-stage--current": column == card.column } ],
+      class: [ "workflow-stage btn", { "workflow-stage--current": column == card.column } ],
       form_class: "flex align-center gap-half",
       data: { turbo_frame: "_top" }
   end

--- a/app/views/cards/triage/_columns.html.erb
+++ b/app/views/cards/triage/_columns.html.erb
@@ -1,10 +1,10 @@
   <div id="<%= dom_id(card, :stages) %>" class="card__stages">
     <%= button_to "Not now", card_not_now_path(card),
-        class: [ "btn justify-start workflow-stage txt-uppercase", { "workflow-stage--current": card.postponed? } ],
+        class: [ "workflow-stage btn", { "workflow-stage--current": card.postponed? } ],
         form_class: "flex align-center gap-half" %>
 
     <%= button_to "The Stream", card_triage_path(card), method: :delete,
-        class: [ "btn justify-start workflow-stage txt-uppercase", { "workflow-stage--current": card.awaiting_triage? } ],
+        class: [ "workflow-stage workflow-stage--stream btn", { "workflow-stage--current": card.awaiting_triage? } ],
         form_class: "flex align-center gap-half" %>
 
     <% card.collection.columns.each do |column| %>
@@ -12,6 +12,6 @@
     <% end %>
 
     <%= button_to "Closed", card_closure_path(card, reason: "Completed"),
-        class: [ "btn justify-start workflow-stage txt-uppercase", { "workflow-stage--current": card.closed? } ],
+        class: [ "workflow-stage btn", { "workflow-stage--current": card.closed? } ],
         form_class: "flex align-center gap-half" %>
   </div>


### PR DESCRIPTION
Adds the fun background back to the Stream workflow stage button. A class simply got dropped somewhere in the recent column refactor.

|Before|After|
|--|--|
|<img width="296" height="278" alt="CleanShot 2025-09-29 at 11 52 26@2x" src="https://github.com/user-attachments/assets/a7f78592-0970-4274-89d3-297404d89e8c" />|<img width="294" height="276" alt="CleanShot 2025-09-29 at 11 52 14@2x" src="https://github.com/user-attachments/assets/a3cff825-e980-4dd1-a6f0-416ddfa13d72" />|