### PR TITLE
Repair margins for attachments

### DIFF
--- a/app/assets/stylesheets/comments.css
+++ b/app/assets/stylesheets/comments.css
@@ -51,12 +51,14 @@
     padding-inline-end: var(--reaction-size);
     text-align: start;
 
-    :first-child {
-      margin-block-start: 0;
-    }
+    .action-text-content {
+      > action-text-attachment:first-child figure {
+        margin-block-start: 0.5ch;
+      }
 
-    :last-child {
-      margin-block-end: 0;
+      > :last-child {
+        margin-block-end: 0;
+      }
     }
   }
 

--- a/app/assets/stylesheets/rich-text-content.css
+++ b/app/assets/stylesheets/rich-text-content.css
@@ -62,7 +62,7 @@
     /* Links should hug media contained within */
     a:has(img),
     a:has(video) {
-      display: inline-block;
+      inline-size: fit-content;
     }
 
     /* Avoid extra space due to empty paragraphs */
@@ -263,7 +263,7 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: center;
-      margin-block-start: var(--block-space-half);
+      margin-block-start: 0.5ch;
     }
   }
 


### PR DESCRIPTION
- Only remove the bottom margin of `last-child` items if they're direct descendants of `.action-text-content`
- Add top margin to attachments if they're the first child (creates breathing room between images and the heading)
- Tighten up gap between image and caption caused by `inline-block` on attachment links.

|Before|After|
|--|--|
|<img width="1810" height="1740" alt="CleanShot 2025-12-03 at 11 03 02@2x" src="https://github.com/user-attachments/assets/2d331208-e604-4cb0-a430-77902f3c6e28" />|<img width="1810" height="1740" alt="CleanShot 2025-12-03 at 11 02 38@2x" src="https://github.com/user-attachments/assets/134b2bd7-5495-4d25-8985-3c63707ef505" />|