### PR TITLE
Gracefully handle ill-formed remote images in rich text

### DIFF
--- a/app/views/action_text/attachables/_remote_image.html.erb
+++ b/app/views/action_text/attachables/_remote_image.html.erb
@@ -1,5 +1,5 @@
 <figure class="attachment attachment--preview">
-  <%= image_tag remote_image.url, width: remote_image.width, height: remote_image.height %>
+  <%= image_tag remote_image.url, skip_pipeline: true, width: remote_image.width, height: remote_image.height %>
   <% if caption = remote_image.try(:caption) %>
     <figcaption class="attachment__caption">
       <%= caption %>

--- a/app/views/events/event/attachments/_remote_image.html.erb
+++ b/app/views/events/event/attachments/_remote_image.html.erb
@@ -1,1 +1,1 @@
-<%= image_tag remote_image.url, class: "attachment attachment--image", width: remote_image.width, height: remote_image.height %>
+<%= image_tag remote_image.url, skip_pipeline: true, class: "attachment attachment--image", width: remote_image.width, height: remote_image.height %>

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -121,4 +121,15 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to boards(:writebook)
   end
+
+  test "show card with comment containing malformed remote image attachment" do
+    card = cards(:logo)
+    card.comments.create!(
+      creator: users(:kevin),
+      body: '<action-text-attachment url="image.png" content-type="image/*" presentation="gallery"></action-text-attachment>'
+    )
+
+    get card_path(card)
+    assert_response :success
+  end
 end


### PR DESCRIPTION
A better fix has been proposed upstream at https://github.com/rails/rails/pull/56283 but this should be fine in the meantime.

ref: https://app.fizzy.do/5986089/cards/3188

