### PR TITLE
Remove overflow from columns

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -73,10 +73,6 @@
       z-index: 3;
     }
 
-    &:not(.cards--considering, .is-collapsed, .cards--grid) {
-      overflow: clip;
-    }
-
     &.is-collapsed {
       border-radius: calc(var(--column-width-collapsed) / 2);
       flex: 0 0 var(--column-width-collapsed);


### PR DESCRIPTION
Removes the overflow from columns. Originally added to improve expand/collapse transitions, but it causes more problems than it solves. The transitions are fine as-is, so I might try to find a different moethod for improving those if time allows.