### PR TITLE
Prevent overlapping bundles from being created

### DIFF
--- a/app/models/notification/bundle.rb
+++ b/app/models/notification/bundle.rb
@@ -57,12 +57,12 @@ class Notification::Bundle < ApplicationRecord
     deliver_later
   end
 
-  private
-    def set_default_window
-      self.starts_at ||= Time.current
-      self.ends_at ||= self.starts_at + user.settings.bundle_aggregation_period
-    end
+  def set_default_window
+    self.starts_at ||= Time.current
+    self.ends_at ||= self.starts_at + user.settings.bundle_aggregation_period
+  end
 
+  private
     def window
       starts_at..ends_at
     end

--- a/app/models/user/notifiable.rb
+++ b/app/models/user/notifiable.rb
@@ -16,11 +16,18 @@ module User::Notifiable
 
   private
     def find_or_create_bundle_for(notification)
-      find_bundle_for(notification) || create_bundle_for(notification)
+      find_bundle_for(notification) || expand_pending_bundle_for(notification) || create_bundle_for(notification)
     end
 
     def find_bundle_for(notification)
       notification_bundles.pending.containing(notification).last
+    end
+
+    def expand_pending_bundle_for(notification)
+      pending = notification_bundles.pending.last
+      if pending.present? && notification.created_at < pending.starts_at
+        pending.update!(starts_at: notification.created_at) # expand the window to include this notification
+      end
     end
 
     def create_bundle_for(notification)

--- a/test/models/notification/bundle_test.rb
+++ b/test/models/notification/bundle_test.rb
@@ -24,6 +24,8 @@ class Notification::BundleTest < ActiveSupport::TestCase
   end
 
   test "notifications are bundled withing the aggregation period" do
+    @user.notification_bundles.destroy_all
+
     notification_1 = assert_difference -> { @user.notification_bundles.pending.count }, 1 do
       @user.notifications.create!(source: events(:logo_published), creator: @user)
     end
@@ -38,7 +40,8 @@ class Notification::BundleTest < ActiveSupport::TestCase
       @user.notifications.create!(source: events(:logo_published), creator: @user)
     end
 
-    bundle_1, bundle_2 = @user.notification_bundles.last(2)
+    assert_equal 2, @user.notification_bundles.count
+    bundle_1, bundle_2 = @user.notification_bundles.all.to_a
     assert_includes bundle_1.notifications, notification_1
     assert_includes bundle_1.notifications, notification_2
     assert_includes bundle_2.notifications, notification_3
@@ -94,6 +97,8 @@ class Notification::BundleTest < ActiveSupport::TestCase
   end
 
   test "deliver_all delivers due bundles" do
+    @user.notification_bundles.destroy_all
+
     notification = @user.notifications.create!(source: events(:logo_published), creator: @user)
 
     bundle = @user.notification_bundles.pending.last
@@ -139,5 +144,20 @@ class Notification::BundleTest < ActiveSupport::TestCase
       # Time in Madrid should be 15:30 (UTC+1 in winter)
       assert_match /everything since 3pm/i, email.text_part&.body&.to_s
     end
+  end
+
+  test "out-of-order notification bundling should still work" do
+    first_notification = @user.notifications.create!(source: events(:logo_published), creator: @user)
+    second_notification = @user.notifications.create!(source: events(:logo_published), creator: @user)
+    @user.notification_bundles.destroy_all
+
+    assert first_notification.created_at < second_notification.created_at
+    @user.bundle(second_notification)
+    @user.bundle(first_notification)
+
+    assert_equal 1, @user.notification_bundles.pending.count
+    assert_equal 2, @user.notification_bundles.last.notifications.count
+    assert_includes @user.notification_bundles.last.notifications, first_notification
+    assert_includes @user.notification_bundles.last.notifications, second_notification
   end
 end


### PR DESCRIPTION
ref: https://3.basecamp.com/2914079/buckets/27/card_tables/cards/9275047474

The recurring issue with overlapping notification bundles was due to notifications being handled out-of-order. The test added here is illustrative, but to save you a click:

```ruby
first_notification = @user.notifications.create!(source: events(:logo_published), creator: @user)
second_notification = @user.notifications.create!(source: events(:logo_published), creator: @user)
assert first_notification.created_at < second_notification.created_at

# process in reverse chronological order
@user.bundle(second_notification)
@user.bundle(first_notification)

assert_equal 1, @user.notification_bundles.pending.count # FAIL, there are 2
```

I imagine this order of events could happen by pure chance. But two small bugs coincide to result in overlapping bundles:

1. Bundle creation relies on `set_default_window` to set `ends_at`, but `set_default_window` was being called _after_ validation, and so `validate_no_overlapping` wasn't working properly for new records.
2. `User::Notifiable#find_or_create_bundle_for` does not handle the case where the notification's timestamp is before the current pending bundle.

So the two fixes applied are:

- call `Bundle#set_default_window` before validation (but only for new records)
- in `User::Notifiable#find_or_create_bundle_for`, expand the window on the existing current bundle to include the notification, if the notification pre-dates the bundle

cc @jorgemanrubia
