### PR TITLE
Mobile columns

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -17,7 +17,6 @@
   }
 
   .card-columns {
-
     container-type: inline-size;
     display: grid;
     gap: var(--column-gap);

--- a/app/views/collections/show/_columns.html.erb
+++ b/app/views/collections/show/_columns.html.erb
@@ -8,37 +8,6 @@
         dragenter->drag-and-strum#dragEnter
         drop->drag-and-drop#drop
         dragend->drag-and-drop#dragEnd" } do %>
-
-  <div hidden class="card-cols">
-    <div class="card-cols__left">
-      <div class="card-col is-collapsed">
-        <div class="crd">Not Now</div>
-      </div>
-    </div>
-
-    <div class="card-col is-expanded">
-      <div class="crd">Stream</div>
-    </div>
-
-    <div class="card-cols__right">
-      <div class="card-col is-expanded">
-        <div class="crd">Card</div>
-      </div>
-      <div class="card-col is-collapsed">
-        <div class="crd">Card</div>
-      </div>
-      <div class="card-col is-collapsed">
-        <div class="crd">Card</div>
-      </div>
-      <div class="card-col is-collapsed">
-        <div class="crd">Done</div>
-      </div>
-    </div>
-  </div>
-
-
-
-
   <div class="card-columns" data-controller="collapsible-columns" data-collapsible-columns-collapsed-class="is-collapsed">
     <div class="card-columns__left">
       <%= render "collections/show/not_now", collection: collection %>


### PR DESCRIPTION
This properly scrolls columns along the x-axis when it doesn't all fit on the screen.

It was rather a trick to figure out how to get scrolling to work on small viewports while still centering content on large viewports. We can't use `justify-content: center` on the column grid container because it keeps you from scrolling to left overflow content. Instead, columns are now `justify-content: start` (which allows scrolling to work properly) and we use `margin-inline: auto` to make sure content sits in the center of the screen.

This is **Step 1** of getting columns to work well on smaller viewports. It handles any case where the column content doesn't fit, regardless of the screen size. **Step 2** will involve more deliberate mobile styles that take place at a mobile breakpoint.


https://github.com/user-attachments/assets/25f3a51a-c934-4d82-98de-4edd1549b4ac