### PR TITLE
Better alignment for nav sections

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -65,6 +65,7 @@
       align-items: center;
       cursor: pointer;
       display: flex;
+      gap: 0.5ch;
     }
 
     &::-webkit-details-marker {
@@ -73,10 +74,8 @@
 
     .icon--caret-down {
       font-size: 1ch;
-      inset: 50% auto auto 0;
-      position: absolute;
+      margin-inline-start: -0.5ch;
       transition: rotate 150ms ease-out;
-      translate: -100% -50%;
     }
 
     .popup__section:not([open]) & {
@@ -95,6 +94,10 @@
     max-inline-size: 100%;
     padding: 0;
     row-gap: 1px;
+
+    details & {
+      margin-inline-start: 0.75ch;
+    }
   }
 
   .popup__item {


### PR DESCRIPTION
Align the icons inside—instead of outside—the collapsible section and indent the list contents.

|Before|After|
|--|--|
|<img width="1122" height="1288" alt="CleanShot 2025-12-01 at 15 15 27@2x" src="https://github.com/user-attachments/assets/03256b88-4475-4518-ba0f-1882eaeedfcc" />|<img width="1122" height="1288" alt="CleanShot 2025-12-01 at 15 15 40@2x" src="https://github.com/user-attachments/assets/f3b180df-5567-4c0b-8123-a9fe6eacce4f" />|