### PR TITLE
Reverse involvement buttons if watching

### DIFF
--- a/app/helpers/accesses_helper.rb
+++ b/app/helpers/accesses_helper.rb
@@ -50,7 +50,7 @@ module AccessesHelper
       collection_involvement_path(collection),
       method: :put,
       aria: { labelledby: involvement_label_id },
-      class: "btn",
+      class: class_names("btn", { "btn--reversed": access.involvement == "watching" }),
       params: { show_watchers: show_watchers, involvement: next_involvement(access.involvement), icon_only: icon_only }
     ) do
       safe_join([


### PR DESCRIPTION
If you're watching a collection, reverse the button. Makes it easier to scan and see what's up.
<img width="517" height="123" alt="CleanShot 2025-10-02 at 14 32 02@2x" src="https://github.com/user-attachments/assets/c86ae158-48f3-47e9-9acf-9ee79ef4319b" />
