### PR TITLE
Remove the caching around Identity-related fragments

### DIFF
--- a/app/controllers/my/menus_controller.rb
+++ b/app/controllers/my/menus_controller.rb
@@ -2,6 +2,6 @@ class My::MenusController < ApplicationController
   include FilterScoped
 
   def show
-    fresh_when @user_filtering
+    fresh_when etag: [ @user_filtering, Current.identity_token ]
   end
 end

--- a/app/views/filters/menu/_places.html.erb
+++ b/app/views/filters/menu/_places.html.erb
@@ -3,9 +3,7 @@
   <%= filter_place_menu_item user_path(Current.user), "My Profile", "person" %>
   <%= filter_place_menu_item notifications_path, "Notifications", "bell" %>
   <%= filter_place_menu_item notifications_settings_path, "Notification Settings", "settings" %>
-  <% cache [ Current.user, Current.identity_token ] do %>
-    <% Current.user.identity.memberships.where.not(user_tenant: Current.user.tenant).each do |membership| %>
-      <%= filter_place_menu_item root_url(script_name: "/#{membership.user_tenant}"), "#{membership.account_name}", "logo-color", new_window: true %>
-    <% end %>
+  <% Current.user.identity.memberships.where.not(user_tenant: Current.user.tenant).each do |membership| %>
+    <%= filter_place_menu_item root_url(script_name: "/#{membership.user_tenant}"), "#{membership.account_name}", "logo-color", new_window: true %>
   <% end %>
 <% end %>

--- a/app/views/sessions/login_menu.html.erb
+++ b/app/views/sessions/login_menu.html.erb
@@ -3,21 +3,18 @@
 <div class="panel shadow center margin-block-double" style="--panel-size: 55ch;">
   <h1 class="txt-xx-large margin-block-end-double">Fizzy</h1>
 
-  <% cache [ Current.user, Current.identity_token ] do %>
-    <%# Bump for rollout 2025-10-10 %>
-    <% identity = Identity.find_signed(Current.identity_token.id) %>
-    <% memberships = identity&.memberships %>
-    <% if memberships.present? %>
-      <h2 class="txt-large margin-block-end">Your Fizzy Accounts</h2>
-      <ul class="flex flex-column gap txt-large" style="list-style-type: none; padding: 0;">
-        <% memberships.each do |membership| %>
-          <li>
-            <%= link_to membership.account_name, root_url(script_name: "/#{membership.user_tenant}"), class: "btn btn--reversed center" %>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="txt-large txt-align-center txt-subtle">You don't have any existing Fizzy accounts.</p>
-    <% end %>
+  <% identity = Identity.find_signed(Current.identity_token.id) %>
+  <% memberships = identity&.memberships %>
+  <% if memberships.present? %>
+    <h2 class="txt-large margin-block-end">Your Fizzy Accounts</h2>
+    <ul class="flex flex-column gap txt-large" style="list-style-type: none; padding: 0;">
+      <% memberships.each do |membership| %>
+        <li>
+          <%= link_to membership.account_name, root_url(script_name: "/#{membership.user_tenant}"), class: "btn btn--reversed center" %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="txt-large txt-align-center txt-subtle">You don't have any existing Fizzy accounts.</p>
   <% end %>
 </div>


### PR DESCRIPTION
The Identity table read should be OK given the menu is etagged and the untenanted page should be a rarity.