### PR TITLE
Use fizzy as app name on deploy notifications

### DIFF
--- a/bin/notify_dash_of_deployment
+++ b/bin/notify_dash_of_deployment
@@ -10,7 +10,7 @@ if [ -n "$DASH_BASIC_AUTH_SECRET" ]; then
     --arg env "${5}" \
     --arg duration "${6}" \
     '{
-      "application":"boxcar",
+      "application":"fizzy",
       "rails_env": $env,
       "branch": $branch,
       "deployer": $author,


### PR DESCRIPTION
Ref: https://3.basecamp.com/2914079/buckets/21350690/card_tables/cards/9217313577

We're moving forward with `fizzy` instead of `boxcar` as the app name.