### PR TITLE
Use cryptographically secure randomness for Magic Link code generation

### DIFF
--- a/app/models/magic_link/code.rb
+++ b/app/models/magic_link/code.rb
@@ -4,7 +4,7 @@ module MagicLink::Code
 
   class << self
     def generate(length)
-      length.times.map { CODE_ALPHABET.sample }.join
+      Array.new(length) { CODE_ALPHABET[SecureRandom.random_number(CODE_ALPHABET.length)] }.join
     end
 
     def sanitize(code)


### PR DESCRIPTION
`#sample` uses PRNG under the hood which is pseudo random, which means that given enough magic link codes you can predict which code would come next. To fix that we have to switch to CSPRNG - `SecureRandom.random_number` - which isn't easy to predict based on previous results.

Saw this get called out here: https://x.com/bradgessler/status/1995970120532066510