### PR TITLE
User first name with initial when representing a user in plain text

### DIFF
--- a/app/models/user/attachable.rb
+++ b/app/models/user/attachable.rb
@@ -5,7 +5,7 @@ module User::Attachable
     include ActionText::Attachable
 
     def attachable_plain_text_representation(...)
-      "@#{first_name.downcase}"
+      "@#{first_name_with_last_name_initial.downcase}"
     end
   end
 end

--- a/test/models/concerns/mentions_test.rb
+++ b/test/models/concerns/mentions_test.rb
@@ -8,7 +8,7 @@ class MentionsTest < ActiveSupport::TestCase
   test "don't create mentions when creating or updating drafts" do
     assert_no_difference -> { Mention.count } do
       perform_enqueued_jobs only: Mention::CreateJob do
-        card = boards(:writebook).cards.create title: "Cleanup", description: "Did you finish up with the cleanup, @david?"
+        card = boards(:writebook).cards.create title: "Cleanup", description: "Did you finish up with the cleanup, @davidh?"
         card.update description: "Any thoughts here @jz"
       end
     end
@@ -17,7 +17,7 @@ class MentionsTest < ActiveSupport::TestCase
   test "create mentions from plain text mentions when publishing cards" do
     perform_enqueued_jobs only: Mention::CreateJob do
       card = assert_no_difference -> { Mention.count } do
-        boards(:writebook).cards.create title: "Cleanup", description: "Did you finish up with the cleanup, @david?"
+        boards(:writebook).cards.create title: "Cleanup", description: "Did you finish up with the cleanup, @davidh?"
       end
 
       card = Card.find(card.id)
@@ -45,14 +45,14 @@ class MentionsTest < ActiveSupport::TestCase
 
   test "don't create repeated mentions when updating cards" do
     perform_enqueued_jobs only: Mention::CreateJob do
-      card = boards(:writebook).cards.create title: "Cleanup", description: "Did you finish up with the cleanup, @david?"
+      card = boards(:writebook).cards.create title: "Cleanup", description: "Did you finish up with the cleanup, @davidh?"
 
       assert_difference -> { Mention.count }, +1 do
         card.published!
       end
 
       assert_no_difference -> { Mention.count } do
-        card.update description: "Any thoughts here @david"
+        card.update description: "Any thoughts here @davidh"
       end
 
       assert_difference -> { Mention.count }, +1 do
@@ -66,7 +66,7 @@ class MentionsTest < ActiveSupport::TestCase
       card = boards(:writebook).cards.create title: "Cleanup", description: "Some initial content", status: :published
 
       assert_difference -> { Mention.count }, +1 do
-        card.comments.create!(body: "Great work on this @david!")
+        card.comments.create!(body: "Great work on this @davidh!")
       end
     end
   end
@@ -76,7 +76,7 @@ class MentionsTest < ActiveSupport::TestCase
       card = boards(:writebook).cards.create title: "Cleanup", description: "Some initial content"
 
       assert_no_difference -> { Mention.count } do
-        card.comments.create!(body: "Great work on this @david!")
+        card.comments.create!(body: "Great work on this @davidh!")
       end
     end
   end


### PR DESCRIPTION
Related: [Remove text-matching @mentions?](https://app.fizzy.do/5986089/cards/2874/)

I realized that mentioning me (even in rich text) would end up mentioning both Ops Fernando and me. The reason is that I would get mentioned due to the rich text mention, while he would get mentioned because the comment's plain text uses only the user's first name, so something like: `Good job @fernando` would end up picking him up.

Changing the plain text representation to first name + initial in last name fixed it: `Good job @fernandoo`.