### PR TITLE
Remove special Safari hack

### DIFF
--- a/app/assets/stylesheets/inputs.css
+++ b/app/assets/stylesheets/inputs.css
@@ -48,6 +48,13 @@
         margin: 0;
       }
     }
+
+    /* Target mobile Safari only */
+    @supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+      @media (hover: none) {
+        font-size: max(16px, 1em) !important;
+      }
+    }
   }
 
   .input--file {


### PR DESCRIPTION
We added this to prevent mobile Safari from automatically zooming in if inputs have a font size < 16px. All well and good, but we need to avoid desktop Safari.