### PR TITLE
Fix inability to unfocus title on new card with escape

### DIFF
--- a/app/views/cards/container/_content.html.erb
+++ b/app/views/cards/container/_content.html.erb
@@ -10,13 +10,13 @@
   <% end %>
   </div>
 <% else %>
-  <%= form_with model: card, id: "card_form", data: { controller: "autoresize auto-save" } do |form| %>
+  <%= form_with model: card, id: "card_form", data: { controller: "autoresize auto-save form" } do |form| %>
     <h1 class="card__title">
       <%= form.label :title, class: "flex flex-column align-center autoresize__wrapper", data: { autoresize_target: "wrapper", autoresize_clone_value: "" } do %>
         <%= form.text_area :title, placeholder: "Name it…",
               class: "card-field__title autoresize__textarea input input--textarea full-width borderless txt-align-start hide-focus-ring hide-scrollbar",
               autofocus: card.title.blank?, rows: 1, dir: "auto", maxlength: 255,
-              data: { autoresize_target: "textarea", action: "input->autoresize#resize auto-save#change blur->auto-save#submit keydown.enter->auto-save#submit:prevent" } %>
+              data: { autoresize_target: "textarea", action: "input->autoresize#resize auto-save#change blur->auto-save#submit keydown.enter->auto-save#submit:prevent keydown.esc->form#blurActiveInput" } %>
       <% end %>
     </h1>
 


### PR DESCRIPTION
Not much of a rails person, but had a try at fixing this; not quite sure if this is right.

When opening a new card, the title input is focused but we can't unfocus using `Esc`, and so we can't use `Esc` to go back to the board. A workaround is to tab to the next input then press `Esc` to unfocus then `Esc` again to exit to the board. 

This PR intends to update this so that the title can be unfocused using `Esc`, then a second `Esc` can take us back to the board.

Before:

https://github.com/user-attachments/assets/e4d844d3-d33a-45fd-8050-c48829e08c1e

After:

https://github.com/user-attachments/assets/82a42fe7-05fd-4513-9364-f8bcc346b8a9

Notably this is not an issue when editing an existing card.
