### PR TITLE
Fix: cascade touches not touching boards

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -16,6 +16,7 @@ class Card < ApplicationRecord
   before_create :assign_number
 
   after_save   -> { board.touch }, if: :published?
+  after_touch  -> { board.touch }, if: :published?
   after_update :handle_board_change, if: :saved_change_to_board_id?
 
   scope :reverse_chronologically, -> { order created_at:     :desc, id: :desc }

--- a/test/models/card/golden_test.rb
+++ b/test/models/card/golden_test.rb
@@ -24,4 +24,19 @@ class Card::GoldenTest < ActiveSupport::TestCase
     assert_includes Card.golden, cards(:logo)
     assert_not_includes Card.golden, cards(:text)
   end
+
+  test "gilding a card touches both the card and the board" do
+    card = cards(:text)
+    board = card.board
+
+    card_updated_at = card.updated_at
+    board_updated_at = board.updated_at
+
+    travel 1.minute do
+      card.gild
+    end
+
+    assert card.reload.updated_at > card_updated_at
+    assert board.reload.updated_at > board_updated_at
+  end
 end


### PR DESCRIPTION
The change in https://github.com/basecamp/fizzy/commit/c606de7b41f57734c4c859c5fc3d98c952b26d58 was preventing cascade touches from cards from broadcasting and from invalidating the boards cache via touching.

https://app.fizzy.do/5986089/cards/3235