### PR TITLE
Target tooltips instead of specific buttons

### DIFF
--- a/app/assets/stylesheets/filters.css
+++ b/app/assets/stylesheets/filters.css
@@ -18,7 +18,7 @@
       --input-background: var(--color-canvas);
     }
 
-    &:has(.filter-toggle:hover) {
+    &:has([data-controller~="tooltip"]:hover) {
       z-index: calc(var(--z-nav) + 1);
     }
   }


### PR DESCRIPTION
Instead of selecting button classes for lifting the z-index, select items that have a tooltip controller.

|Before|After|
|--|--|
|<img width="680" height="346" alt="CleanShot 2025-12-03 at 11 16 15@2x" src="https://github.com/user-attachments/assets/c9a76cf4-094f-4969-ae6f-c27b7aab3e3b" />|<img width="680" height="346" alt="CleanShot 2025-12-03 at 11 15 52@2x" src="https://github.com/user-attachments/assets/0e53a64f-0a54-4518-81f7-56c63124ecbc" />|