### PR TITLE
Use environment variable for default mailer address

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "Fizzy <support@fizzy.do>"
+  default from: ENV.fetch("MAILER_FROM_ADDRESS", "Fizzy <support@fizzy.do>")
 
   layout "mailer"
   append_view_path Rails.root.join("app/views/mailers")


### PR DESCRIPTION
This allows the from address from ActionMailer messages to be set via an environment variable rather than always using the SaaS from address. This is important since many mail providers will block from addresses from domains not owned by the API user. 