### PR TITLE
Underline event titles

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -101,7 +101,7 @@ module EventsHelper
     end
 
     def event_card_title(card)
-      tag.span card.title, style: "color: var(--card-color)"
+      tag.span card.title, class: "txt-underline"
     end
 
     def event_due_date(event)


### PR DESCRIPTION
Adds underlines to event titles instead of a different color

|Before|After|
|--|--|
|<img width="700" height="780" alt="CleanShot 2025-10-31 at 15 31 27@2x" src="https://github.com/user-attachments/assets/e5caad0f-f630-4cbc-80d1-d1276e835333" />|<img width="700" height="780" alt="CleanShot 2025-10-31 at 15 31 38@2x" src="https://github.com/user-attachments/assets/393ad1be-b3cd-406e-b197-5db2c6987fa3" />|