### PR TITLE
bin/setup no longer resets when migrations are pending

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -76,10 +76,12 @@ fi
 
 if [[ $* == *--reset* ]]; then
   step "Resetting the database" rails db:reset
-elif needs_seeding; then
-  step "Setting up the database" rails db:reset
 else
   step "Preparing the database" rails db:prepare
+
+  if needs_seeding; then
+    step "Seeding the database" rails db:seed
+  fi
 fi
 
 step "Cleaning up logs and tempfiles" rails log:clear tmp:clear


### PR DESCRIPTION
Previously, `bin/setup` would run `db:reset` if the seed check failed because of pending migrations.