### PR TITLE
Add total counts and restructure admin stats dashboard

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -4,9 +4,11 @@ class Admin::StatsController < AdminController
   layout "public"
 
   def show
+    @accounts_total = Account.count
     @accounts_last_7_days = Account.where(created_at: 7.days.ago..).count
     @accounts_last_24_hours = Account.where(created_at: 24.hours.ago..).count
 
+    @identities_total = Identity.count
     @identities_last_7_days = Identity.where(created_at: 7.days.ago..).count
     @identities_last_24_hours = Identity.where(created_at: 24.hours.ago..).count
 

--- a/app/views/admin/stats/show.html.erb
+++ b/app/views/admin/stats/show.html.erb
@@ -6,14 +6,18 @@
 
 <section class="settings">
   <div class="settings__panel panel shadow center">
-    <header>
-      <h2 class="divider txt-medium margin-block-start">Recent Activity</h2>
-    </header>
-
-    <div class="flex gap margin-block-half">
-      <div class="flex flex-column gap-half flex-item-grow">
-        <div>Accounts Created</div>
+    <div class="flex flex-column gap margin-block-half">
+      <div class="flex flex-column gap-half">
+        <header>
+          <h2 class="divider txt-medium margin-block-start">Accounts Created</h2>
+        </header>
         <div class="flex gap-half">
+          <div class="flex flex-column gap-quarter flex-item-grow">
+            <div class="txt-x-small">Total</div>
+            <div class="txt-large">
+              <strong><%= @accounts_total %></strong>
+            </div>
+          </div>
           <div class="flex flex-column gap-quarter flex-item-grow">
             <div class="txt-x-small">7 days</div>
             <div class="txt-large">
@@ -29,9 +33,17 @@
         </div>
       </div>
 
-      <div class="flex flex-column gap-half flex-item-grow">
-        <div>Identities Created</div>
+      <div class="flex flex-column gap-half">
+        <header>
+          <h2 class="divider txt-medium margin-block-start">Identities Created</h2>
+        </header>
         <div class="flex gap-half">
+          <div class="flex flex-column gap-quarter flex-item-grow">
+            <div class="txt-x-small">Total</div>
+            <div class="txt-large">
+              <strong><%= @identities_total %></strong>
+            </div>
+          </div>
           <div class="flex flex-column gap-quarter flex-item-grow">
             <div class="txt-x-small">7 days</div>
             <div class="txt-large">


### PR DESCRIPTION
- Add total counts for accounts and identities alongside 7-day and 24-hour metrics
- Change total counts layout from horizontal to vertical stacking

<img width="1105" height="1445" alt="image" src="https://github.com/user-attachments/assets/bbfcacc6-1a89-4998-bc78-6ffe17d24334" />
