### PR TITLE
fallback to rbenv if mise not installed

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -81,8 +81,15 @@ gum style --foreground 153 "   ˚ ∘             ∘ ˚   "
 gum style --foreground 111 --bold "  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  "
 echo
 
-step "Installing Ruby" mise install --yes
-eval "$(mise hook-env)"
+if which mise > /dev/null 2>&1; then
+  echo "Installing Ruby (via mise)"
+  mise install --yes
+  -eval "$(mise hook-env)"
+else
+  echo "Setting Ruby version (via rbenv)"
+  rbenv install --skip-existing
+  rbenv local $(cat .ruby-version)
+fi
 
 if which pacman >/dev/null 2>&1; then
   packages=(imagemagick mariadb-libs openslide libvips gitleaks)


### PR DESCRIPTION
pretty sure rbenv is still dominating, not a bash guy but this got me through `bin/setup`. otherwise `command mise not found` stops the show.