### PR TITLE
Disable stale while revalidate for own avatar

### DIFF
--- a/app/controllers/users/avatars_controller.rb
+++ b/app/controllers/users/avatars_controller.rb
@@ -7,7 +7,7 @@ class Users::AvatarsController < ApplicationController
   before_action :ensure_permission_to_administer_user, only: :destroy
 
   def show
-    if stale? @user, cache_control: { max_age: (30.minutes unless Current.user == @user), stale_while_revalidate: 1.week }.compact
+    if stale? @user, cache_control: cache_control
       render_avatar_or_initials
     end
   end
@@ -24,6 +24,14 @@ class Users::AvatarsController < ApplicationController
 
     def ensure_permission_to_administer_user
       head :forbidden unless Current.user.can_change?(@user)
+    end
+
+    def cache_control
+      if @user == Current.user
+        {}
+      else
+        { max_age: 30.minutes, stale_while_revalidate: 1.week }
+      end
     end
 
     def render_avatar_or_initials

--- a/test/controllers/users/avatars_controller_test.rb
+++ b/test/controllers/users/avatars_controller_test.rb
@@ -8,7 +8,8 @@ class Users::AvatarsControllerTest < ActionDispatch::IntegrationTest
   test "show self without caching" do
     get user_avatar_path(users(:david))
     assert_match "image/svg+xml", @response.content_type
-    assert_nil @response.cache_control[:max_age]
+    assert @response.cache_control[:private]
+    assert_equal "0", @response.cache_control[:max_age]
   end
 
   test "show other with caching" do


### PR DESCRIPTION
Locally, having stale_while_revalidate works great, but in production when we are behind CloudFlare, this results in an old image being shown after you upload a new one

See: https://app.fizzy.do/5986089/cards/2978