### PR TITLE
Move card title margins to perma CSS

### DIFF
--- a/app/assets/stylesheets/card-perma.css
+++ b/app/assets/stylesheets/card-perma.css
@@ -58,6 +58,22 @@
 
     .card__title {
       font-size: clamp(var(--text-medium), 6vw, var(--text-x-large));
+      margin-block-end: 0.5ch;
+
+      /* With tight line spacing, Windows will cover over adjacent lines of text
+      * when input text is selected. Here, we're setting the selection color to a
+      * transparent value so the overlapping text lines are at least visible. */
+      ::selection {
+        background: oklch(var(--lch-blue-light) / 0.5);
+      }
+
+      &:has(textarea) {
+        margin-block-end: 0;
+
+        @supports not (field-sizing: content) {
+          text-wrap: unset; /* Safari is annoying if you have text-wrap: balance in textareas */
+        }
+      }
     }
 
     .card__meta,

--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -151,23 +151,7 @@
     font-size: var(--text-xx-large);
     font-weight: 900;
     line-height: 1.15;
-    margin-block-end: 0.5ch;
     text-wrap: balance;
-
-    /* With tight line spacing, Windows will cover over adjacent lines of text
-     * when input text is selected. Here, we're setting the selection color to a
-     * transparent value so the overlapping text lines are at least visible. */
-    ::selection {
-      background: oklch(var(--lch-blue-light) / 0.5);
-    }
-
-    &:has(textarea) {
-      margin-block-end: 0;
-
-      @supports not (field-sizing: content) {
-        text-wrap: unset; /* Safari is annoying if you have text-wrap: balance in textareas */
-      }
-    }
 
     .card-field__title {
       overflow: hidden; /* prevent scrolling on windows */

--- a/app/assets/stylesheets/nav.css
+++ b/app/assets/stylesheets/nav.css
@@ -103,12 +103,8 @@
   }
 
   .nav__section {
-    border-block-end: 1px solid var(--color-ink-lighter);
+    border-block-start: 1px solid var(--color-ink-lighter);
     font-size: var(--text-small);
-
-    &:first-of-type {
-      border-block-start: 1px solid var(--color-ink-lighter);
-    }
 
     &[open] {
       padding-block-end: 0.4rem;
@@ -220,6 +216,7 @@
 
   .nav__footer {
     background-color: var(--color-canvas);
+    border-block-start: 1px solid var(--color-ink-lighter);
     font-size: var(--text-small);
     line-height: 1.6;
     margin-block-start: calc(-1 * var(--nav-section-gap));

--- a/app/views/my/menus/_accounts.html.erb
+++ b/app/views/my/menus/_accounts.html.erb
@@ -1,6 +1,7 @@
 <% if accounts.many? %>
   <% cache [ Current.identity, accounts, Current.account ] do %>
     <%= collapsible_nav_section "Accounts" do %>
+      <%# Bust cache 1 Dec 2025 %>
       <% accounts.each do |account| %>
         <%= filter_place_menu_item landing_url(script_name: account.slug), account.name, "marker", current: account == Current.account, turbo: false %>
       <% end %>


### PR DESCRIPTION
- Scope the card title margin to card-perma.css so it won't show up in notifications, previews, etc.
- Add a border back to the Fizzy menu footer
- Bust cache for nav menu sections