### PR TITLE
Move browser check to the sessions controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,5 +8,4 @@ class ApplicationController < ActionController::Base
 
   etag { "v1" }
   stale_when_importmap_changes
-  allow_browser versions: :modern
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  allow_browser versions: :modern
+
   # FIXME: Remove this before launch!
   unless Rails.env.local?
     http_basic_authenticate_with \


### PR DESCRIPTION
The check is unnecessary once users have logged in, and its presence on some unauthenticated pages is blocking things like:

- image proxy requests for user avatars (emails)
- opengraph requests for public pages (social media)

ref: https://app.fizzy.do/5986089/cards/1775
ref: https://app.fizzy.do/5986089/cards/1740

cc @jzimdars 