### PR TITLE
Determine staff members based on flag

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -18,10 +18,6 @@ class Identity < ApplicationRecord
     end
   end
 
-  def staff?
-    email_address.ends_with?("@37signals.com") || email_address.ends_with?("@basecamp.com")
-  end
-
   private
     def deactivate_users
       users.find_each(&:deactivate)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,8 +19,6 @@ class User < ApplicationRecord
 
   scope :with_avatars, -> { preload(:account, :avatar_attachment) }
 
-  delegate :staff?, to: :identity, allow_nil: true
-
   def deactivate
     transaction do
       accesses.destroy_all

--- a/db/migrate/20251125130010_add_a_staff_flag_to_identities.rb
+++ b/db/migrate/20251125130010_add_a_staff_flag_to_identities.rb
@@ -1,0 +1,5 @@
+class AddAStaffFlagToIdentities < ActiveRecord::Migration[8.2]
+  def change
+    add_column :identities, :staff, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2025_11_25_110629) do
+ActiveRecord::Schema[8.2].define(version: 2025_11_25_130010) do
   create_table "accesses", id: :uuid, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "accessed_at"
     t.uuid "account_id", null: false
@@ -300,6 +300,7 @@ ActiveRecord::Schema[8.2].define(version: 2025_11_25_110629) do
   create_table "identities", id: :uuid, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email_address", null: false
+    t.boolean "staff", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_identities_on_email_address", unique: true
   end

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -13,12 +13,6 @@ class IdentityTest < ActiveSupport::TestCase
     end
   end
 
-  test "staff?" do
-    assert Identity.new(email_address: "test@37signals.com").staff?
-    assert Identity.new(email_address: "test@basecamp.com").staff?
-    assert_not Identity.new(email_address: "test@example.com").staff?
-  end
-
   test "join" do
     identity = identities(:david)
     account = accounts(:initech)


### PR DESCRIPTION
This replaces the old system based on email addresses, the aim is to make it more generic and thus appropriate for OSS/self-hosting

See: https://3.basecamp.com/2914079/buckets/37331921/todos/9302705265#__recording_9320051455