### PR TITLE
Ensure avatar thumbnails are square

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   include Timelined # Depends on Accessor
 
   has_one_attached :avatar do |attachable|
-    attachable.variant :thumb, resize_to_limit: [ 256, 256 ]
+    attachable.variant :thumb, resize_to_fill: [ 256, 256 ]
   end
 
   belongs_to :account


### PR DESCRIPTION
Previously we were fitting the image inside a 256x256 box while keeping it's original aspect ratio. But this can lead to images that are squished and/or pixelated when we try to show them inside a square container in the app.

Instead we can resize them to be square.