### PR TITLE
Nicer column x-scrolling and hover states

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -3,6 +3,10 @@
   /* ------------------------------------------------------------------------ */
 
   #main:has(.card-columns) {
+    --main-padding: 0;
+  }
+
+  .card-columns {
     --bubble-size: 3.5rem;
     --cards-gap: min(1.2cqi, 1.7rem);
     --column-gap: 8px;
@@ -14,10 +18,7 @@
     --progress-max-cards: 20;
     --progress-max-height: 50dvh;
 
-    padding-inline: var(--column-gap);
-  }
-
-  .card-columns {
+    -ms-overflow-style: none;  /* Hide x-scrollbar on Edge */
     container-type: inline-size;
     display: grid;
     gap: var(--column-gap);
@@ -26,7 +27,14 @@
     max-inline-size: var(--main-width);
     overflow-x: auto;
     overflow-y: hidden;
+    padding-block-end: var(--column-width-collapsed);
     position: relative;
+    scrollbar-width: none; /* Hide x-scrollbar on FF */
+
+    /* Hide x-scrollbar on Chrome/Safari/Opera */
+    &::-webkit-scrollbar {
+      display: none;
+    }
 
     /* When it has something expanded */
     &:has(.card-columns__left .cards:not(.is-collapsed), .card-columns__right .cards:not(.is-collapsed)) {
@@ -51,10 +59,12 @@
 
   .card-columns__left {
     justify-content: end;
+    padding-inline-start: var(--column-gap);
   }
 
   .card-columns__right {
     justify-content: start;
+    padding-inline-end: var(--column-gap);
   }
 
   /* Column


### PR DESCRIPTION
- Remove horizontal scrollbars from the columns
- When scrolling, content now goes right up to the viewport edge instead of the padding edge that was there before (hard to tell from the screencap, but it does look better)
- Add some padding to the bottom of the columns container so the translated columns don't get clipped when dragging.

|Before|After|
|--|--|
|<img width="1298" height="1366" alt="CleanShot 2025-11-06 at 15 52 06@2x" src="https://github.com/user-attachments/assets/3b6bb495-0fc7-4b1b-9e6d-de5c2240709f" />|<img width="1298" height="1366" alt="CleanShot 2025-11-06 at 15 52 29@2x" src="https://github.com/user-attachments/assets/73ddd8a0-33fb-4c4f-bb97-45c26cd7e975" />|
|<img width="1120" height="1282" alt="CleanShot 2025-11-06 at 15 50 08@2x" src="https://github.com/user-attachments/assets/5f889cec-4348-49a6-8713-f6e0aed0db27" />|<img width="1120" height="1282" alt="CleanShot 2025-11-06 at 15 49 29@2x" src="https://github.com/user-attachments/assets/54363024-1e73-4f4a-b22d-9a58dda135b0" />|