### PR TITLE
Fix: boosts not working

### DIFF
--- a/app/views/my/_menu.html.erb
+++ b/app/views/my/_menu.html.erb
@@ -14,7 +14,8 @@
         navigable_list_focus_on_selection_value: false,
         navigable_list_actionable_items_value: true } do %>
     <%= turbo_frame_tag "my_menu", src: my_menu_path, loading: :lazy, target: "_top" do %>
-      <%= render "my/menus/jump" %>
+      <% # Passing empty block to avoid double-render  %>
+      <%= render("my/menus/jump") { } %>
     <% end %>
   <% end %>
 </nav>


### PR DESCRIPTION
We were rendering a duplicated container hidden in the menu.

Using block_given? to yield in the template was not fixing this.

https://app.fizzy.do/5986089/cards/2901