### PR TITLE
Extend public caching to 30 seconds

### DIFF
--- a/app/controllers/concerns/cached_publicly.rb
+++ b/app/controllers/concerns/cached_publicly.rb
@@ -1,0 +1,12 @@
+module CachedPublicly
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_cache_headers
+  end
+
+  private
+    def set_cache_headers
+      expires_in 30.seconds, public: true
+    end
+end

--- a/app/controllers/public/cards_controller.rb
+++ b/app/controllers/public/cards_controller.rb
@@ -1,12 +1,10 @@
 class Public::CardsController < ApplicationController
-  include PublicCardScoped
+  include CachedPublicly, PublicCardScoped
 
   allow_unauthenticated_access only: :show
 
   layout "public"
 
   def show
-    # To enable caching at intermediate proxies during traffic spikes
-    expires_in 5.seconds, public: true
   end
 end

--- a/app/controllers/public/collections/columns/closeds_controller.rb
+++ b/app/controllers/public/collections/columns/closeds_controller.rb
@@ -1,5 +1,5 @@
 class Public::Collections::Columns::ClosedsController < ApplicationController
-  include PublicCollectionScoped
+  include CachedPublicly, PublicCollectionScoped
 
   allow_unauthenticated_access only: :show
 
@@ -7,8 +7,5 @@ class Public::Collections::Columns::ClosedsController < ApplicationController
 
   def show
     set_page_and_extract_portion_from @collection.cards.closed.recently_closed_first
-
-    # To enable caching at intermediate proxies during traffic spikes
-    expires_in 5.seconds, public: true
   end
 end

--- a/app/controllers/public/collections/columns/not_nows_controller.rb
+++ b/app/controllers/public/collections/columns/not_nows_controller.rb
@@ -1,5 +1,5 @@
 class Public::Collections::Columns::NotNowsController < ApplicationController
-  include PublicCollectionScoped
+  include CachedPublicly, PublicCollectionScoped
 
   allow_unauthenticated_access only: :show
 
@@ -7,8 +7,5 @@ class Public::Collections::Columns::NotNowsController < ApplicationController
 
   def show
     set_page_and_extract_portion_from @collection.cards.postponed.reverse_chronologically.with_golden_first
-
-    # To enable caching at intermediate proxies during traffic spikes
-    expires_in 5.seconds, public: true
   end
 end

--- a/app/controllers/public/collections/columns/streams_controller.rb
+++ b/app/controllers/public/collections/columns/streams_controller.rb
@@ -1,5 +1,5 @@
 class Public::Collections::Columns::StreamsController < ApplicationController
-  include PublicCollectionScoped
+  include CachedPublicly, PublicCollectionScoped
 
   allow_unauthenticated_access only: :show
 
@@ -7,8 +7,5 @@ class Public::Collections::Columns::StreamsController < ApplicationController
 
   def show
     set_page_and_extract_portion_from @collection.cards.awaiting_triage.by_last_activity.with_golden_first
-
-    # To enable caching at intermediate proxies during traffic spikes
-    expires_in 5.seconds, public: true
   end
 end

--- a/app/controllers/public/collections/columns_controller.rb
+++ b/app/controllers/public/collections/columns_controller.rb
@@ -1,5 +1,5 @@
 class Public::Collections::ColumnsController < ApplicationController
-  include ActionView::RecordIdentifier, PublicCollectionScoped
+  include ActionView::RecordIdentifier, CachedPublicly, PublicCollectionScoped
 
   allow_unauthenticated_access only: :show
 
@@ -9,9 +9,6 @@ class Public::Collections::ColumnsController < ApplicationController
 
   def show
     set_page_and_extract_portion_from @column.cards.active.by_last_activity.with_golden_first
-
-    # To enable caching at intermediate proxies during traffic spikes
-    expires_in 5.seconds, public: true
   end
 
   private

--- a/app/controllers/public/collections_controller.rb
+++ b/app/controllers/public/collections_controller.rb
@@ -1,5 +1,5 @@
 class Public::CollectionsController < ApplicationController
-  include PublicCollectionScoped
+  include CachedPublicly, PublicCollectionScoped
 
   allow_unauthenticated_access only: :show
 
@@ -7,8 +7,5 @@ class Public::CollectionsController < ApplicationController
 
   def show
     set_page_and_extract_portion_from @collection.cards.awaiting_triage.by_last_activity.with_golden_first
-
-    # To enable caching at intermediate proxies during traffic spikes
-    expires_in 5.seconds, public: true
   end
 end


### PR DESCRIPTION
Up from the previous 5 seconds. It's still short enough that the pages shouldn't feel stale, but it further reduces the number of requests that will reach the app.

Also moved this into a shared concern so we can adjust the caching rule in one place.

/cc @monorkin @flavorjones 