### PR TITLE
Fix: anchor links to comments not working

### DIFF
--- a/app/views/cards/comments/_comment.html.erb
+++ b/app/views/cards/comments/_comment.html.erb
@@ -1,7 +1,7 @@
 <% cache comment do %>
-  <%= turbo_frame_tag comment do %>
+  <%= turbo_frame_tag comment, :container do %>
     <%# Bump for CSS changes: 2025-06-30 -%>
-    <div class="comment flex align-start full-width <%= "comment--system" if comment.creator.system? %>" data-creator-id="<%= comment.creator_id %>" data-created-by-current-user-target="creation">
+    <div id="<%= dom_id(comment) %>" class="comment flex align-start full-width <%= "comment--system" if comment.creator.system? %>" data-creator-id="<%= comment.creator_id %>" data-created-by-current-user-target="creation">
       <figure class="comment__avatar flex-item-no-shrink" aria-hidden="true">
         <%= avatar_tag comment.creator, hidden_for_screen_reader: true %>
       </figure>
@@ -13,7 +13,7 @@
               <%= link_to comment.creator.name, comment.creator, class: "txt-ink btn btn--plain fill-transparent", data: { turbo_frame: "_top" } %>
             </strong>
 
-            <%= link_to comment, class: "txt-undecorated txt-ink translucent txt-normal txt-capitalize" do %>
+            <%= link_to comment, class: "txt-undecorated txt-ink translucent txt-normal txt-capitalize", data: { turbo_frame: "_top" } do %>
               <%= local_datetime_tag comment.created_at, style: :agoorweekday %>,
               <%= local_datetime_tag comment.created_at, style: :time %>
             <% end %>

--- a/app/views/cards/comments/edit.html.erb
+++ b/app/views/cards/comments/edit.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag @comment do %>
+<%= turbo_frame_tag @comment, :container do %>
   <div class="comment flex align-start full-width">
     <figure class="comment__avatar flex-item-no-shrink" aria-hidden="true">
       <%= avatar_tag @comment.creator, hidden_for_screen_reader: true %>


### PR DESCRIPTION
The problem was having the turbo frames as targets: their display: contents would make auto-scrolling not working!

https://fizzy.37signals.com/5986089/cards/2190