### PR TITLE
Remove the account slug from the PWA manifest

### DIFF
--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -23,9 +23,7 @@
 
   <%= yield :head %>
 
-  <% if Current.account %>
-    <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
-  <% end %>
+  <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
   <link rel="icon" href="/favicon.png" type="image/png">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 </head>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,6 +1,5 @@
-<% account = Account.find_by_external_account_id!(request.env["fizzy.external_account_id"]) rescue nil %>
 {
-  "name": <%= [ "Fizzy", account&.name, Rails.env.production? ? nil : Rails.env ].compact.join(" - ").to_json.html_safe %>,
+  "name": <%= [ "Fizzy", Rails.env.production? ? nil : Rails.env ].compact.join(" - ").to_json.html_safe %>,
   "icons": [
     {
       "src": "/app-icon-192.png",
@@ -19,9 +18,9 @@
       "purpose": "maskable"
     }
   ],
-  "start_url": "<%= root_path %>",
+  "start_url": "/",
   "display": "standalone",
-  "scope": "<%= root_path %>",
+  "scope": "/",
   "description": "Card-up the biggest issues in your projects",
   "categories": ["bugs", "business", "productivity"],
   "shortcuts": [


### PR DESCRIPTION
- linked in the `head` on all requests (previously just tenanted requests)
- `start_url` and `scope` are "/" (previously account slug)

ref: https://app.fizzy.do/5986089/cards/3024