### PR TITLE
Add `Current.account` to cache key

### DIFF
--- a/app/views/my/menus/show.html.erb
+++ b/app/views/my/menus/show.html.erb
@@ -63,7 +63,7 @@
 
     <% accounts = Current.identity.accounts %>
     <% if accounts.many? %>
-      <% cache [ Current.identity, accounts ] do %>
+      <% cache [ Current.identity, accounts, Current.account ] do %>
         <%= collapsible_nav_section "Accounts" do %>
           <% accounts.each do |account| %>
             <%= filter_place_menu_item landing_url(script_name: account.slug), account.name, "marker", new_window: true, current: account == Current.account %>


### PR DESCRIPTION
I added the current account to the list in #1631 because I think it's confusing when the account list in the menu changes every time you switch. It's helpful and reassuring to see which is the currently selected account and it helps reinforce that this is a UI for switching.

Apparently, the selected account isn't being properly cached, however. See: https://app.fizzy.do/6074589/cards/140

This addresses that by adding Current.account to the cache key.

<img width="883" height="487" alt="image" src="https://github.com/user-attachments/assets/67a49b5c-fdc2-462c-892f-428e4ee4b79d" />
