### PR TITLE
Add Connection tests

### DIFF
--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -2,12 +2,35 @@ require "test_helper"
 
 module ApplicationCable
   class ConnectionTest < ActionCable::Connection::TestCase
-    # test "connects with cookies" do
-    #   cookies.signed[:user_id] = 42
-    #
-    #   connect
-    #
-    #   assert_equal connection.user_id, "42"
-    # end
+    setup do
+      # Use non-37s account to assess that Current.account is set correctly
+      @account = accounts(:initech)
+      @session = sessions(:mike)
+    end
+
+    test "connects with valid session and account info" do
+      cookies.signed[:session_token] = @session.signed_id
+
+      connect "/cable", env: { "fizzy.external_account_id" => @account.external_account_id }
+
+      assert_equal users(:mike), connection.current_user
+      assert_equal @account, Current.account
+    end
+
+    test "rejects with invalid session token" do
+      cookies.signed[:session_token] = "invalid-session-id"
+
+      assert_reject_connection do
+        connect "/cable", env: { "fizzy.external_account_id" => @account.external_account_id }
+      end
+    end
+
+    test "rejects when account does not exist" do
+      cookies.signed[:session_token] = @session.signed_id
+
+      assert_reject_connection do
+        connect "/cable", env: { "fizzy.external_account_id" => -1 }
+      end
+    end
   end
 end

--- a/test/fixtures/sessions.yml
+++ b/test/fixtures/sessions.yml
@@ -9,3 +9,6 @@ jz:
 
 jason:
   identity: jason
+
+mike:
+  identity: mike


### PR DESCRIPTION
Because 1) testing authentication never hurts; 2) having a real world open source example of such tests would be great for the community 🙂.