### PR TITLE
Fix unauthorized column reordering

### DIFF
--- a/app/controllers/concerns/column_scoped.rb
+++ b/app/controllers/concerns/column_scoped.rb
@@ -7,6 +7,6 @@ module ColumnScoped
 
   private
     def set_column
-      @column = Current.account.columns.find(params[:column_id])
+      @column = Current.user.accessible_columns.find(params[:column_id])
     end
 end

--- a/app/models/user/accessor.rb
+++ b/app/models/user/accessor.rb
@@ -4,6 +4,7 @@ module User::Accessor
   included do
     has_many :accesses, dependent: :destroy
     has_many :boards, through: :accesses
+    has_many :accessible_columns, through: :boards, source: :columns
     has_many :accessible_cards, through: :boards, source: :cards
     has_many :accessible_comments, through: :accessible_cards, source: :comments
 

--- a/test/controllers/columns/left_positions_controller_test.rb
+++ b/test/controllers/columns/left_positions_controller_test.rb
@@ -20,4 +20,17 @@ class Columns::LeftPositionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_position_b, column_a.reload.position
     assert_equal original_position_a, column_b.reload.position
   end
+
+  test "users can only reorder columns in boards they have access to" do
+    column = columns(:writebook_in_progress)
+
+    post column_left_position_path(column), as: :turbo_stream
+    assert_response :success
+
+    boards(:writebook).update! all_access: false
+    boards(:writebook).accesses.revoke_from users(:kevin)
+
+    post column_left_position_path(column), as: :turbo_stream
+    assert_response :not_found
+  end
 end

--- a/test/controllers/columns/right_positions_controller_test.rb
+++ b/test/controllers/columns/right_positions_controller_test.rb
@@ -20,4 +20,17 @@ class Columns::RightPositionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_position_b, column_a.reload.position
     assert_equal original_position_a, column_b.reload.position
   end
+
+  test "users can only reorder columns in boards they have access to" do
+    column = columns(:writebook_triage)
+
+    post column_right_position_path(column), as: :turbo_stream
+    assert_response :success
+
+    boards(:writebook).update! all_access: false
+    boards(:writebook).accesses.revoke_from users(:kevin)
+
+    post column_right_position_path(column), as: :turbo_stream
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
Users could reorder columns they didn't have access to. Fixed by limiting ColumnScoped to User::Accessor#accessible_columns.

References https://hackerone.com/reports/3449905

/cc @jorgemanrubia @monorkin 