### PR TITLE
Remove aside and toolbar role from perma actions

### DIFF
--- a/app/views/cards/_container.html.erb
+++ b/app/views/cards/_container.html.erb
@@ -3,10 +3,10 @@
     class="card-perma" style="--card-color: <%= card.color %>;">
     <%= render "cards/container/status", card: card %>
 
-    <aside class="card-perma__actions card-perma__actions--left" role="toolbar">
+    <div class="card-perma__actions card-perma__actions--left">
       <%= render "cards/container/gild", card: card if @card.published? && !@card.closed? %>
       <%= render "cards/container/image", card: card %>
-    </aside>
+    </div>
 
     <div class="card-perma__bg">
       <%= card_article_tag card, class: "card" do %>

--- a/app/views/cards/container/footer/_published.html.erb
+++ b/app/views/cards/container/footer/_published.html.erb
@@ -1,7 +1,7 @@
 <%# FIXME: Let's move this aside outside of the card container section so these frames don't reload/flicker when card is replaced %>
-<aside class="card-perma__actions card-perma__actions--right" role="toolbar">
+<div class="card-perma__actions card-perma__actions--right">
   <%= turbo_frame_tag card, :watch, src: card_watch_path(card), target: "_top", refresh: :morph %>
   <%= turbo_frame_tag card, :pin, src: card_pin_path(card), refresh: :morph %>
-</aside>
+</div>
 
 <%= render "cards/container/closure", card: card %>


### PR DESCRIPTION
Use `<div>` instead of `<aside role="toolbar">` for the perma actions. It looks all nice and semantic, true! But toolbars need to be unified with 3+ items, and asides are for supplemental content—not primary actions.

https://fizzy.37signals.com/5986089/cards/2094