### PR TITLE
Ensure check icons are targeted properly

### DIFF
--- a/app/assets/stylesheets/filters.css
+++ b/app/assets/stylesheets/filters.css
@@ -133,14 +133,6 @@
   }
 
   .quick-filter {
-    .checked {
-      display: none;
-    }
-
-    [aria-checked="true"] .checked {
-      display: block;
-    }
-
     &:has([aria-checked="true"]):not(.quick-filter--with-default) {
       .input--select {
         --input-background: var(--color-selected);

--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -113,6 +113,14 @@
       }
     }
 
+    .checked {
+      display: none;
+    }
+
+    &[aria-checked="true"] .checked {
+      display: block;
+    }
+
     &[aria-selected] {
       background-color: var(--color-selected);
 
@@ -137,14 +145,6 @@
     max-inline-size: 100%;
     padding: var(--inline-space-half) var(--popup-item-padding-inline);
     text-align: start;
-
-    .icon.current {
-      display: none;
-
-      .popup__item--current & {
-        display: block;
-      }
-    }
   }
 
   .popup__icon {

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -17,11 +17,11 @@ module FiltersHelper
 
   def filter_place_menu_item(path, label, icon, new_window: false, current: false)
     link_to_params = new_window ? { target: "_blank" } : {}
-    tag.li class: [ "popup__item", { "popup__item--current": current } ], id: "filter-place-#{label.parameterize}", data: { filter_target: "item", navigable_list_target: "item" } do
+    tag.li class: "popup__item", id: "filter-place-#{label.parameterize}", data: { filter_target: "item", navigable_list_target: "item" }, aria: { checked: current } do
       concat icon_tag(icon, class: "popup__icon")
       concat(link_to(path, link_to_params.merge(class: "popup__btn btn")) do
         concat tag.span(label, class: "overflow-ellipsis")
-        concat icon_tag("check", class: "current flex-item-justify-end", "aria-hidden": true)
+        concat icon_tag("check", class: "checked flex-item-justify-end", "aria-hidden": true)
       end)
     end
   end


### PR DESCRIPTION
We have a couple different ways of showing ✔︎ icons for `popup__item`. Quick filters use `[aria-selected]`, and the Accounts section in the main nav uses `popup__item--current`. This was causing specificity conflicts.

This PR consolidates this behavior into the popup CSS file. Now all ✔︎ icons are hidden unless the item has the `aria-checked` attribute.