### PR TITLE
Fix `bin/setup` to explicitly use bash syntax for `mise hook-env`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -82,7 +82,7 @@ gum style --foreground 111 --bold "  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘
 echo
 
 step "Installing Ruby" mise install --yes
-eval "$(mise hook-env)"
+eval "$(mise hook-env -s bash)"
 
 if which pacman >/dev/null 2>&1; then
   packages=(imagemagick mariadb-libs openslide libvips gitleaks)


### PR DESCRIPTION
The bin/setup script fails when a user's default shell is Fish, producing this error:

```
bin/setup: line 88: set: -g: invalid option
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
```

This PR explicitly tells mise to output bash-compatible syntax by adding the `-s` bash flag

This ensures the script works correctly regardless of the user's default shell configuration.