### PR TITLE
Reintroduce a more modest content margin

### DIFF
--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -1,13 +1,13 @@
 @layer components {
   .rich-text-content {
-    --block-margin: 0;
+    --block-margin: 0.5lh;
 
     :where(h1, h2, h3, h4, h5, h6) {
       display: block;
       font-weight: 800;
       letter-spacing: -0.02ch;
       line-height: 1.1;
-      margin-block: var(--block-margin);
+      margin-block: 0 var(--block-margin);
       overflow-wrap: break-word;
       text-wrap: balance;
     }


### PR DESCRIPTION
This reintroduces default margins to rich text content.

I removed the margins in https://github.com/basecamp/fizzy/pull/1380 in an effort to tighten up the content and allow it to work like most other text editors on the web. The problem with this is that it creates a bunch of empty `<p>` tags since you have to hit enter twice to create a space.

This reverts to basically what we had before, although the space has been reduced a bit to group content a bit better (`0.5lh` instead of `1rem`).

|Before (w/o extra newlines)|Before (w/ extra newlines)|After (w/o extra newlines)|
|--|--|--|
|<img width="1736" height="1690" alt="CleanShot 2025-11-05 at 13 20 38@2x" src="https://github.com/user-attachments/assets/d1bb3c70-cdcc-41f0-ad75-7331f8ceb298" />|<img width="1736" height="1690" alt="CleanShot 2025-11-05 at 13 21 11@2x" src="https://github.com/user-attachments/assets/ae104b53-62bf-4552-a759-86fce23da066" />|<img width="1736" height="1690" alt="CleanShot 2025-11-05 at 13 20 13@2x" src="https://github.com/user-attachments/assets/b8c643ed-681a-4337-82fe-9968cc3a9983" />|