### PR TITLE
Remove top margin on lexxy-toolbar

### DIFF
--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -192,7 +192,6 @@
 
     lexxy-toolbar {
       border-block-start: 1px solid var(--color-ink-light);
-      margin-block-start: var(--block-space-half) !important;
     }
 
     & ~ .btn.btn--reversed {


### PR DESCRIPTION
|Before|After|
|--|--|
|<img width="1168" height="458" alt="CleanShot 2025-12-01 at 14 55 50@2x" src="https://github.com/user-attachments/assets/3472d7b5-66fc-4093-8c23-23f8ae2b0688" />|<img width="1168" height="458" alt="CleanShot 2025-12-01 at 14 55 41@2x" src="https://github.com/user-attachments/assets/33bbb06a-c2d7-48a2-a029-17dc198aa17f" />|