### PR TITLE
Add hotkey to create a new card

### DIFF
--- a/app/views/columns/show/_add_card_button.html.erb
+++ b/app/views/columns/show/_add_card_button.html.erb
@@ -1,7 +1,7 @@
 <div class="collection-tools card">
-  <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link", form: { data: { turbo_frame: "_top" } }, data: { controller: "hotkey", action: "keydown.a@document->hotkey#click" } do %>
+  <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link", form: { data: { turbo_frame: "_top" } }, data: { controller: "hotkey", action: "keydown.c@document->hotkey#click" } do %>
     <span>Add a card</span>
-    <kbd>A</kbd>
+    <kbd>C</kbd>
   <% end %>
 
   <hr class="separator--horizontal full-width" aria-hidden="true">

--- a/app/views/events/index/_add_card_button.html.erb
+++ b/app/views/events/index/_add_card_button.html.erb
@@ -1,8 +1,8 @@
 <div class="header__actions header__actions--start">
   <% if collection = user_filtering.single_collection_or_first %>
-    <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link btn--circle-mobile", data: { controller: "hotkey", action: "keydown.a@document->hotkey#click" } do %>
+    <%= button_to collection_cards_path(collection), method: :post, class: "btn btn--link btn--circle-mobile", data: { controller: "hotkey", action: "keydown.c@document->hotkey#click" } do %>
       <span>Add a card</span>
-      <kbd>A</kbd>
+      <kbd>C</kbd>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Create a new card with the `C` key. Works on both the home page and collection page.

- `C` feels like a better hotkey than `A` in case we want to create hotkeys for adding other items (boards are the most likely).
- I elected to remove the `+` icon in the button because it feels a bit cluttery to have an icon-y thing on both sides of the text.

<img width="874" height="356" alt="CleanShot 2025-10-31 at 16 03 04@2x" src="https://github.com/user-attachments/assets/381565c8-39ed-4685-aa4a-d8b53a509844" />
