### PR TITLE
Add syntax highlighting to public description

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -498,5 +498,9 @@
       margin-inline: auto;
       text-align: start;
     }
+
+    code {
+      text-align: left;
+    }
   }
 }

--- a/app/views/public/boards/show.html.erb
+++ b/app/views/public/boards/show.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 
 <% if @board.public_description.present? %>
-  <div class="card__board-public-description txt-align-center center margin-block-end">
+  <div class="card__board-public-description rich-text-content txt-align-center center margin-block-end" data-controller="syntax-highlight">
     <%= @board.public_description %>
   </div>
 <% end %>


### PR DESCRIPTION
|Before|After|
|--|--|
|<img width="1628" height="334" alt="CleanShot 2025-11-06 at 13 17 12@2x" src="https://github.com/user-attachments/assets/e6dac2e4-d4e8-481c-ac41-f3a1b0c04877" />|<img width="1628" height="334" alt="CleanShot 2025-11-06 at 13 15 58@2x" src="https://github.com/user-attachments/assets/d0f4ed2b-737e-433a-b716-82010fb28db6" />|