### PR TITLE
Configure email delivery in production using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo contains a starter deployment file that you can modify for your own sp
 The steps to configure your very own Fizzy are:
 
 1. Fork the repo
-2. Edit few things in config/deploy.yml, .kamal/secrets, and config/environments/production.rb
+2. Edit few things in config/deploy.yml and .kamal/secrets
 3. Run `kamal setup` to do your first deploy.
 
 We'll go through each of these in turn.
@@ -37,6 +37,7 @@ We've added comments to that file to highlight what each setting needs to be, bu
 - `ssh/user`: If you access your server a `root` you can leave this alone; if you use a different user, set it here.
 - `proxy/ssl` and `proxy/host`: Kamal can set up SSL certificates for you automatically. To enable that, set the hostname again as `host`. If you don't want SSL for some reason, you can set `ssl: false` to turn it off.
 - `env/clear/MAILER_FROM_ADDRESS`: This is the email address that Fizzy will send emails from. It should usually be an address from the same domain where you're running Fizzy.
+- `env/clear/SMTP_ADDRESS`: The address of an SMTP server that you can send email through. You can use a 3rd-party service for this, like Sendgrid or Postmark, in which case their documentation will tell you what to use for this.
 
 Fizzy also requires a few environment variables to be set up, some of which contain secrets.
 The simplest way to do this is to put them in a file called `.kamal/secrets`.
@@ -58,6 +59,7 @@ SMTP_PASSWORD=email-provider-password
 The values you enter here will be specific to you, and you can get or create them as follows:
 
 - `SECRET_KEY_BASE` should be a long, random secret. You can run `bin/rails secret` to create a suitable value for this.
+- `SMTP_USERNAME` & `SMTP_PASSWORD` should be valid credentials for your SMTP server. If you're using a 3rd-party service here, consult their documentation for what to use.
 - `VAPID_PUBLIC_KEY` & `VAPID_PRIVATE_KEY` are a pair of credentials that are used for sending notifications. You can create your own keys by starting a development console with:
 
   ```sh
@@ -72,10 +74,6 @@ The values you enter here will be specific to you, and you can get or create the
   puts "VAPID_PRIVATE_KEY=#{vapid_key.private_key}"
   puts "VAPID_PUBLIC_KEY=#{vapid_key.public_key}"
   ```
-
-- `SMTP_USERNAME`/`SMTP_PASSWORD` are credentials you should get from your email provider.
-
-Lastly, you'll need to set up the rest of your email configuration in `config/environments/production.rb`. There is an example configuration in comments at the top of that file. The actual settings you use here will depend on your email provider, but in most cases will look similar to that section, so you can uncomment it and edit to suit. Note that it will use the `SMTP_USERNAME` and `SMTP_PASSWORD` values you entered in your secrets.
 
 Once you've made all those changes, commit them to your fork so they're saved.
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -28,7 +28,8 @@ env:
     - SMTP_USERNAME
     - SMTP_PASSWORD
   clear:
-    MAILER_FROM_ADDRESS: support@example.com # The email address that Fizzy sends email from
+    MAILER_FROM_ADDRESS: support@example.com # The email "from" address that Fizzy sends email from
+    SMTP_ADDRESS: mail.example.com # The SMTP server you'll use to send email
     SOLID_QUEUE_IN_PUMA: true # Run background jobs in the app container
 
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,18 +5,20 @@ Rails.application.configure do
 
   # Email provider Settings
   #
-  # Configure these according to whichever email provider you use. An example setup
-  # using SMTP looks like the following:
-  #
-  # config.action_mailer.smtp_settings = {
-  #   address:              'smtp.example.com', # The address of your email provider's SMTP server
-  #   port:                 2525,
-  #   domain:               'example.com',      # Your domain, which Fizzy will send email from
-  #   user_name:            ENV["SMTP_USERNAME"],
-  #   password:             ENV["SMTP_PASSWORD"],
-  #   authentication:       :plain,
-  #   enable_starttls_auto: true
-  # }
+  # SMTP setting can be configured via environment variables.
+  # For other configuration options, consult the Action Mailer documentation.
+  if smtp_address = ENV["SMTP_ADDRESS"].presence
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address: smtp_address,
+      port: ENV.fetch("SMTP_PORT", "587").to_i,
+      domain: ENV.fetch("SMTP_DOMAIN", nil),
+      user_name: ENV.fetch("SMTP_USERNAME", nil),
+      password: ENV.fetch("SMTP_PASSWORD", nil),
+      authentication: ENV.fetch("SMTP_AUTHENTICATION", "plain"),
+      enable_starttls_auto: ENV.fetch("SMTP_ENABLE_STARTTLS_AUTO", "true") == "true"
+    }
+  end
 
   # Code is not reloaded between requests.
   config.enable_reloading = false
@@ -79,23 +81,6 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "fizzy_production"
 
   config.action_mailer.perform_caching = false
-
-  config.action_mailer.delivery_method = ENV.fetch("MAILER_DELIVERY_METHOD", "smtp").to_sym
-
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch("SMTP_ADDRESS", "localhost"),
-    port: ENV.fetch("SMTP_PORT", "587").to_i,
-    domain: ENV.fetch("SMTP_DOMAIN", nil),
-    user_name: ENV.fetch("SMTP_USERNAME", nil),
-    password: ENV.fetch("SMTP_PASSWORD", nil),
-    authentication: ENV.fetch("SMTP_AUTHENTICATION", "plain"),
-    enable_starttls_auto: ENV.fetch("SMTP_ENABLE_STARTTLS_AUTO", "true") == "true"
-  }
-
-  config.action_mailer.sendmail_settings = {
-    location: ENV.fetch("SENDMAIL_LOCATION", "/usr/sbin/sendmail"),
-    arguments: ENV.fetch("SENDMAIL_ARGUMENTS", "-i")
-  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Looks like Fizzy currently defaults to Sendmail, this update enables developers to switch to SMTP when needed via environment variables.