### PR TITLE
Add Missing Production Databases for Solid Queue and Solid Cache

### DIFF
--- a/config/database.mysql.yml
+++ b/config/database.mysql.yml
@@ -33,3 +33,11 @@ production:
     <<: *default
     database: fizzy_production_cable
     migrations_paths: db/cable_migrate
+  queue:
+    <<: *default
+    database: fizzy_production_queue
+    migrations_paths: db/queue_migrate
+  cache:
+    <<: *default
+    database: fizzy_production_cache
+    migrations_paths: db/cache_migrate


### PR DESCRIPTION
The app failed to boot on Fly.io because Rails 8 expected separate `queue` and `cache` databases in production, but the MySQL config only defined `primary` and `cable`.

## Root Cause

Rails 8 uses Solid Queue and Solid Cache in production, and both require their own database connections. The MySQL config didn’t include `queue` or `cache` entries for the production environment.

## Fix

Added `queue` and `cache` database definitions to `config/database.mysql.yml` under `production`, matching the existing SQLite setup.

### Production databases now include:

* `fizzy_production`
* `fizzy_production_cable`
* `fizzy_production_queue`
* `fizzy_production_cache`

Development and test remain unchanged because they don’t use database-backed queue/cache.
