### PR TITLE
Hide nav dialog when closed

### DIFF
--- a/app/assets/stylesheets/nav.css
+++ b/app/assets/stylesheets/nav.css
@@ -65,7 +65,6 @@
                 0 0.2em 0.2em oklch(var(--lch-blue-medium) / 5%),
                 0 0.4em 0.4em oklch(var(--lch-blue-medium) / 5%),
                 0 0.8em 0.8em oklch(var(--lch-blue-medium) / 5%);
-    display: grid;
     grid-template-rows: auto 1fr auto;
     gap: var(--nav-section-gap);
     overflow: hidden;


### PR DESCRIPTION
Make sure that the dialog is `display: none` when closed.