### PR TITLE
Orient popovers to bottom edge of viewport

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -30,6 +30,10 @@
       transform: translateX(0);
     }
 
+    &.orient-top {
+      inset-block: auto 0;
+    }
+
     &:has(.popup__footer) {
       --panel-padding: var(--block-space) var(--block-space) 0 var(--block-space);
     }


### PR DESCRIPTION
The popup controller was already correctly applying the `orient-top` class, but we didn't have CSS to reposition anything. This should do the trick.

|Before|After|
|--|--|
|<img width="582" height="894" alt="CleanShot 2025-10-29 at 14 39 04@2x" src="https://github.com/user-attachments/assets/d5fc9695-ea88-4fe8-97ca-d0081a967450" />|<img width="582" height="894" alt="CleanShot 2025-10-29 at 14 39 19@2x" src="https://github.com/user-attachments/assets/209560c1-31f0-43f6-a8aa-ebb6829be6f3" />|