### PR TITLE
Make sure the schema and schema cache are consistent with reality

### DIFF
--- a/db/migrate/20251014204033_ensure_consistent_schema.rb
+++ b/db/migrate/20251014204033_ensure_consistent_schema.rb
@@ -1,0 +1,15 @@
+class EnsureConsistentSchema < ActiveRecord::Migration[8.1]
+  # ref: https://fizzy.37signals.com/5986089/cards/2322
+  def change
+    change_column_default :accesses, :involvement, "access_only"
+
+    unless index_exists?(:webhooks, :subscribed_actions)
+      add_index :webhooks, :subscribed_actions
+    end
+
+    if index_exists?(:tags, [ :title ])
+      remove_index :tags, [ :title ]
+    end
+    add_index :tags, [ :title ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_10_07_084223) do
+ActiveRecord::Schema[8.1].define(version: 2025_10_14_204033) do
   create_table "accesses", force: :cascade do |t|
     t.datetime "accessed_at"
     t.integer "collection_id", null: false
     t.datetime "created_at", null: false
-    t.string "involvement", default: "watching", null: false
+    t.string "involvement", default: "access_only", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["accessed_at"], name: "index_accesses_on_accessed_at", order: :desc
@@ -424,6 +424,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_10_07_084223) do
     t.datetime "created_at", null: false
     t.string "title"
     t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_tags_on_title", unique: true
   end
 
   create_table "user_settings", force: :cascade do |t|
@@ -500,6 +501,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_10_07_084223) do
     t.datetime "updated_at", null: false
     t.text "url", null: false
     t.index ["collection_id"], name: "index_webhooks_on_collection_id"
+    t.index ["subscribed_actions"], name: "index_webhooks_on_subscribed_actions"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -76,7 +76,7 @@ columns:
       precision:
       scale:
     'null': false
-    default: watching
+    default: access_only
     default_function:
     collation:
     comment:
@@ -2930,7 +2930,23 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-  tags: []
+  tags:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: tags
+    name: index_tags_on_title
+    unique: true
+    columns:
+    - title
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
   user_settings:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_settings
@@ -3148,4 +3164,20 @@ indexes:
     nulls_not_distinct:
     comment:
     valid: true
-version: 20251007084223
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: webhooks
+    name: index_webhooks_on_subscribed_actions
+    unique: false
+    columns:
+    - subscribed_actions
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+version: 20251014204033

--- a/test/models/notifier/event_notifier_test.rb
+++ b/test/models/notifier/event_notifier_test.rb
@@ -34,14 +34,9 @@ class Notifier::EventNotifierTest < ActiveSupport::TestCase
     assert_equal [ users(:kevin) ], notifications.map(&:user)
   end
 
-  test "the published event creates notifications for subscribers as well as watchers" do
-    collections(:writebook).access_for(users(:jz)).watching!
-    notifications = Notifier.for(events(:logo_published)).notify
-
-    assert_equal users(:kevin, :jz).sort, notifications.map(&:user).sort
-  end
-
   test "links to the card" do
+    collections(:writebook).access_for(users(:kevin)).watching!
+
     Notifier.for(events(:logo_published)).notify
 
     assert_equal cards(:logo), Notification.last.source.eventable


### PR DESCRIPTION
There has been a bit of drift between actual schemas in production and what's implied by the migrations.

And fixed some tests that were relying on everyone always watching.

ref: https://fizzy.37signals.com/5986089/cards/2322