### PR TITLE
ci-oss.yml: Move the `if` to inside the jobs block

### DIFF
--- a/.github/workflows/ci-oss.yml
+++ b/.github/workflows/ci-oss.yml
@@ -2,10 +2,11 @@ name: CI (OSS)
 
 on:
   pull_request:
-  if: github.event.pull_request.head.repo.full_name != github.repository
+    types: [opened, synchronize]
 
 jobs:
   test:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/test.yml
     with:
       saas: false


### PR DESCRIPTION
ci-oss.yml was failing to parse the "if:" where it was.

cc @jorgemanrubia 
