### PR TITLE
Process notification recipients in consistent order

### DIFF
--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -14,7 +14,8 @@ class Notifier
 
   def notify
     if should_notify?
-      recipients.map do |recipient|
+      # Processing recipients in order avoids deadlocks if notifications overlap.
+      recipients.sort_by(&:id).map do |recipient|
         Notification.create! user: recipient, source: source, creator: creator
       end
     end


### PR DESCRIPTION
We've seen some cases of deadlock when processing notifications, because locks are gathered on the users in different orders. Let's try sticking to a consistent order instead, which should cause the jobs to serialize rather than deadlock.