### PR TITLE
Add hide-scrollbar utility and use on card titles

### DIFF
--- a/app/assets/stylesheets/card-columns.css
+++ b/app/assets/stylesheets/card-columns.css
@@ -18,7 +18,6 @@
     --progress-max-cards: 20;
     --progress-max-height: 50dvh;
 
-    -ms-overflow-style: none;  /* Hide x-scrollbar on Edge */
     container-type: inline-size;
     display: grid;
     gap: var(--column-gap);
@@ -29,12 +28,6 @@
     overflow-y: hidden;
     padding-block-end: var(--column-width-collapsed);
     position: relative;
-    scrollbar-width: none; /* Hide x-scrollbar on FF */
-
-    /* Hide x-scrollbar on Chrome/Safari/Opera */
-    &::-webkit-scrollbar {
-      display: none;
-    }
 
     /* When it has something expanded */
     &:has(.card-columns__left .cards:not(.is-collapsed), .card-columns__right .cards:not(.is-collapsed)) {

--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -249,4 +249,14 @@
       display: unset;
     }
   }
+
+  .hide-scrollbar {
+    -ms-overflow-style: none;  /* Edge */
+    scrollbar-width: none; /* FF */
+
+    /* Chrome/Safari/Opera */
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
 }

--- a/app/views/boards/show/_columns.html.erb
+++ b/app/views/boards/show/_columns.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: "card-columns", data: {
+<%= tag.div class: "card-columns hide-scrollbar", data: {
       controller: "collapsible-columns drag-and-drop drag-and-strum",
       drag_and_drop_dragged_item_class: "drag-and-drop__dragged-item",
       drag_and_drop_hover_container_class: "drag-and-drop__hover-container",

--- a/app/views/cards/container/_title.html.erb
+++ b/app/views/cards/container/_title.html.erb
@@ -20,7 +20,7 @@
     <h1 class="card__title">
       <%= form.label :title, class: "flex flex-column align-center autoresize__wrapper", data: { autoresize_target: "wrapper", autoresize_clone_value: "" } do %>
         <%= form.text_area :title, placeholder: "Name it…",
-              class: "card-field__title input input--textarea hide-focus-ring full-width borderless txt-align-start autoresize__textarea",
+              class: "card-field__title autoresize__textarea input input--textarea full-width borderless txt-align-start hide-focus-ring hide-scrollbar",
               autofocus: card.title.blank?, rows: 1,
               data: { autoresize_target: "textarea", action: "input->autoresize#resize auto-save#change blur->auto-save#submit keydown.enter->auto-save#submit:prevent" } %>
       <% end %>

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -3,7 +3,7 @@
         data: { controller: "autoresize form local-save", local_save_key_value: "card-#{@card.id}", action: "turbo:submit-end->local-save#submit" } do |form| %>
     <h1 class="card__title flex align-start gap-half">
       <%= form.label :title, class: "flex flex-column align-center autoresize__wrapper", data: { autoresize_target: "wrapper", autoresize_clone_value: "" } do %>
-        <%= form.text_area :title, class: "card-field__title input input--textarea hide-focus-ring full-width borderless txt-align-start autoresize__textarea",
+        <%= form.text_area :title, class: "card-field__title autoresize__textarea input input--textarea full-width borderless txt-align-start hide-focus-ring hide-scrollbar",
               required: true, autofocus: true, placeholder: "Name it…", rows: 1,
               data: { autoresize_target: "textarea", action: "input->autoresize#resize keydown.enter->form#submit:prevent keydown.ctrl+enter->form#submit:prevent keydown.meta+enter->form#submit:prevent keydown.esc->form#cancel focus->form#select" } %>
       <% end %>

--- a/app/views/public/boards/show/_columns.html.erb
+++ b/app/views/public/boards/show/_columns.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :cards_container do %>
-  <div class="card-columns" data-controller="collapsible-columns" data-collapsible-columns-board-value="<%= board.id %>" data-collapsible-columns-collapsed-class="is-collapsed" data-collapsible-columns-no-transitions-class="no-transitions">
+  <div class="card-columns hide-scrollbar" data-controller="collapsible-columns" data-collapsible-columns-board-value="<%= board.id %>" data-collapsible-columns-collapsed-class="is-collapsed" data-collapsible-columns-no-transitions-class="no-transitions">
 
     <div class="card-columns__left">
       <%= render "public/boards/show/not_now", board: board %>


### PR DESCRIPTION
- Extract the styles to hide scrollbars into a utility class
- Add `.hide-scrollbar` class to card title fields

|Before|After|
|--|--|
|<img width="2122" height="454" alt="CleanShot 2025-11-20 at 11 02 33@2x" src="https://github.com/user-attachments/assets/67f4d6b5-22c8-46aa-b722-65d0d0002116" />|<img width="2122" height="454" alt="CleanShot 2025-11-20 at 11 02 14@2x" src="https://github.com/user-attachments/assets/42a8fa9a-0d58-4a70-a301-1d25de21085c" />|