### PR TITLE
Auto default for UUID primary keys

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,6 +2,4 @@ class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
   configure_replica_connections
-
-  attribute :id, :uuid, default: -> { ActiveRecord::Type::Uuid.generate }
 end

--- a/app/models/search/record/sqlite.rb
+++ b/app/models/search/record/sqlite.rb
@@ -2,8 +2,6 @@ module Search::Record::SQLite
   extend ActiveSupport::Concern
 
   included do
-    # Override default UUID id attribute, as FTS5 uses rowid integer primary key
-    attribute :id, :integer, default: nil
     attribute :result_title, :string
     attribute :result_content, :string
 

--- a/config/initializers/uuid_framework_models.rb
+++ b/config/initializers/uuid_framework_models.rb
@@ -1,14 +1,10 @@
-# Inject UUID primary key support into Rails framework models
+# Inject account associations into Rails framework models
 Rails.application.config.to_prepare do
-  ActionText::RichText.attribute :id, :uuid, default: -> { ActiveRecord::Type::Uuid.generate }
   ActionText::RichText.belongs_to :account, default: -> { record.account }
 
-  ActiveStorage::Attachment.attribute :id, :uuid, default: -> { ActiveRecord::Type::Uuid.generate }
   ActiveStorage::Attachment.belongs_to :account, default: -> { record.account }
 
-  ActiveStorage::Blob.attribute :id, :uuid, default: -> { ActiveRecord::Type::Uuid.generate }
   ActiveStorage::Blob.belongs_to :account, default: -> { Current.account }
 
-  ActiveStorage::VariantRecord.attribute :id, :uuid, default: -> { ActiveRecord::Type::Uuid.generate }
   ActiveStorage::VariantRecord.belongs_to :account, default: -> { blob.account }
 end


### PR DESCRIPTION
Patch load_schmema! to set the default value for UUID primary keys. This removes the need to patch ApplicationRecord + Rails models individually.

It also means we no longer need to patch the default in for the integer primary key in Search::Record::SQLite.