### PR TITLE
Don't let cloudflare cache avatars

### DIFF
--- a/app/controllers/users/avatars_controller.rb
+++ b/app/controllers/users/avatars_controller.rb
@@ -32,7 +32,7 @@ class Users::AvatarsController < ApplicationController
       if @user == Current.user
         {}
       else
-        { max_age: 30.minutes, stale_while_revalidate: 1.week, public: true }
+        { max_age: 30.minutes, stale_while_revalidate: 1.week }
       end
     end
 

--- a/test/controllers/users/avatars_controller_test.rb
+++ b/test/controllers/users/avatars_controller_test.rb
@@ -15,7 +15,7 @@ class Users::AvatarsControllerTest < ActionDispatch::IntegrationTest
   test "show other initials with caching" do
     get user_avatar_path(users(:kevin))
     assert_match "image/svg+xml", @response.content_type
-    assert @response.cache_control[:public]
+    assert @response.cache_control[:private]
     assert_equal 30.minutes.to_s, @response.cache_control[:max_age]
   end
 


### PR DESCRIPTION
The issue here is that anyone else who views my avatar will cause it to be cached, and then I can't easily bust the cache if I change my avatar.

I have no doubt that we can improve avatar handling and caching, but I've hit my time budget.