### PR TITLE
Removed legacy join link

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,9 +138,6 @@ Rails.application.routes.draw do
 
   resources :qr_codes
 
-  # FIXME: Remove this before release
-  get "join/:tenant/:code", to: redirect { |params, request| "/#{params[:tenant]}/join/#{params[:code]}" }
-
   get "join/:code", to: "join_codes#new", as: :join
   post "join/:code", to: "join_codes#create"
 


### PR DESCRIPTION
Looks like this can be removed as the join_codes_controller does not use tenant anymore