### PR TITLE
Don't hide quick filters on mobile

### DIFF
--- a/app/assets/stylesheets/filters.css
+++ b/app/assets/stylesheets/filters.css
@@ -124,10 +124,6 @@
       margin-inline-end: calc((var(--btn-size) + var(--inline-space-half) + 0.25em) * -1);
       min-inline-size: calc(var(--input-width) + (0.25 * var(--collapsed-filter-space)));
     }
-
-    @media (max-width: 479px) {
-      --input-width: 100%;
-    }
   }
 
   .filter-toggle {


### PR DESCRIPTION
You can currently use quick filters on mobile, but you can't see them if you visit a link that has them filled out for you (like clicking a tag link, for instance). This change makes sure they're visible by default.

|Before|After|
|--|--|
|<img width="880" height="650" alt="CleanShot 2025-12-03 at 11 46 30@2x" src="https://github.com/user-attachments/assets/9fb551ca-dad9-4649-8011-06cc4e49e8f9" />|<img width="880" height="650" alt="CleanShot 2025-12-03 at 11 50 56@2x" src="https://github.com/user-attachments/assets/73b2e6e1-d402-4824-a0bf-42ba48dea0cd" />|