### PR TITLE
Tailscale-aware deploys

### DIFF
--- a/.kamal/hooks/pre-connect
+++ b/.kamal/hooks/pre-connect
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Verify Tailscale connection and SSH authentication before deploying.
+
+on_tailscale() {
+  tailscale status --json 2>/dev/null | jq -e '.Self.Online' >/dev/null 2>&1
+}
+
+# Check Tailscale connection
+if ! on_tailscale; then
+  echo "" >&2
+  echo "You must be connected to Tailscale to deploy." >&2
+  echo "" >&2
+  echo "→ Connect to Tailscale and try again" >&2
+  echo "" >&2
+  exit 1
+fi
+
+# Verify SSH access
+echo "Deploying via Tailscale. Verifying SSH access…" >&2
+
+TEST_HOST="fizzy-app-101"
+
+SSH_OUTPUT=$(ssh -o ConnectTimeout=5 "app@$TEST_HOST" true 2>&1)
+SSH_EXIT=$?
+
+echo "$SSH_OUTPUT" >&2
+
+if echo "$SSH_OUTPUT" | grep -q "Permission denied"; then
+  GITHUB_USER=$(gh api user 2>/dev/null | jq -r '.login // "unknown"')
+  GITHUB_KEYS_URL="https://github.com/${GITHUB_USER}.keys"
+
+  echo "" >&2
+  echo "ERROR: SSH authentication failed" >&2
+  echo "" >&2
+  echo "You must deploy with an SSH key that's on your GitHub account." >&2
+  echo "" >&2
+  echo "→ Verify your public key is at $GITHUB_KEYS_URL" >&2
+  echo "  Add it at https://github.com/settings/keys if not" >&2
+  echo "" >&2
+  echo "Note that SSH keys are pulled from GitHub every 5 minutes, so if you've" >&2
+  echo "just added a new key to GitHub, try again in five." >&2
+  echo "" >&2
+  exit 1
+fi
+
+exit $SSH_EXIT


### PR DESCRIPTION
* If Tailscale isn't running, advise bringing it up
* (No SSH gateway support; may retrofit later when the Docker registry is accessible without Tailscale.)