### PR TITLE
Warn users when mise is not activated

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,5 @@
+[tools]
+ruby = "3.4.7"
+
 [env]
 PROMETHEUS_EXPORTER_URL = "http://127.0.0.1:9306/metrics"

--- a/bin/setup
+++ b/bin/setup
@@ -112,6 +112,15 @@ gum style --foreground 111 --bold "  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘
 echo
 
 step "Installing Ruby" mise install --yes
+
+# Warn if mise is not activated in the user's shell
+if [ -z "$MISE_SHELL" ]; then
+  gum style --foreground 214 "⚠️  mise is not activated in your shell"
+  gum style --foreground 240 "Add this to your shell config and restart your shell:"
+  gum style --foreground 111 '    eval "$(mise activate bash)"'
+  echo
+fi
+
 eval "$(mise hook-env -s bash)"
 
 if which pacman >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

I'm not sure if this is needed but I needed this to overcome a Ruby/bundler setup issue by:

1. **Adding Ruby to `.mise.toml`**: Explicitly configures mise to manage Ruby 3.4.7 installation. Without this, mise may skip installing Ruby if a system Ruby exists (I had system ruby installed via pacman), causing gem executables (like `bundle`) to be installed in locations outside of mise's PATH management.

```
fizzy main ❯ ./bin/setup

   ˚ ∘             ∘ ˚
  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘

▸ Installing Ruby
mise install --yes
mise all tools are installed

./bin/setup: line 124: bundle: command not found
```

2. **Warning about mise activation**: Adds a check in `bin/setup` to warn users if mise is not activated in their shell configuration. Without this, `ruby` and `bundle` won't be available after setup completes. I didn't have mise installed before this and didn't have activate in my rc files.

## What I think was happening

The project has a `.ruby-version` file, but it didn't seem like  mise was detecting/installing Ruby from it. When system Ruby matched the version, mise would skip installation, causing gems to install to user directories outside of mise's managed PATH.

Might be a doc or a user error and not a patch. This is just what I needed to do. 

