### PR TITLE
Ensure Account::ExternalIdSequenceTest.value is never nil

### DIFF
--- a/app/models/account/external_id_sequence.rb
+++ b/app/models/account/external_id_sequence.rb
@@ -8,7 +8,7 @@ class Account::ExternalIdSequence < ApplicationRecord
     end
 
     def value
-      first&.value
+      first&.value || self.next
     end
 
     private

--- a/test/models/account/external_id_sequence_test.rb
+++ b/test/models/account/external_id_sequence_test.rb
@@ -39,4 +39,16 @@ class Account::ExternalIdSequenceTest < ActiveSupport::TestCase
     assert_equal values.min..values.max, values.sort.first..values.sort.last
     assert_equal 20, values.max - values.min + 1, "Values should be sequential with no gaps"
   end
+
+  test "#value creates the first record if it doesn't yet exist" do
+    assert_nil Account::ExternalIdSequence.first
+
+    value = nil
+    assert_difference -> { Account::ExternalIdSequence.count }, 1 do
+      value = Account::ExternalIdSequence.value
+    end
+
+    assert_not_nil value
+    assert_equal value, Account::ExternalIdSequence.first.value
+  end
 end


### PR DESCRIPTION
If no record exists, create it. This fixes a test in fizzy-saas in test/models/signup_test.rb that was not actually testing with a valid external account id.

cc @jorgemanrubia 