### PR TITLE
Fix crash during migrations audit

### DIFF
--- a/bin/migration-audit
+++ b/bin/migration-audit
@@ -62,12 +62,15 @@ echo
 
 step "Deleting schema files" rm -f db/schema.rb db/schema_cache.yml
 
-step "Deleting tenant directory" rm -rf storage/tenants/development/175932900
+temporary_tenant="9999999999"
+step "Creating temporary tenant" bash -c "bin/rails runner \"ApplicationRecord.create_tenant(\"$temporary_tenant\")\""
+
+step "Deleting tenant directory" rm -rf storage/tenants/development/$temporary_tenant
 
 step --spin "Migrating..." "Regenerating schema files" bin/rails db:migrate
 
 # Check if the schema files have any git changes
-if git diff --quiet db/schema.rb db/schema_cache.yml; then
+if git diff --quiet -- db/schema.rb db/schema_cache.yml; then
   gum style --foreground 46 "✓ Schema files are in sync with migrations"
   exit 0
 else


### PR DESCRIPTION
I've ran into an issue where this audit always fails.

```
Database: Check migrations
bin/migration-audit


Migration or schema files changed:
db/migrate/20251015081645_create_account_join_codes.rb
db/schema.rb
db/schema_cache.yml

▸ Deleting schema files
rm -f db/schema.rb db/schema_cache.yml

▸ Deleting tenant directory
rm -rf storage/tenants/development/175932900

▸ Regenerating schema files
bin/rails db:migrate

fatal: ambiguous argument 'db/schema.rb': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

✗ Schema files are out of sync with migrations!

Differences:
fatal: ambiguous argument 'db/schema.rb': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

The problem was that I'm missing tenant 175932900, so deleting the dir wouldn't cause migrations to re-run, and would leave me with a missing schema.rb file (because the audit deletes it).
This would then lead to a crash because git diff gets passe a non-existent file.

This PR, switches the logic around such that the schema gets deleted and then a new tenant gets created, this then runs all tenanted migrations. After the migrations run, the new tenant's database gets deleted.