### PR TITLE
hide "add a step" input when card is closed

### DIFF
--- a/app/views/cards/display/perma/_steps.html.erb
+++ b/app/views/cards/display/perma/_steps.html.erb
@@ -1,10 +1,12 @@
 <ol class="steps txt-small margin-block-start-auto">
   <%= render partial: "cards/steps/step", collection: card.steps, as: :step %>
 
-  <li id="<%= dom_id(card, :new_step) %>" class="step">
-    <input type="checkbox" class="step__checkbox" disabled>
-    <%= form_with model: [card, Step.new], url: card_steps_path(card), class: "min-width", data: { controller: "form", action: "submit->form#preventEmptySubmit turbo:submit-end->form#reset" } do |form| %>
-      <%= form.text_field :content, class: "input step__content hide-focus-ring", placeholder: "Add a step…", autocomplete: "off", data: { form_target: "input", "1p-ignore": "true" }, aria: { label: "Add a step" } %>
-    <% end %>
-  </li>
+  <% unless card.closed? %>
+    <li id="<%= dom_id(card, :new_step) %>" class="step">
+      <input type="checkbox" class="step__checkbox" disabled>
+      <%= form_with model: [card, Step.new], url: card_steps_path(card), class: "min-width", data: { controller: "form", action: "submit->form#preventEmptySubmit turbo:submit-end->form#reset" } do |form| %>
+        <%= form.text_field :content, class: "input step__content hide-focus-ring", placeholder: "Add a step…", autocomplete: "off", data: { form_target: "input", "1p-ignore": "true" }, aria: { label: "Add a step" } %>
+      <% end %>
+    </li>
+  <% end %>
 </ol>


### PR DESCRIPTION
Related discussion: https://github.com/basecamp/fizzy/discussions/1832

This prevents the `Add a step` input from accepting new text after the card is closed.