### PR TITLE
Don't broadcast card changes when touching activity spikes

### DIFF
--- a/app/models/card/activity_spike/detector.rb
+++ b/app/models/card/activity_spike/detector.rb
@@ -20,10 +20,12 @@ class Card::ActivitySpike::Detector
     end
 
     def register_activity_spike
-      if card.activity_spike
-        card.activity_spike.touch
-      else
-        card.create_activity_spike!
+      Card.suppressing_turbo_broadcasts do
+        if card.activity_spike
+          card.activity_spike.touch
+        else
+          card.create_activity_spike!
+        end
       end
     end
 


### PR DESCRIPTION
We do this from jobs, so there is no request id to discard the page refresh in the client. We don't want page refreshes in these cases, as those are normally handled via the change that originated this detection, in any case.