### PR TITLE
test: assert on the redirect in the login helper

### DIFF
--- a/test/test_helpers/session_test_helper.rb
+++ b/test/test_helpers/session_test_helper.rb
@@ -8,6 +8,7 @@ module SessionTestHelper
     user = users(user) unless user.is_a? User
 
     post session_path, params: { email_address: user.email_address, password: "secret123456" }
+    assert_response :redirect
 
     cookie = cookies.get_cookie "session_token"
     assert_not_nil cookie, "Expected session_token cookie to be set after sign in"


### PR DESCRIPTION
which can help diagnose more subtle Rails errors like in https://github.com/basecamp/activerecord-tenanted/issues/210