### PR TITLE
Add card deletion warning to board deletion confirmation message

### DIFF
--- a/app/views/boards/edit/_delete.html.erb
+++ b/app/views/boards/edit/_delete.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: board, class: "txt-align-center margin-block-start-auto", method: :delete do |form| %>
-  <%= form.button class: "btn txt-negative borderless txt-small", data: { turbo_confirm: "Are you sure you want to permanently delete this board and all associated cards?" } do %>
+  <%= form.button class: "btn txt-negative borderless txt-small", data: { turbo_confirm: "Are you sure you want to permanently delete this board and all the cards on it? This can't be undone." } do %>
     <%= icon_tag "trash" %>
     <span>Delete this board</span>
   <% end %>


### PR DESCRIPTION
Deleting a board in Fizzy also deletes all of the cards on that board.

This explicitly states that to the user in the confirmation message/warning.