### PR TITLE
Send notification to Dash on deploys

### DIFF
--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -3,6 +3,8 @@
 MESSAGE="$KAMAL_PERFORMER deployed $KAMAL_SERVICE_VERSION to $KAMAL_DESTINATION in $KAMAL_RUNTIME seconds"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+bin/notify_dash_of_deployment "$MESSAGE" $KAMAL_VERSION $KAMAL_PERFORMER $CURRENT_BRANCH $KAMAL_DESTINATION $KAMAL_RUNTIME
+
 if [[ $CURRENT_BRANCH == "main" && $KAMAL_DESTINATION == "production" ]]; then
   gh release create $KAMAL_SERVICE_VERSION --target $KAMAL_VERSION --generate-notes 2> /dev/null || true
 

--- a/.kamal/secrets.beta
+++ b/.kamal/secrets.beta
@@ -1,5 +1,6 @@
-SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Beta/RAILS_MASTER_KEY)
+SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Deployments/DASH_BASIC_AUTH_SECRET Beta/RAILS_MASTER_KEY)
 
 GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
 BASECAMP_REGISTRY_PASSWORD=$(kamal secrets extract BASECAMP_REGISTRY_PASSWORD $SECRETS)
+DASH_BASIC_AUTH_SECRET=$(kamal secrets extract DASH_BASIC_AUTH_SECRET $SECRETS)
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)

--- a/.kamal/secrets.dhh
+++ b/.kamal/secrets.dhh
@@ -1,5 +1,6 @@
-SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Beta/RAILS_MASTER_KEY)
+SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Deployments/DASH_BASIC_AUTH_SECRET Beta/RAILS_MASTER_KEY)
 
 GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
 BASECAMP_REGISTRY_PASSWORD=$(kamal secrets extract BASECAMP_REGISTRY_PASSWORD $SECRETS)
+DASH_BASIC_AUTH_SECRET=$(kamal secrets extract DASH_BASIC_AUTH_SECRET $SECRETS)
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)

--- a/.kamal/secrets.production
+++ b/.kamal/secrets.production
@@ -1,5 +1,6 @@
-SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Production/RAILS_MASTER_KEY)
+SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Deployments/DASH_BASIC_AUTH_SECRET Production/RAILS_MASTER_KEY)
 
 GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
 BASECAMP_REGISTRY_PASSWORD=$(kamal secrets extract BASECAMP_REGISTRY_PASSWORD $SECRETS)
+DASH_BASIC_AUTH_SECRET=$(kamal secrets extract DASH_BASIC_AUTH_SECRET $SECRETS)
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)

--- a/.kamal/secrets.staging
+++ b/.kamal/secrets.staging
@@ -1,5 +1,6 @@
-SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Staging/RAILS_MASTER_KEY)
+SECRETS=$(kamal secrets fetch --adapter 1password --account basecamp --from Deploy/Fizzy Deployments/BASECAMP_REGISTRY_PASSWORD Deployments/DASH_BASIC_AUTH_SECRET Staging/RAILS_MASTER_KEY)
 
 GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
 BASECAMP_REGISTRY_PASSWORD=$(kamal secrets extract BASECAMP_REGISTRY_PASSWORD $SECRETS)
+DASH_BASIC_AUTH_SECRET=$(kamal secrets extract DASH_BASIC_AUTH_SECRET $SECRETS)
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)

--- a/bin/notify_dash_of_deployment
+++ b/bin/notify_dash_of_deployment
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Example usage: bin/notify_dash_of_deployment $MESSAGE $KAMAL_VERSION $KAMAL_PERFORMER $CURRENT_BRANCH $KAMAL_DESTINATION $KAMAL_RUNTIME
+
+if [ -n "$DASH_BASIC_AUTH_SECRET" ]; then
+  jq -n -c --arg message "${1}" \
+    --arg commit "${2}" \
+    --arg author "${3}" \
+    --arg branch "${4}" \
+    --arg env "${5}" \
+    --arg duration "${6}" \
+    '{
+      "application":"boxcar",
+      "rails_env": $env,
+      "branch": $branch,
+      "deployer": $author,
+      "message": $message,
+      "rev": $commit,
+      "duration": $duration
+      }' |
+    curl --user "$DASH_BASIC_AUTH_SECRET" -H "Content-Type: application/json" --data-binary @- \
+      https://dash.37signals.com/deploy
+else
+  echo "WARNING: Dash deploy notification not sent."
+fi


### PR DESCRIPTION
Ref: https://3.basecamp.com/2914079/buckets/21350690/card_tables/cards/9217313577

The Dash notification will in turn report to Grafana which will be viewable on this [dashboard](https://grafana.37signals.com/d/f9fd8e8f-b7d3-466f-9943-fbfd4c597c38/deploys).