### PR TITLE
Footer height takes safe area into account

### DIFF
--- a/app/assets/stylesheets/bar.css
+++ b/app/assets/stylesheets/bar.css
@@ -3,14 +3,15 @@
     --row-gap: 0.2lh;
 
     background-color: var(--color-terminal-bg);
-    block-size: var(--footer-height);
+    block-size: calc(var(--footer-height) + env(safe-area-inset-bottom));
     color: var(--color-terminal-text);
     display: flex;
     flex-direction: column;
     font-size: 0.9em;
     inset: auto 0 0 0;
     max-block-size: 100%;
-    padding: var(--block-space) calc(var(--tray-size) + calc(var(--inline-space) * 3)) calc(var(--block-space) + env(safe-area-inset-bottom));
+    padding-block: var(--block-space) calc(var(--block-space) + env(safe-area-inset-bottom));
+    padding-inline: calc(var(--tray-size) + calc(var(--inline-space) * 3));
     place-content: center;
     position: fixed;
     z-index: var(--z-terminal);


### PR DESCRIPTION
The footer height should take the safe-area into account.

**Note**: I'm not sure how to clear the cache of a mobile PWA. Hopefully the CSS will be fingerprinted or something so the updated styles will pop in without needing any extra work.

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-10-15 at 16 09 46" src="https://github.com/user-attachments/assets/0daa134a-c02c-473d-a3a9-8a62268ed2cf" />
