### PR TITLE
Introduce gitleaks to the codebase

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+[extend]
+useDefault = true
+
+[allowlist]
+paths = [
+  '''log''',
+  '''tmp''',
+  '''.*\.yml\.enc''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,9 @@
+d8463077:gems/fizzy-saas/bin/setup:generic-api-key:54
+c4073c1c:app/models/integration/basecamp.rb:generic-api-key:3
+c4073c1c:app/models/integration/basecamp.rb:generic-api-key:4
+02a42167:test/models/webhook_test.rb:slack-webhook-url:57
+2fc9215b:test/models/webhook/delivery_test.rb:slack-webhook-url:156
+2fc9215b:test/models/webhook_test.rb:slack-webhook-url:57
+a515ea3b:test/fixtures/webhooks.yml:generic-api-key:5
+a515ea3b:test/fixtures/webhooks.yml:generic-api-key:11
+1f21c12c:test/vcr_cassettes/command/ai/translator_test-test_combine_commands_and_filters.yml:github-oauth:73012

--- a/bin/gitleaks
+++ b/bin/gitleaks
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if ! which gitleaks > /dev/null 2>&1 ; then
+  echo "gitleaks is not installed, please install it first" 1>&2
+  exit 1
+fi
+
+mkdir -p tmp
+if ! gitleaks dir --redact=50 --report-path tmp/gitleaks-report.json ; then
+  echo "gitleaks found potential secrets, please check tmp/gitleaks-report.json" 1>&2
+  exit 1
+fi
+
+exit 0

--- a/bin/setup
+++ b/bin/setup
@@ -59,7 +59,7 @@ step "Installing Ruby" mise install --yes
 eval "$(mise hook-env)"
 
 if which pacman >/dev/null 2>&1; then
-  packages=(imagemagick mariadb-libs openslide libvips)
+  packages=(imagemagick mariadb-libs openslide libvips gitleaks)
   if ! pacman -Q "${packages[@]}" >/dev/null 2>&1; then
     step "Installing packages" sudo pacman -S --noconfirm --needed "${packages[@]}"
   fi

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -8,6 +8,7 @@ CI.run do
   step "Security: Gem audit",       "bin/bundler-audit check --update"
   step "Security: Importmap audit", "bin/importmap audit"
   step "Security: Brakeman audit",  "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
+  step "Security: Gitleaks audit",  "bin/gitleaks"
 
   step "Tests: Rails: SaaS config", "bin/rails test"
   step "Tests: Rails: OSS config",  "OSS_CONFIG=1 bin/rails test"

--- a/test/fixtures/webhooks.yml
+++ b/test/fixtures/webhooks.yml
@@ -3,7 +3,7 @@ active:
   active: true
   name: Production API
   url: https://api.example.com/webhooks
-  signing_secret: p94Bx2HjempCdYB4DTyZkY1b
+  signing_secret: p94Bx2HjempCdYB4DTyZkY1b # gitleaks:allow randomly generated
   subscribed_actions: '<%= %w[ card_published card_assigned card_closed ].to_json %>'
   board: writebook_uuid
   account: 37s_uuid
@@ -13,7 +13,7 @@ inactive:
   active: false
   name: Test Webhook
   url: https://test.example.com/webhooks
-  signing_secret: H8ms8ADcV92v2x17hnLEiL5m
+  signing_secret: H8ms8ADcV92v2x17hnLEiL5m # gitleaks:allow randomly generated
   subscribed_actions: '<%= %w[ card_published card_assigned card_closed ].to_json %>'
   board: private_uuid
   account: 37s_uuid

--- a/test/models/webhook/delivery_test.rb
+++ b/test/models/webhook/delivery_test.rb
@@ -164,7 +164,7 @@ class Webhook::DeliveryTest < ActiveSupport::TestCase
     webhook = Webhook.create!(
       board: boards(:writebook),
       name: "Slack",
-      url: "https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx"
+      url: "https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx" # gitleaks:allow
     )
     event = events(:layout_commented)
     delivery = Webhook::Delivery.create!(webhook: webhook, event: event)

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -54,7 +54,7 @@ class WebhookTest < ActiveSupport::TestCase
   end
 
   test "for_slack?" do
-    webhook = Webhook.new url: "https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx"
+    webhook = Webhook.new url: "https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx" # gitleaks:allow
     assert webhook.for_slack?
 
     webhook = Webhook.new url: "https://hooks.slack.com/services/T12345678/B12345678"


### PR DESCRIPTION
- `bin/setup` installs gitleaks
- add `gitleaks dir` command to CI
- configure gitleaks to ignore tmp, log, and encrypted files
- tag existing false positives with `gitleaks:allow`
- add historical false positives to the ignore list