### PR TITLE
Repair tooltip z-index selector

### DIFF
--- a/app/assets/stylesheets/card-perma.css
+++ b/app/assets/stylesheets/card-perma.css
@@ -161,7 +161,7 @@
       z-index: 1;
     }
 
-    &:has([data-controller="tooltip"]:hover) {
+    &:has([data-controller~="tooltip"]:hover) {
       z-index: var(--z-tooltip);
     }
   }


### PR DESCRIPTION
Select if the attribute contains `tooltip` instead of looking for an exact match.