### PR TITLE
Use hide avatars from tabindex on preview

### DIFF
--- a/app/views/cards/display/_preview.html.erb
+++ b/app/views/cards/display/_preview.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <footer class="card__footer">
-    <%= render "cards/display/preview/meta", card: card %>
+    <%= render "cards/display/preview/meta", card: card, preview: true %>
     <%= render "cards/display/common/background", card: card %>
   </footer>
 


### PR DESCRIPTION
Prevents card avatar links from sitting in the tabindex on the collection page. We actually had plumbing for this already, but were missing a local assign.