### PR TITLE
Make collection-specific keys for collapsed column state

### DIFF
--- a/app/javascript/controllers/collapsible_columns_controller.js
+++ b/app/javascript/controllers/collapsible_columns_controller.js
@@ -3,6 +3,9 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static classes = [ "collapsed" ]
   static targets = [ "column", "button" ]
+  static values = {
+    collection: String
+  }
 
   connect() {
     this.#restoreColumns()
@@ -71,6 +74,6 @@ export default class extends Controller {
   }
 
   #localStorageKeyFor(column) {
-    return `expand-${column.getAttribute("id")}`
+    return `expand-${this.collectionValue}-${column.getAttribute("id")}`
   }
 }

--- a/app/views/collections/show/_columns.html.erb
+++ b/app/views/collections/show/_columns.html.erb
@@ -8,7 +8,7 @@
         dragenter->drag-and-strum#dragEnter
         drop->drag-and-drop#drop
         dragend->drag-and-drop#dragEnd" } do %>
-  <div class="card-columns" data-controller="collapsible-columns" data-collapsible-columns-collapsed-class="is-collapsed">
+  <div class="card-columns" data-controller="collapsible-columns" data-collapsible-columns-collection-value="<%= collection.id %>" data-collapsible-columns-collapsed-class="is-collapsed">
     <div class="card-columns__left">
       <%= render "collections/show/not_now", collection: collection %>
     </div>

--- a/app/views/public/collections/show/_columns.html.erb
+++ b/app/views/public/collections/show/_columns.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :cards_container do %>
-  <div class="card-columns" data-controller="collapsible-columns" data-collapsible-columns-collapsed-class="is-collapsed">
+  <div class="card-columns" data-controller="collapsible-columns" data-collapsible-columns-collection-value="<%= collection.id %>" data-collapsible-columns-collapsed-class="is-collapsed">
 
     <div class="card-columns__left">
       <%= render "public/collections/show/not_now", collection: collection %>


### PR DESCRIPTION
Before, we were saving columns' collapsed state to localStorage using the column ID. That works well for a single collection, but causes problems when collections have columns with the same ID; it allows for the possibility of too many columns being expanded at the same time.

To fix this, we just need to add the collection ID to the key saved to localStorage; that way each key is unique.