### PR TITLE
Specify asset path in deployment

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,5 +1,6 @@
 service: fizzy
 image: basecamp/fizzy
+asset_path: /rails/public/assets
 
 servers:
   jobs:


### PR DESCRIPTION
We need this so that app containers can serve old asset versions, to cover the cases where a request for an old asset is a MISS on the CDN.