### PR TITLE
Fix missing closure notice 

### DIFF
--- a/app/views/cards/container/_content.html.erb
+++ b/app/views/cards/container/_content.html.erb
@@ -2,8 +2,8 @@
   <div data-turbo-permanent>
   <%= turbo_frame_tag card, :edit do %>
     <%# When canceling an edit (with the ESC key), restore the button area to show "Edit" instead of "Save changes". %>
-    <%= turbo_stream.update dom_id(card, :card_closure_toggle) do %>
-      <%= render "cards/container/closure_buttons", card: card %>
+    <%= turbo_stream.replace dom_id(card, :card_closure_toggle) do %>
+      <%= render "cards/container/closure", card: card %>
     <% end %>
 
     <%= render "cards/container/content_display", card: card %>

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag @card, :edit do %>
-  <%# When entering edit mode, this turbo-stream replaces the button area to show
+  <%# When entering edit mode, this turbo-stream updates the button area to show
       "Save changes" instead of "Edit". Turbo processes this stream as part of the
       frame response. %>
   <%= turbo_stream.update dom_id(@card, :card_closure_toggle) do %>

--- a/app/views/cards/update.turbo_stream.erb
+++ b/app/views/cards/update.turbo_stream.erb
@@ -4,6 +4,6 @@
   <%= render "cards/container/content_display", card: @card %>
 <% end %>
 
-<%= turbo_stream.update dom_id(@card, :card_closure_toggle) do %>
-  <%= render "cards/container/closure_buttons", card: @card %>
+<%= turbo_stream.replace dom_id(@card, :card_closure_toggle) do %>
+  <%= render "cards/container/closure", card: @card %>
 <% end %>


### PR DESCRIPTION
Need to replace the entire block, not just the buttons in most cases

<img width="769" height="334" alt="image" src="https://github.com/user-attachments/assets/622fee34-36d0-4e63-87fa-af2ee02909ac" />


Regressed in https://github.com/basecamp/fizzy/commit/a7df8260c3982be8deea9f2be12afa9b04a39263