### PR TITLE
Fix crash when inserting an emoji into a max length reaction

### DIFF
--- a/app/javascript/controllers/reaction_emoji_controller.js
+++ b/app/javascript/controllers/reaction_emoji_controller.js
@@ -6,7 +6,12 @@ export default class extends Controller {
   insertEmoji(event) {
     const emojiChar = event.target.getAttribute("data-emoji")
     const value = this.inputTarget.value
-    this.inputTarget.value = `${value}${emojiChar}`
+    const newValue = `${value}${emojiChar}`
+
+    if (this.inputTarget.maxLength > 0 && newValue.length <= this.inputTarget.maxLength) {
+      this.inputTarget.value = newValue
+    }
+
     this.inputTarget.focus()
   }
 }


### PR DESCRIPTION
Fixes: https://app.fizzy.do/5986089/cards/3272
Fixes: https://basecamp.sentry.io/issues/7083330736