### PR TITLE
Use card number as ID when dragging

### DIFF
--- a/app/views/cards/display/_preview.html.erb
+++ b/app/views/cards/display/_preview.html.erb
@@ -1,6 +1,6 @@
 <% draggable = local_assigns.fetch(:draggable, false) && card.published? %>
 
-<%= card_article_tag card, class: "card", draggable: draggable, data: { id: card.id, drag_and_drop_target: "item" } do %>
+<%= card_article_tag card, class: "card", draggable: draggable, data: { id: card.number, drag_and_drop_target: "item" } do %>
   <div class="flex flex-column flex-item-grow max-inline-size">
     <header class="card__header">
       <%= render "cards/display/preview/board", card: card %>


### PR DESCRIPTION
Because the endpoints are `CardScoped` by number, we should also use the number here for consistency.