### PR TITLE
Account for input padding on autoresize pseudo-element

### DIFF
--- a/app/assets/stylesheets/autoresize.css
+++ b/app/assets/stylesheets/autoresize.css
@@ -3,7 +3,7 @@
     .autoresize__wrapper {
       display: grid !important;
       position: relative;
-    
+
       > *, &::after {
         grid-area: 1 / 1 / 2 / 2;
       }
@@ -12,6 +12,7 @@
         content: attr(data-autoresize-clone-value) " ";
         font: inherit;
         line-height: inherit;
+        padding-block: var(--autosize-block-padding, 0);
         visibility: hidden;
         white-space: pre-wrap;
       }

--- a/app/assets/stylesheets/cards.css
+++ b/app/assets/stylesheets/cards.css
@@ -143,6 +143,7 @@
   }
 
   .card__title {
+    --autosize-block-padding: 0 0.5ch;
     --input-border-radius: 0;
     --input-color: var(--card-content-color);
     --lines: 3;
@@ -155,7 +156,7 @@
 
     .card-field__title {
       overflow: hidden; /* prevent scrolling on windows */
-      padding-block-end: 0.5ch;
+      padding-block: var(--autosize-block-padding);
 
       &:is(textarea)::placeholder {
         color: inherit;


### PR DESCRIPTION
To get the autoresize pseudo-element to have the same height as the input, we need to account for any additional block padding the input might have.

|Before|After|
|--|--|
|<img width="1592" height="340" alt="CleanShot 2025-12-02 at 15 20 55@2x" src="https://github.com/user-attachments/assets/b72054f3-e66e-4d02-ac7a-6deae11f625c" />|<img width="1592" height="340" alt="CleanShot 2025-12-02 at 15 16 59@2x" src="https://github.com/user-attachments/assets/115c0f93-879c-4b77-b4e4-860fc7ec8996" />|