### PR TITLE
Prevent board names with only spaces and show validation message

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
 
       if (isEmpty) {
         event.preventDefault()
-        input.setCustomValidity(input.validationMessage || "Please fill out this field")
+        input.setCustomValidity(input.dataset.validationMessage || "Please fill out this field")
         input.reportValidity()
         input.addEventListener("input", () => input.setCustomValidity(""), { once: true })
       }

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -3,7 +3,7 @@
 <div class="panel panel--centered">
   <%= form_with model: @board, class: "flex flex-column gap", data: { controller: "form", action: "submit->form#preventEmptySubmit" } do |form| %>
     <h1 class="txt-x-large margin-none font-weight-black"><%= @page_title %></h1>
-    <%= form.text_field :name, required: true, class: "input full-width", autofocus: true, autocomplete: "off", placeholder: "Name it…", data: { form_target: "input", action: "keydown.esc@document->form#cancel" } %>
+    <%= form.text_field :name, required: true, class: "input full-width", autofocus: true, autocomplete: "off", placeholder: "Name it…", data: { form_target: "input", action: "keydown.esc@document->form#cancel", validation_message: "Board names can‘t be blank" } %>
 
     <button type="submit" class="btn btn--link center">
       <span>Create board</span>


### PR DESCRIPTION
- Use existing `preventEmptySubmit` method to ensure board names can't just be a bunch of spaces.
- Add support for customizable validation messages when submit fails

<img width="1078" height="446" alt="CleanShot 2025-12-04 at 11 43 22@2x" src="https://github.com/user-attachments/assets/44d0c97e-8a4c-4ef2-a363-3d63e0c6bffc" />
