### PR TITLE
Move AccountSlug::Extractor later in the stack for reloading in development

### DIFF
--- a/config/initializers/tenanting/account_slug.rb
+++ b/config/initializers/tenanting/account_slug.rb
@@ -44,5 +44,5 @@ module AccountSlug
 end
 
 Rails.application.config.middleware.tap do |stack|
-  stack.insert_before Rails::Rack::Logger, AccountSlug::Extractor
+  stack.insert_before ActiveRecord::Middleware::DatabaseSelector, AccountSlug::Extractor
 end


### PR DESCRIPTION
so that in development, it runs after reloading; but still before the database selector middleware in case we ever want to do something account-specific.

ref: https://app.fizzy.do/5986089/cards/3017