### PR TITLE
Disable Turbo prefetch on signup link

### DIFF
--- a/app/views/sessions/menus/show.html.erb
+++ b/app/views/sessions/menus/show.html.erb
@@ -26,7 +26,7 @@
 
     <% if defined?(saas) %>
       <div class="margin-block-start">
-        <%= link_to saas.new_signup_membership_path, class: "btn btn--plain txt-link center txt-small" do %>
+        <%= link_to saas.new_signup_membership_path, class: "btn btn--plain txt-link center txt-small", data: { turbo_prefetch: false } do %>
           <span>Sign up for a new Fizzy account</span>
         <% end %>
       </div>


### PR DESCRIPTION
This is because we have basic auth enabled there, so prefetching will trigger the popup.