### PR TITLE
Don't cache the whole stream column

### DIFF
--- a/app/views/collections/show/_stream.html.erb
+++ b/app/views/collections/show/_stream.html.erb
@@ -1,27 +1,24 @@
-<% cache [ collection, page.records ] do %>
-  <section id="the-stream" class="cards cards--considering"
-    data-drag-and-drop-target="container"
-    data-action="turbo:before-morph-attribute->collapsible-columns#preventToggle"
-    data-drag-and-drop-url="<%= columns_card_drops_stream_path("__id__") %>">
-    <div class="cards__decoration"></div>
+<section id="the-stream" class="cards cards--considering"
+  data-drag-and-drop-target="container"
+  data-action="turbo:before-morph-attribute->collapsible-columns#preventToggle"
+  data-drag-and-drop-url="<%= columns_card_drops_stream_path("__id__") %>">
+  <div class="cards__decoration"></div>
 
-    <header class="cards__expander">
-      <h2 class="cards__expander-title">The Stream</h2>
-      <%= link_to collection_columns_stream_path(collection), class: "btn btn--circle txt-x-small borderless cards__expander-button", data: { turbo_frame: "_top" } do %>
-        <%= icon_tag "expand", class: "translucent" %>
-        <span class="for-screen-reader">Expand column</span>
-      <% end %>
-    </header>
-
-    <%= render "columns/show/add_card_button", collection: collection %>
-
-    <% if page.used? %>
-      <%= with_automatic_pagination "the-stream", @page do %>
-        <%= render "collections/columns/list", cards: page.records, draggable: true %>
-      <% end %>
+  <header class="cards__expander">
+    <h2 class="cards__expander-title">The Stream</h2>
+    <%= link_to collection_columns_stream_path(collection), class: "btn btn--circle txt-x-small borderless cards__expander-button", data: { turbo_frame: "_top" } do %>
+      <%= icon_tag "expand", class: "translucent" %>
+      <span class="for-screen-reader">Expand column</span>
     <% end %>
+  </header>
 
-    <div class="cards__decoration-end"></div>
-  </section>
-<% end %>
+  <%= render "columns/show/add_card_button", collection: collection %>
 
+  <% if page.used? %>
+    <%= with_automatic_pagination "the-stream", @page do %>
+      <%= render "collections/columns/list", cards: page.records, draggable: true %>
+    <% end %>
+  <% end %>
+
+  <div class="cards__decoration-end"></div>
+</section>


### PR DESCRIPTION
It can result in serving the wrong watch button, causing trouble like https://fizzy.37signals.com/5986089/cards/2157

The list of cards is already cached.