### PR TITLE
Scope tags by account

### DIFF
--- a/app/models/card/taggable.rb
+++ b/app/models/card/taggable.rb
@@ -9,7 +9,7 @@ module Card::Taggable
   end
 
   def toggle_tag_with(title)
-    tag = Tag.find_or_create_by!(title: title)
+    tag = account.tags.find_or_create_by!(title: title)
 
     transaction do
       if tagged_with?(tag)

--- a/test/models/card/taggable_test.rb
+++ b/test/models/card/taggable_test.rb
@@ -16,4 +16,13 @@ class Card::TaggableTest < ActiveSupport::TestCase
       @card.toggle_tag_with "ruby"
     end
   end
+
+  test "scope tags by account" do
+    assert_difference -> { Tag.count }, 2 do
+      cards(:logo).toggle_tag_with "ruby"
+      cards(:paycheck).toggle_tag_with "ruby"
+    end
+
+    assert_not_equal cards(:logo).tags.last, cards(:paycheck).tags.last
+  end
 end


### PR DESCRIPTION
We missed this one when we went to MySQL. This can results in cards tagged with cards from other accounts. No data leaked, fortunately. The symptom was that you would see the card tagged as expected but you wouldn't see the tags in the menu.