### PR TITLE
Clean up some spots where "current account" is ambiguous

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -10,6 +10,7 @@ module ApplicationCable
       def set_current_user
         if session = find_session_by_cookie
           account = Account.find_by(external_account_id: request.env["fizzy.external_account_id"])
+          Current.account = account
           self.current_user = session.identity.users.find_by!(account: account) if account
         end
       end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -12,11 +12,19 @@ class Current < ActiveSupport::CurrentAttributes
     end
   end
 
-  def account=(value)
-    super(value)
+  def with_account(value)
+    @old_account = self.account
+    self.account = value
+    yield
+  ensure
+    self.account = @old_account
+  end
 
-    if value.present? && identity.present?
-      self.user = identity.users.find_by(account: value)
-    end
+  def without_account
+    @old_account = self.account
+    self.account = nil
+    yield
+  ensure
+    self.account = @old_account
   end
 end

--- a/config/initializers/tenanting/account_slug.rb
+++ b/config/initializers/tenanting/account_slug.rb
@@ -24,10 +24,18 @@ module AccountSlug
 
         # Stash the account's Queenbee ID.
         env["fizzy.external_account_id"] = AccountSlug.decode($2)
-        Current.account = Account.find_by(external_account_id: env["fizzy.external_account_id"])
       end
 
-      @app.call env
+      if env["fizzy.external_account_id"]
+        account = Account.find_by(external_account_id: env["fizzy.external_account_id"])
+        Current.with_account(account) do
+          @app.call env
+        end
+      else
+        Current.without_account do
+          @app.call env
+        end
+      end
     end
   end
 

--- a/gems/fizzy-saas/app/models/signup/account_name_generator.rb
+++ b/gems/fizzy-saas/app/models/signup/account_name_generator.rb
@@ -24,11 +24,13 @@ class Signup::AccountNameGenerator
     end
 
     def existing_indices
-      identity.accounts.filter_map do |account|
-        if account.name.match?(first_account_name_regex)
-          1
-        elsif match = account.name.match(nth_account_name_regex)
-          match[1].to_i
+      Current.without_account do
+        identity.accounts.filter_map do |account|
+          if account.name.match?(first_account_name_regex)
+            1
+          elsif match = account.name.match(nth_account_name_regex)
+            match[1].to_i
+          end
         end
       end
     end

--- a/gems/fizzy-saas/test/models/signup/account_name_generator_test.rb
+++ b/gems/fizzy-saas/test/models/signup/account_name_generator_test.rb
@@ -12,29 +12,37 @@ class Signup::AccountNameGeneratorTest < ActiveSupport::TestCase
     assert_equal "Newart's Fizzy", account_name, "The 1st account doesn't have 1st in the name"
 
     first_account = Account.create!(external_account_id: "1st", name: account_name)
-    @identity.users.create!(account: first_account, name: @name)
-    @identity.reload
+    Current.without_account do
+      @identity.users.create!(account: first_account, name: @name)
+      @identity.reload
+    end
 
     account_name = @generator.generate
     assert_equal "Newart's 2nd Fizzy", account_name
 
     second_account = Account.create!(external_account_id: "2nd", name: account_name)
-    @identity.users.create!(account: second_account, name: @name)
-    @identity.reload
+    Current.without_account do
+      @identity.users.create!(account: second_account, name: @name)
+      @identity.reload
+    end
 
     account_name = @generator.generate
     assert_equal "Newart's 3rd Fizzy", account_name
 
     third_account = Account.create!(external_account_id: "3rd", name: account_name)
-    @identity.users.create!(account: third_account, name: @name)
-    @identity.reload
+    Current.without_account do
+      @identity.users.create!(account: third_account, name: @name)
+      @identity.reload
+    end
 
     account_name = @generator.generate
     assert_equal "Newart's 4th Fizzy", account_name
 
     fourth_account = Account.create!(external_account_id: "4th", name: account_name)
-    @identity.users.create!(account: fourth_account, name: @name)
-    @identity.reload
+    Current.without_account do
+      @identity.users.create!(account: fourth_account, name: @name)
+      @identity.reload
+    end
 
     account_name = @generator.generate
     assert_equal "Newart's 5th Fizzy", account_name
@@ -42,8 +50,10 @@ class Signup::AccountNameGeneratorTest < ActiveSupport::TestCase
 
   test "generate continues from the previous highest index" do
     account = Account.create!(external_account_id: "12th", name: "Newart's 12th Fizzy")
-    @identity.users.create!(account: account, name: @name)
-    @identity.reload
+    Current.without_account do
+      @identity.users.create!(account: account, name: @name)
+      @identity.reload
+    end
 
     account_name = @generator.generate
     assert_equal "Newart's 13th Fizzy", account_name

--- a/gems/fizzy-saas/test/models/signup_test.rb
+++ b/gems/fizzy-saas/test/models/signup_test.rb
@@ -30,23 +30,24 @@ class SignupTest < ActiveSupport::TestCase
 
   test "#complete" do
     Account.any_instance.expects(:setup_customer_template).once
+    Current.without_account do
+      signup = Signup.new(
+        full_name: "Kevin",
+        identity: identities(:kevin)
+      )
 
-    signup = Signup.new(
-      full_name: "Kevin",
-      identity: identities(:kevin)
-    )
+      assert signup.complete
 
-    assert signup.complete
+      assert signup.account
+      assert signup.user
+      assert_equal "Kevin", signup.user.name
 
-    assert signup.account
-    assert signup.user
-    assert_equal "Kevin", signup.user.name
-
-    signup_invalid = Signup.new(
-      full_name: "",
-      identity: identities(:kevin)
-    )
-    assert_not signup_invalid.complete
-    assert_not_empty signup_invalid.errors[:full_name]
+      signup_invalid = Signup.new(
+        full_name: "",
+        identity: identities(:kevin)
+      )
+      assert_not signup_invalid.complete
+      assert_not_empty signup_invalid.errors[:full_name]
+    end
   end
 end

--- a/test/controllers/sessions/menus_controller_test.rb
+++ b/test/controllers/sessions/menus_controller_test.rb
@@ -18,9 +18,12 @@ class Sessions::MenusControllerTest < ActionDispatch::IntegrationTest
 
   test "show with exactly one account" do
     sign_in_as @identity
-    @identity.users.delete_all
-    account = Account.create!(external_account_id: 9999991, name: "Test Account")
-    @identity.users.create!(account: account, name: "Kevin")
+
+    Current.without_account do
+      @identity.users.delete_all
+      account = Account.create!(external_account_id: 9999991, name: "Test Account")
+      @identity.users.create!(account: account, name: "Kevin")
+    end
 
     untenanted do
       get session_menu_url

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -13,31 +13,34 @@ class AccountTest < ActiveSupport::TestCase
   end
 
   test ".create_with_admin_user creates a new local account" do
-    identity = identities(:david)
-    account = nil
+    Current.without_account do
+      identity = identities(:david)
+      account = nil
 
-    assert_changes -> { Account.count }, +1 do
-      assert_changes -> { User.count }, +2 do
-        account = Account.create_with_admin_user(
-          account: {
-            external_account_id: ActiveRecord::FixtureSet.identify("account-create-with-admin-user-test"),
-            name: "Account Create With Admin"
-          },
-          owner: {
-            name: "David",
-            identity: identity
-          }
-        )
+      assert_changes -> { Account.count }, +1 do
+        assert_changes -> { User.count }, +2 do
+          account = Account.create_with_admin_user(
+            account: {
+              external_account_id: ActiveRecord::FixtureSet.identify("account-create-with-admin-user-test"),
+              name: "Account Create With Admin"
+            },
+            owner: {
+              name: "David",
+              identity: identity
+            }
+          )
+        end
       end
-    end
-    assert_not_nil account
-    assert account.persisted?
-    assert_equal ActiveRecord::FixtureSet.identify("account-create-with-admin-user-test"), account.external_account_id
-    assert_equal "Account Create With Admin", account.name
 
-    admin = account.users.find_by(role: "admin")
-    assert_equal "David", admin.name
-    assert_equal "david@37signals.com", admin.identity.email_address
-    assert_equal "admin", admin.role
+      assert_not_nil account
+      assert account.persisted?
+      assert_equal ActiveRecord::FixtureSet.identify("account-create-with-admin-user-test"), account.external_account_id
+      assert_equal "Account Create With Admin", account.name
+
+      admin = account.users.find_by(role: "admin")
+      assert_equal "David", admin.name
+      assert_equal "david@37signals.com", admin.identity.email_address
+      assert_equal "admin", admin.role
+    end
   end
 end

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -23,14 +23,16 @@ class IdentityTest < ActiveSupport::TestCase
     identity = identities(:david)
     account = accounts(:initech)
 
-    assert_difference "User.count", 1 do
-      identity.join(account)
+    Current.without_account do
+      assert_difference "User.count", 1 do
+        identity.join(account)
+      end
+
+      user = account.users.find_by!(identity: identity)
+
+      assert_not_nil user
+      assert_equal identity, user.identity
+      assert_equal identity.email_address, user.name
     end
-
-    user = account.users.find_by!(identity: identity)
-
-    assert_not_nil user
-    assert_equal identity, user.identity
-    assert_equal identity.email_address, user.name
   end
 end

--- a/test/test_helpers/search_test_helper.rb
+++ b/test/test_helpers/search_test_helper.rb
@@ -14,10 +14,10 @@ module SearchTestHelper
     Identity.find_by(email_address: "test@example.com")&.destroy
 
     @account = Account.create!(name: "Search Test", external_account_id: ActiveRecord::FixtureSet.identify("search_test"))
+    Current.account = @account
     @identity = Identity.create!(email_address: "test@example.com")
     @user = User.create!(name: "Test User", account: @account, identity: @identity)
     @board = Board.create!(name: "Test Board", account: @account, creator: @user)
-    Current.account = @account
   end
 
   def teardown_search_test

--- a/test/test_helpers/session_test_helper.rb
+++ b/test/test_helpers/session_test_helper.rb
@@ -41,10 +41,13 @@ module SessionTestHelper
 
   def with_current_user(user)
     user = users(user) unless user.is_a? User
-    Current.session = Session.new(identity: user.identity)
-    yield
-  ensure
-    Current.clear_all
+    @old_session = Current.session
+    begin
+      Current.session = Session.new(identity: user.identity)
+      yield
+    ensure
+      Current.session = @old_session
+    end
   end
 
   def untenanted(&block)


### PR DESCRIPTION
Primarily this is in tests (which were caught by temporarily introducing acts_as_tenant and enabling safety checks), but notably action cable connections were not working properly, and that's now fixed.