### PR TITLE
Make the dialog sizing property optional

### DIFF
--- a/app/javascript/controllers/dialog_controller.js
+++ b/app/javascript/controllers/dialog_controller.js
@@ -5,7 +5,8 @@ import { limitHeightToViewport } from "helpers/sizing_helpers"
 export default class extends Controller {
   static targets = [ "dialog" ]
   static values = {
-    modal: { type: Boolean, default: false }
+    modal: { type: Boolean, default: false },
+    sizing: { type: Boolean, default: true }
   }
 
   connect() {
@@ -22,7 +23,7 @@ export default class extends Controller {
       orient(this.dialogTarget)
     }
 
-    limitHeightToViewport(this.dialogTarget, true)
+    limitHeightToViewport(this.dialogTarget, this.sizingValue)
 
     this.#loadLazyFrames()
     this.dialogTarget.setAttribute("aria-hidden", "false")

--- a/app/views/notifications/_tray.html.erb
+++ b/app/views/notifications/_tray.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from Current.user, :notifications %>
 
-<section class="tray tray--notifications" data-controller="dialog badge" data-badge-unread-class="unread" data-action="turbo:render#update">
+<section class="tray tray--notifications" data-controller="dialog badge" data-badge-unread-class="unread" data-action="turbo:render#update" data-dialog-sizing-value="false">
   <dialog class="tray__dialog"
       data-controller="navigable-list"
       data-dialog-target="dialog"


### PR DESCRIPTION
Make the resizing of dialog elements to fit the viewport optional. This lets us disable it in cases where we have specific CSS in place to handle dialog sizing (like the notifications tray).

|Before|After|
|--|--|
|<img width="998" height="888" alt="CleanShot 2025-11-12 at 11 34 29@2x" src="https://github.com/user-attachments/assets/dcf5aefa-f20e-4cf4-ac85-5bd2a854d2d8" />|<img width="998" height="888" alt="CleanShot 2025-11-12 at 11 44 45@2x" src="https://github.com/user-attachments/assets/370d3072-f89a-43e3-bcd8-a576cbeb5f24" />|