### PR TITLE
Check for empty values before submitting

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { debounce, nextFrame } from "helpers/timing_helpers";
 
 export default class extends Controller {
-  static targets = [ "cancel", "submit" ]
+  static targets = [ "cancel", "submit", "input" ]
 
   static values = {
     debounceTimeout: { type: Number, default: 300 }
@@ -14,6 +14,17 @@ export default class extends Controller {
 
   submit() {
     this.element.requestSubmit()
+  }
+
+  preventEmptySubmit(event) {
+    const input = this.hasInputTarget ? this.inputTarget : null
+
+    if (input) {
+      const value = (input.value || "").trim()  
+      if (value.length === 0) {
+        event.preventDefault()
+      }
+    }
   }
 
   debouncedSubmit(event) {

--- a/app/views/cards/display/perma/_steps.html.erb
+++ b/app/views/cards/display/perma/_steps.html.erb
@@ -3,8 +3,8 @@
 
   <li class="step">
     <input type="checkbox" class="step__checkbox" disabled>
-    <%= form_with model: [card, Step.new], url: card_steps_path(card) do |form| %>
-      <%= form.text_field :content, class: "input step__content hide-focus-ring", placeholder: "Add a step…", required: true, autocomplete: "off" %>
+    <%= form_with model: [card, Step.new], url: card_steps_path(card), data: { controller: "form", action: "submit->form#preventEmptySubmit" } do |form| %>
+      <%= form.text_field :content, class: "input step__content hide-focus-ring", placeholder: "Add a step…", autocomplete: "off", data: { form_target: "input" } %>
     <% end %>
   </li>
 </ol>


### PR DESCRIPTION
The `required` attribute on steps isn't really what we want, because it's not required that you add steps. Instead, we just want to make sure you can't submit empty steps.

Here, I simply added a `preventEmptySubmit` method that checks the input value and prevents submission if it's blank.