### PR TITLE
Revert "Changing columns requires board admin"

### DIFF
--- a/app/controllers/boards/columns_controller.rb
+++ b/app/controllers/boards/columns_controller.rb
@@ -1,7 +1,6 @@
 class Boards::ColumnsController < ApplicationController
   include BoardScoped
 
-  before_action :ensure_permission_to_admin_board, only: %i[ create update destroy ]
   before_action :set_column, only: %i[ show update destroy ]
 
   def show

--- a/test/controllers/boards/columns_controller_test.rb
+++ b/test/controllers/boards/columns_controller_test.rb
@@ -36,45 +36,4 @@ class Boards::ColumnsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
   end
-
-  test "create requires board admin permission" do
-    logout_and_sign_in_as :jz
-
-    assert_no_difference -> { boards(:writebook).columns.count } do
-      post board_columns_path(boards(:writebook)), params: { column: { name: "New Column" } }, as: :turbo_stream
-      assert_response :forbidden
-    end
-  end
-
-  test "update requires board admin permission" do
-    logout_and_sign_in_as :jz
-
-    column = columns(:writebook_in_progress)
-    original_name = column.name
-
-    put board_column_path(boards(:writebook), column), params: { column: { name: "Updated Name" } }, as: :turbo_stream
-
-    assert_response :forbidden
-    assert_equal original_name, column.reload.name
-  end
-
-  test "destroy requires board admin permission" do
-    logout_and_sign_in_as :jz
-
-    column = columns(:writebook_on_hold)
-
-    assert_no_difference -> { boards(:writebook).columns.count } do
-      delete board_column_path(boards(:writebook), column), as: :turbo_stream
-      assert_response :forbidden
-    end
-  end
-
-  test "board creator can manage columns" do
-    logout_and_sign_in_as :david  # David is not admin but created writebook board
-
-    assert_difference -> { boards(:writebook).columns.count }, +1 do
-      post board_columns_path(boards(:writebook)), params: { column: { name: "Creator Column" } }, as: :turbo_stream
-      assert_response :success
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit cecccadc14bfbee03282a2b65bb08f27eeff655c.

See conversation at https://github.com/basecamp/fizzy/pull/1906, this is intended behavior.

cc @jzimdars @jeremy 