### PR TITLE
Add properties for Lexxy's built-in styles

### DIFF
--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -28,9 +28,18 @@
       }
     }
 
-    :where(b, strong) {
+    :where(b, strong, .lexxy-content__bold) {
       font-weight: 700;
     }
+
+    :where(i, em, .lexxy-content__italic) {
+      font-style: italic;
+    }
+
+    :where(s, .lexxy-content__strikethrough) {
+      text-decoration: line-through;
+    }
+
 
     :where(p, blockquote) {
       letter-spacing: -0.005ch;
@@ -73,10 +82,6 @@
     .horizontal-divider  {
       margin: var(--block-margin) 0;
       padding-block: var(--block-margin);
-    }
-
-    .lexxy-content__strikethrough {
-      text-decoration: line-through;
     }
 
     /* Code */


### PR DESCRIPTION
Usually, `<b>`, `<i>`, etc are enough but when you attempt a combo like bold-italic, Lexxy applies two classes to a single element instead of rendering tags like in the output
<img width="1164" height="1425" alt="screenshot-2025-11-24_09-45-51" src="https://github.com/user-attachments/assets/d8f3b676-566c-4c12-b7d9-97a75fe0832d" />
