### PR TITLE
Only include active users in Lexxy prompts

### DIFF
--- a/app/controllers/prompts/users_controller.rb
+++ b/app/controllers/prompts/users_controller.rb
@@ -1,6 +1,6 @@
 class Prompts::UsersController < ApplicationController
   def index
-    @users = User.all.alphabetically
+    @users = User.active.alphabetically
 
     if stale? etag: @users
       render layout: false

--- a/app/models/collection/accessible.rb
+++ b/app/models/collection/accessible.rb
@@ -57,7 +57,7 @@ module Collection::Accessible
     end
 
     def grant_access_to_everyone
-      accesses.grant_to(User.all) if all_access_previously_changed?(to: true)
+      accesses.grant_to(User.active) if all_access_previously_changed?(to: true)
     end
 
     def mentions_for_user(user)

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -86,7 +86,7 @@ class CollectionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to edit_collection_path(collection)
     assert collection.reload.all_access?
-    assert_equal User.all, collection.users
+    assert_equal User.active.sort, collection.users.sort
   end
 
   test "destroy" do

--- a/test/models/collection/accessible_test.rb
+++ b/test/models/collection/accessible_test.rb
@@ -18,7 +18,7 @@ class Collection::AccessibleTest < ActiveSupport::TestCase
     collection = Current.set(session: sessions(:david)) do
       Collection.create! name: "New collection", all_access: true
     end
-    assert_equal User.all, collection.users
+    assert_equal User.active.sort, collection.users.sort
   end
 
   test "grants access to everyone after update" do
@@ -28,7 +28,7 @@ class Collection::AccessibleTest < ActiveSupport::TestCase
     assert_equal [ users(:david) ], collection.users
 
     collection.update! all_access: true
-    assert_equal User.all, collection.users.reload
+    assert_equal User.active.sort, collection.users.reload.sort
   end
 
   test "collection watchers" do


### PR DESCRIPTION
Specifically, exclude users that are inactive or with role "system".

ref: https://app.fizzy.do/5986089/cards/2760
ref: https://app.fizzy.do/5986089/cards/2789