### PR TITLE
Only reverse Watching button if icon_only

### DIFF
--- a/app/helpers/accesses_helper.rb
+++ b/app/helpers/accesses_helper.rb
@@ -50,7 +50,7 @@ module AccessesHelper
       collection_involvement_path(collection),
       method: :put,
       aria: { labelledby: involvement_label_id },
-      class: class_names("btn", { "btn--reversed": access.involvement == "watching" }),
+      class: class_names("btn", { "btn--reversed": access.involvement == "watching" && icon_only }),
       params: { show_watchers: show_watchers, involvement: next_involvement(access.involvement), icon_only: icon_only }
     ) do
       safe_join([


### PR DESCRIPTION
Only reverse the involvement toggle if it's `icon_only`

|Before|After|
|--|--|
|<img width="876" height="360" alt="CleanShot 2025-10-02 at 16 11 00@2x" src="https://github.com/user-attachments/assets/b355d40c-07fb-4e86-b9b7-b51b6b58a7c6" />|<img width="878" height="362" alt="CleanShot 2025-10-02 at 16 11 36@2x" src="https://github.com/user-attachments/assets/d3d73c9c-347e-47f2-b653-c5aa67e0a70b" />|
|<img width="934" height="222" alt="CleanShot 2025-10-02 at 16 12 04@2x" src="https://github.com/user-attachments/assets/516203d7-e601-4616-911c-99bf2aeb360e" />|<img width="934" height="222" alt="CleanShot 2025-10-02 at 16 12 04@2x" src="https://github.com/user-attachments/assets/d6462ac6-9a40-497f-a383-4f4594012aab" />|