### PR TITLE
Hide column list when creating a new card

### DIFF
--- a/app/views/cards/_container.html.erb
+++ b/app/views/cards/_container.html.erb
@@ -20,7 +20,9 @@
             <%= render "cards/container/title", card: card %>
             <%= render "cards/display/perma/steps", card: card %>
           </div>
-          <%= render "cards/triage/columns", card: card if card.open? %>
+          <% if card.published? %>
+            <%= render "cards/triage/columns", card: card if card.open? %>
+          <% end %>
         </div>
 
         <footer class="card__footer full-width flex align-start gap">


### PR DESCRIPTION
When creating a card, hide the column select list. All cards should start off in The Stream, and it would be weird to create a card and immediately place it in either Not Now or Done.