### PR TITLE
Always use the creator name for the plain text form

### DIFF
--- a/app/models/event/description.rb
+++ b/app/models/event/description.rb
@@ -14,7 +14,7 @@ class Event::Description
   end
 
   def to_plain_text
-    to_sentence(creator_text, card.title)
+    to_sentence(creator_name, card.title)
   end
 
   private
@@ -37,8 +37,8 @@ class Event::Description
       tag.span card.title, class: "txt-underline"
     end
 
-    def creator_text
-      event.creator == user ? "You" : h(event.creator.name)
+    def creator_name
+      h(event.creator.name)
     end
 
     def card

--- a/test/models/event/description_test.rb
+++ b/test/models/event/description_test.rb
@@ -11,7 +11,7 @@ class Event::DescriptionTest < ActiveSupport::TestCase
   test "generates plain text description for card published event" do
     description = events(:logo_published).description_for(users(:david))
 
-    assert_includes description.to_plain_text, "You added"
+    assert_includes description.to_plain_text, "David added"
     assert_includes description.to_plain_text, "logo"
   end
 
@@ -21,10 +21,10 @@ class Event::DescriptionTest < ActiveSupport::TestCase
     assert_includes description.to_plain_text, "David commented on"
   end
 
-  test "uses 'You' when event creator is the current user" do
+  test "uses always the name even when the event creator is the current user" do
     description = events(:logo_published).description_for(users(:david))
 
-    assert_includes description.to_plain_text, "You added"
+    assert_includes description.to_plain_text, "David added"
   end
 
   test "uses creator name when event creator is not the current user" do

--- a/test/models/webhook/delivery_test.rb
+++ b/test/models/webhook/delivery_test.rb
@@ -219,7 +219,7 @@ class Webhook::DeliveryTest < ActiveSupport::TestCase
     assert_not Webhook::Delivery.exists?(stale_delivery.id)
   end
 
-  test "renders 'You' when event creator is current user" do
+  test "renders the creator name when event creator is current user" do
     webhook = Webhook.create!(
       board: boards(:writebook),
       name: "Basecamp",
@@ -231,7 +231,7 @@ class Webhook::DeliveryTest < ActiveSupport::TestCase
     Current.session = sessions(:david)
 
     request_stub = stub_request(:post, webhook.url)
-      .with { |request| CGI.parse(request.body)["content"].first.include?("You added") }
+      .with { |request| CGI.parse(request.body)["content"].first.include?("David added") }
       .to_return(status: 200)
 
     delivery.deliver


### PR DESCRIPTION
You does not make sense for webhooks