### PR TITLE
Don't show mini bubbles in Maybe column

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -673,7 +673,6 @@
   /* -------------------------------------------------------------------------- */
 
   /* Surface a mini bubble if there are cards with bubbles inside */
-  .cards--considering:has(.bubble:not([hidden])),
   .cards--doing.is-collapsed:has(.bubble:not([hidden])) {
     .cards__transition-container {
       --bubble-color: var(--card-color, oklch(var(--lch-blue-medium)));
@@ -690,7 +689,7 @@
         inline-size: 1em;
         inset: 0 0 auto auto;
         position: absolute;
-        translate: 0 0;
+        translate: 20% -20%;
         z-index: 1;
       }
     }


### PR DESCRIPTION
- Don't show the mini bubble in the Maybe column
- Better position for mini bubbles in Doing columns

|Before|After|
|--|--|
|<img width="1312" height="448" alt="CleanShot 2025-11-19 at 11 49 49@2x" src="https://github.com/user-attachments/assets/23aca173-fc7f-46c6-992a-f31203d3ceba" />|<img width="1312" height="448" alt="CleanShot 2025-11-19 at 11 48 01@2x" src="https://github.com/user-attachments/assets/01ab3e84-f835-4ff7-b665-febf345638d0" />|