### PR TITLE
dependabot: make the schedule weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,9 @@ updates:
       development-dependencies:
         dependency-type: "development"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
Daily is very noisy when we're using so many git branches.