### PR TITLE
Stalled cards are unstalled by anything that touches updated_at

### DIFF
--- a/app/models/card/entropic.rb
+++ b/app/models/card/entropic.rb
@@ -7,16 +7,17 @@ module Card::Entropic
         .joins(board: :account)
         .left_outer_joins(board: :entropy)
         .joins("LEFT OUTER JOIN entropies AS account_entropies ON account_entropies.account_id = accounts.id AND account_entropies.container_type = 'Account' AND account_entropies.container_id = accounts.id")
-        .where("last_active_at <= DATE_SUB(NOW(), INTERVAL COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) SECOND)")
+        .where("last_active_at <= DATE_SUB(?, INTERVAL COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) SECOND)", Time.now)
     end
 
     scope :postponing_soon, -> do
+      now = Time.now
       active
         .joins(board: :account)
         .left_outer_joins(board: :entropy)
         .joins("LEFT OUTER JOIN entropies AS account_entropies ON account_entropies.account_id = accounts.id AND account_entropies.container_type = 'Account' AND account_entropies.container_id = accounts.id")
-        .where("last_active_at >  DATE_SUB(NOW(), INTERVAL COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) SECOND)")
-        .where("last_active_at <= DATE_SUB(NOW(), INTERVAL CAST(COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) * 0.75 AS SIGNED) SECOND)")
+        .where("last_active_at >  DATE_SUB(?, INTERVAL COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) SECOND)", now)
+        .where("last_active_at <= DATE_SUB(?, INTERVAL CAST(COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) * 0.75 AS SIGNED) SECOND)", now)
     end
 
     delegate :auto_postpone_period, to: :board

--- a/app/models/card/stallable.rb
+++ b/app/models/card/stallable.rb
@@ -7,14 +7,16 @@ module Card::Stallable
     has_one :activity_spike, class_name: "Card::ActivitySpike", dependent: :destroy
 
     scope :with_activity_spikes, -> { joins(:activity_spike) }
-    scope :stalled, -> { open.active.with_activity_spikes.where("card_activity_spikes.updated_at": ..STALLED_AFTER_LAST_SPIKE_PERIOD.ago) }
+    scope :stalled, -> { open.active.with_activity_spikes.where("card_activity_spikes.updated_at": ..STALLED_AFTER_LAST_SPIKE_PERIOD.ago, updated_at: ..STALLED_AFTER_LAST_SPIKE_PERIOD.ago) }
 
     before_update :remember_to_detect_activity_spikes
     after_update_commit :detect_activity_spikes_later, if: :should_detect_activity_spikes?
   end
 
   def stalled?
-    open? && last_activity_spike_at < STALLED_AFTER_LAST_SPIKE_PERIOD.ago if activity_spike.present?
+    if activity_spike.present?
+      open? && last_activity_spike_at < STALLED_AFTER_LAST_SPIKE_PERIOD.ago && updated_at < STALLED_AFTER_LAST_SPIKE_PERIOD.ago
+    end
   end
 
   def last_activity_spike_at


### PR DESCRIPTION
This implementation also compares `updated_at` against `STALLED_AFTER_LAST_SPIKE_PERIOD`, so that a possible timeline would be:

- card is published
- card has an activity spike
- time passes, card becomes stalled
- card is touched, and becomes unstalled
- time passes, card becomes stalled again

Currently the "time passes" value is 14 days (`Card::Stallable::STALLED_AFTER_LAST_SPIKE_PERIOD`) for both post-activity-spike and post-touch time comparisons.

An alternative implementation could be to remove the activity spike when a stalled card is touched; if we did that then the card would not stall again until there is first another activity spike. In this implementation, the card will re-stall every two weeks.

ref: https://app.fizzy.do/5986089/cards/2492