### PR TITLE
Use explicit grid-column width for column header

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -237,7 +237,7 @@
     .cards:not(.is-collapsed) & {
       display: grid;
       grid-template-areas: "menu expander maximize";
-      grid-template-columns: auto 1fr auto;
+      grid-template-columns: var(--column-width-collapsed) 1fr var(--column-width-collapsed);
       margin-block-end: calc(0.5 * var(--cards-gap));
     }
   }


### PR DESCRIPTION
If a button doesn't exist, the `auto` width of the grid column will collapse to `0`. To fix this, set an explicit width on the grid-column so header elements get positioned in their appropriate slots regardless of what other content exists.