### PR TITLE
Add defensive styles for non-square avatar images

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -49,13 +49,15 @@
       }
 
       .avatar {
-        border-radius: 50%;
+        aspect-ratio: 1;
+        border-radius: 2.5em;
         color: white;
         display: block;
         font-weight: 600;
         height: 2.5em;
         line-height: 2.5em;
         mso-line-height-rule: exactly;
+        object-fit: cover;
         overflow: hidden;
         text-align: center;
         width: 2.5em;


### PR DESCRIPTION
<img width="660" height="429" alt="image" src="https://github.com/user-attachments/assets/a8cb5c35-4a84-48df-b6eb-bd8813ec562c" />
