### PR TITLE
Set Autotuner GC recommendations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,13 @@ USER rails:rails
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
+# Ruby GC tuning values pulled from Autotuner recommendations
+ENV RUBY_GC_HEAP_0_INIT_SLOTS=692636 \
+    RUBY_GC_HEAP_1_INIT_SLOTS=175943 \
+    RUBY_GC_HEAP_2_INIT_SLOTS=148807 \
+    RUBY_GC_HEAP_3_INIT_SLOTS=9169 \
+    RUBY_GC_HEAP_4_INIT_SLOTS=3054
+
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 80 443 9394
 CMD ["./bin/thrust", "./bin/rails", "server"]


### PR DESCRIPTION
From https://basecamp.sentry.io/issues/6937130571/

```
The following suggestions adjust the size of the heap at boot time, which can improve bootup speed and reduce the time taken for the app to reach peak performance.

Suggested tuning values:
  RUBY_GC_HEAP_0_INIT_SLOTS=692636
  RUBY_GC_HEAP_1_INIT_SLOTS=175943
  RUBY_GC_HEAP_2_INIT_SLOTS=148807
  RUBY_GC_HEAP_3_INIT_SLOTS=9169
  RUBY_GC_HEAP_4_INIT_SLOTS=3054

It is always recommended to experiment with these suggestions as some suggestions may not always yield positive performance improvements. The recommended method is to perform A/B testing where a portion of traffic does not have the these suggested values and a portion of traffic with these suggested values.
```