### PR TITLE
Increase the number of job workers to match CPUs

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,8 +4,8 @@ default: &default
       batch_size: 500
   workers:
     - queues: [ "default", "solid_queue_recurring", "backend", "webhooks" ]
-      threads: 3
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      threads: 1
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", Concurrent.physical_processor_count) %>
       polling_interval: 0.1
 
 development: *default


### PR DESCRIPTION
JOB_CONCURRENCY would still override this number.