### PR TITLE
Prefer find_by! over where + first!

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -35,7 +35,7 @@ class Account < ApplicationRecord
   end
 
   def system_user
-    users.where(role: :system).first!
+    users.find_by!(role: :system)
   end
 
   private


### PR DESCRIPTION
This was the only instance of where + first!, so I replaced it with `find_by!` for consistency and conciseness.