### PR TITLE
Update dark mode highlight color

### DIFF
--- a/app/assets/stylesheets/_global.css
+++ b/app/assets/stylesheets/_global.css
@@ -329,6 +329,7 @@
     --color-terminal-bg: var(--color-canvas);
     --color-terminal-text-light: oklch(var(--lch-green-dark));
     --color-golden: oklch(var(--lch-blue-medium));
+    --color-highlight: oklch(var(--lch-blue-lighter));
 
     --shadow: 0 0 0 1px oklch(var(--lch-black) / 0.42),
               0 .2em 1.6em -0.8em oklch(var(--lch-black) / 0.6),


### PR DESCRIPTION
The highlight color looks brown-ish and not "highlight-y" in dark mode. Now it has a blue tint, which is better.