### PR TITLE
Fix: no syntax highlighting for Lexxy code in production

### DIFF
--- a/config/initializers/sanitization.rb
+++ b/config/initializers/sanitization.rb
@@ -3,6 +3,6 @@ Rails.application.config.after_initialize do
   Rails::HTML5::SafeListSanitizer.allowed_attributes.merge(%w[ data-turbo-frame controls type width data-action data-lightbox-target data-lightbox-url-value ])
 
   # ugh, see https://github.com/rails/rails/issues/54478 which I need to fix upstream --mike
-  ActionText::ContentHelper.allowed_tags = Rails::HTML5::SafeListSanitizer.allowed_tags + [ ActionText::Attachment.tag_name, "figure", "figcaption" ]
-  ActionText::ContentHelper.allowed_attributes = Rails::HTML5::SafeListSanitizer.allowed_attributes + ActionText::Attachment::ATTRIBUTES
+  ActionText::ContentHelper.allowed_tags = Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + [ ActionText::Attachment.tag_name, "figure", "figcaption" ] + ActionText::ContentHelper.allowed_tags.to_a
+  ActionText::ContentHelper.allowed_attributes = Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + ActionText::Attachment::ATTRIBUTES + ActionText::ContentHelper.allowed_attributes.to_a
 end


### PR DESCRIPTION
https://fizzy.37signals.com/5986089/cards/1573

This was becasue our sanitization initializer was overriding Lexxy's. This only happened in production due to eager loading, since Lexxy initializer runs when action context is loaded.

cc @flavorjones 