### PR TITLE
Update lexxy to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.1.10.beta)
+    lexxy (0.1.11.beta)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)


### PR DESCRIPTION
https://github.com/basecamp/lexxy/releases/tag/v0.1.11.beta