### PR TITLE
Fixed typo in VCR filters

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ VCR.configure do |config|
   config.allow_http_connections_when_no_cassette = true
   config.cassette_library_dir = "test/vcr_cassettes"
   config.hook_into :webmock
-  config.filter_sensitive_data("<OPEN_API_KEY>") { Rails.application.credentials.openai_api_key || ENV["OPEN_AI_API_KEY"] }
+  config.filter_sensitive_data("<OPEN_AI_KEY>") { Rails.application.credentials.openai_api_key || ENV["OPEN_AI_API_KEY"] }
   config.default_cassette_options = {
     match_requests_on: [ :method, :uri, :body ]
   }


### PR DESCRIPTION
I know it's a small thing, but I just noticed that :shrug:

Be careful if you reintroduce your old VCRs as they have `OPEN_API_KEY`