### PR TITLE
Use button instead of header for expander

### DIFF
--- a/app/views/collections/show/_column.html.erb
+++ b/app/views/collections/show/_column.html.erb
@@ -11,7 +11,7 @@
     <%= render "collections/show/menu/column", column: column %>
   <% end %>
 
-  <%= link_to collection_column_path(column.collection, column), class: "btn btn--circle txt-x-small borderless cards__expander-button", data: { turbo_frame: "_top" } do %>
+  <%= link_to collection_column_path(column.collection, column), class: "cards__expander-button btn btn--circle txt-x-small borderless", data: { turbo_frame: "_top" } do %>
     <%= icon_tag "expand", class: "translucent" %>
     <span class="for-screen-reader">Expand column</span>
   <% end %>

--- a/app/views/collections/show/_expander.html.erb
+++ b/app/views/collections/show/_expander.html.erb
@@ -1,6 +1,6 @@
-<header class="cards__expander" data-collapsible-columns-target="button" data-action="click->collapsible-columns#toggle"
-  style="--card-count: <%= [ count, 20 ].min %>" role="button" aria-controls="<%= column_id %>" aria-expanded="false">
+<button class="cards__expander btn btn--plain" data-collapsible-columns-target="button" data-action="click->collapsible-columns#toggle"
+  style="--card-count: <%= [ count, 20 ].min %>" aria-controls="<%= column_id %>" aria-expanded="false">
   <span class="cards__expander-count" data-drag-and-drop-counter="true"><%= count > 99 ? "99+" : count %></span>
   <h2 class="cards__expander-title"><%= title %></h2>
-</header>
+</button>
 <%= yield if block_given? %>

--- a/app/views/collections/show/_stream.html.erb
+++ b/app/views/collections/show/_stream.html.erb
@@ -12,6 +12,7 @@
         <span class="for-screen-reader">Expand column</span>
       <% end %>
     </header>
+
     <%= render "columns/show/add_card_button", collection: collection %>
 
     <% if page.used? %>


### PR DESCRIPTION
Use a button instead of a header element since `role="button"` isn't supported on headers.

https://fizzy.37signals.com/5986089/cards/2039