### PR TITLE
dep: update Rails and AR::Tenanted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/basecamp/activerecord-tenanted
-  revision: aaa4a3473eab400c4c8a6ca05a7207578d3ade53
+  revision: e409f75dc2ea1c3355e98feb22b76b3cc0a01fe0
   specs:
-    activerecord-tenanted (0.5.0)
+    activerecord-tenanted (0.6.0)
       activerecord (>= 8.1.beta)
       railties (>= 8.1.beta)
       zeitwerk
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: d3d17c297a70d3e255a34693a1fb0074712e9930
+  revision: bc41ad696a76a151db56259938dccf64ef87b501
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -537,7 +537,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.1.0)
+    uri (1.1.1)
     useragent (0.16.11)
     vcr (6.3.1)
       base64

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,9 @@ module Fizzy
 
     # use routes for error pages instead of static files
     config.exceptions_app = self.routes
+
+    # include the tenant in query logs
+    config.active_record.query_log_tags_enabled = true
+    config.active_record.query_log_tags = [ :tenant ]
   end
 end


### PR DESCRIPTION
Note that the query logs in this version of AR::Tenanted have changed, to use standard Rails query log tags, which I have enabled.

Note that enabling Rails query log tags disables prepared statements. I don't think turning off prepared statements will impact our performance, but I'll verify that post-deploy (we have dashboards for a reason).