### PR TITLE
remove require of `lib/fizzy` from storage.yml

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,6 +1,4 @@
 <%
-  require_relative "../lib/fizzy"
-
   config_path = if Fizzy.saas?
     gem_path = Gem::Specification.find_by_name("fizzy-saas").gem_dir
     File.join(gem_path, "config", "storage.yml")


### PR DESCRIPTION
require_relative doesn't work as expected in ERB templates

e.g., when firing up bin/minio-setup this looks in the parent directory

However, we shouldn't need it since `lib` is eager loaded.

cc @jorgemanrubia 