### PR TITLE
Improve spacing, color, and click area for dividers

### DIFF
--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -62,14 +62,17 @@
     }
 
     :where(hr) {
+      color: currentColor;
       block-size: 0;
-      border-block-end: 1px solid currentColor;
+      border: none;
+      border-block-end: 2px solid currentColor;
       inline-size: 20%;
-      margin: var(--block-margin) 0;
+      margin: calc(var(--block-margin) * 2) 0;
     }
 
     .horizontal-divider  {
-      margin-inline: 0;
+      margin: var(--block-margin) 0;
+      padding-block: var(--block-margin);
     }
 
     .lexxy-content__strikethrough {


### PR DESCRIPTION
- Make horizontal dividers properly inherit `currentColor`
- Increase click area for horizontal dividers when editing
- Add a bit more space around them

|Before|After|
|--|--|
|<img width="1736" height="416" alt="CleanShot 2025-11-05 at 13 39 45@2x" src="https://github.com/user-attachments/assets/0cc594c8-56c5-4fdd-9fb6-ff41b8bd2622" />|<img width="1736" height="416" alt="CleanShot 2025-11-05 at 13 39 28@2x" src="https://github.com/user-attachments/assets/d4a88243-eb16-4d13-ac7a-b677e18fcd07" />|