### PR TITLE
Robots, begone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include Authorization
+  include BlockSearchEngineIndexing
   include CurrentRequest, CurrentTimezone, SetPlatform
   include RequestForgeryProtection
   include TurboFlash, ViewTransitions

--- a/app/controllers/concerns/block_search_engine_indexing.rb
+++ b/app/controllers/concerns/block_search_engine_indexing.rb
@@ -1,0 +1,14 @@
+# Tell crawlers like Googlebot to drop pages entirely from search results, even
+# if other sites link to it
+module BlockSearchEngineIndexing
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :block_search_engine_indexing
+  end
+
+  private
+    def block_search_engine_indexing
+      headers["X-Robots-Tag"] = "none"
+    end
+end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-Agent: *
+Disallow: /

--- a/test/controllers/concerns/block_search_engine_indexing_test.rb
+++ b/test/controllers/concerns/block_search_engine_indexing_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class BlockSearchEngineIndexingTest < ActionDispatch::IntegrationTest
+  test "sets X-Robots-Tag header to none on authenticated requests" do
+    sign_in_as :david
+
+    get board_path(boards(:writebook))
+    assert_response :success
+    assert_equal "none", response.headers["X-Robots-Tag"]
+  end
+
+  test "sets X-Robots-Tag header to none on unauthenticated requests" do
+    untenanted do
+      get new_session_path
+    end
+
+    assert_response :success
+    assert_equal "none", response.headers["X-Robots-Tag"]
+  end
+
+  test "sets X-Robots-Tag header to none on public board pages" do
+    boards(:writebook).publish
+
+    get public_board_path(boards(:writebook).publication.key)
+    assert_response :success
+    assert_equal "none", response.headers["X-Robots-Tag"]
+  end
+end


### PR DESCRIPTION
* robots.txt: "Please, don't come in." If a page is directly linked, the URL can still appear in search results, though.
* X-Robots-Tag: "If you're here, forget what you saw." Works even if the crawler ignores robots.txt or reaches a page via external link. Can remove already-indexed pages.
* Public boards may be indexed. They're meant to be shareable and discoverable, not just private link sharing.