### PR TITLE
Support OIDC user login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "trilogy", "~> 2.9"
 
 # Features
 gem "bcrypt", "~> 3.1.7"
+gem "omniauth_openid_connect", "~> 0.8.0"
+gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "geared_pagination", "~> 1.2"
 gem "rqrcode"
 gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,9 @@ GEM
       railties
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.3)
+    attr_required (1.0.2)
     autotuner (1.1.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1203.0)
@@ -155,6 +157,7 @@ GEM
     bcrypt_pbkdf (1.1.2)
     benchmark (0.5.0)
     bigdecimal (4.0.1)
+    bindata (2.5.1)
     bindex (0.8.1)
     bootsnap (1.22.0)
       msgpack (~> 1.2)
@@ -189,12 +192,22 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     ed25519 (1.4.0)
+    email_validator (2.2.4)
+      activemodel
     erb (6.0.1)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
     faker (3.6.0)
       i18n (>= 1.8.11, < 2)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -212,6 +225,8 @@ GEM
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashdiff (1.2.1)
+    hashie (5.1.0)
+      logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -232,6 +247,13 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.18.1)
+    json-jwt (1.17.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      base64
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     jwt (3.1.2)
       base64
     kamal (2.10.1)
@@ -284,6 +306,8 @@ GEM
     mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-http-persistent (4.0.8)
       connection_pool (>= 2.2.4, < 4)
     net-imap (0.6.3)
@@ -317,6 +341,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.8.0)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.3.1)
+      activemodel
+      attr_required (>= 1.0.0)
+      email_validator
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      mail
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_url
+      webfinger (~> 2.0)
     openssl (4.0.0)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -345,6 +393,17 @@ GEM
     rack (3.2.5)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
+    rack-oauth2 (2.3.0)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -450,6 +509,11 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
+    swd (2.0.3)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     thor (1.5.0)
     thruster (0.1.17)
     thruster (0.1.17-aarch64-linux)
@@ -468,10 +532,17 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
     uri (1.1.1)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     vcr (6.4.0)
     web-push (3.1.0)
       jwt (~> 3.0)
       openssl (>= 3.0)
+    webfinger (2.1.3)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -520,6 +591,8 @@ DEPENDENCIES
   mittens
   mocha
   net-http-persistent
+  omniauth-rails_csrf_protection (~> 1.0)
+  omniauth_openid_connect (~> 0.8.0)
   platform_agent
   propshaft
   puma (>= 5.0)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -9,7 +9,7 @@ module Authentication
 
     etag { Current.identity.id if authenticated? }
 
-    include Authentication::ViaMagicLink, LoginHelper
+    include Authentication::ViaMagicLink, Authentication::ViaOidc, LoginHelper
   end
 
   class_methods do
@@ -103,5 +103,19 @@ module Authentication
 
     def session_token
       cookies[:session_token]
+    end
+
+    def authentication_failed(message: "Something went wrong. Please try again.", redirect_path: new_session_path)
+      respond_to do |format|
+        format.html { redirect_to redirect_path, alert: message }
+        format.json { render json: { message: message }, status: :unauthorized }
+      end
+    end
+
+    def rate_limit_exceeded(message: "Try again later.", redirect_path: new_session_path)
+      respond_to do |format|
+        format.html { redirect_to redirect_path, alert: message }
+        format.json { render json: { message: message }, status: :too_many_requests }
+      end
     end
 end

--- a/app/controllers/concerns/authentication/via_oidc.rb
+++ b/app/controllers/concerns/authentication/via_oidc.rb
@@ -1,0 +1,15 @@
+module Authentication::ViaOidc
+  extend ActiveSupport::Concern
+
+  private
+    def authenticate_with_oidc(auth_hash)
+      identity = Identity.find_or_create_from_oidc(auth_hash)
+
+      if identity.present?
+        start_new_session_for identity
+        redirect_to after_authentication_url
+      else
+        authentication_failed(message: "Something went wrong using your identity provider.")
+      end
+    end
+end

--- a/app/controllers/sessions/magic_links_controller.rb
+++ b/app/controllers/sessions/magic_links_controller.rb
@@ -52,12 +52,7 @@ class Sessions::MagicLinksController < ApplicationController
 
     def email_address_mismatch
       clear_pending_authentication_token
-      alert_message = "Something went wrong. Please try again."
-
-      respond_to do |format|
-        format.html { redirect_to new_session_path, alert: alert_message }
-        format.json { render json: { message: alert_message }, status: :unauthorized }
-      end
+      authentication_failed
     end
 
     def invalid_code
@@ -76,11 +71,7 @@ class Sessions::MagicLinksController < ApplicationController
     end
 
     def rate_limit_exceeded
-      rate_limit_exceeded_message = "Try again in 15 minutes."
-      respond_to do |format|
-        format.html { redirect_to session_magic_link_path, alert: rate_limit_exceeded_message }
-        format.json { render json: { message: rate_limit_exceeded_message }, status: :too_many_requests }
-      end
+      super(message: "Try again in 15 minutes.", redirect_path: session_magic_link_path)
     end
 
     def requires_signup_completion?(magic_link)

--- a/app/controllers/sessions/oidc_controller.rb
+++ b/app/controllers/sessions/oidc_controller.rb
@@ -1,0 +1,27 @@
+class Sessions::OidcController < ApplicationController
+  disallow_account_scope
+  require_unauthenticated_access
+  rate_limit to: 10, within: 15.minutes, only: :create, with: :rate_limit_exceeded
+  skip_forgery_protection only: :create
+
+  layout "public"
+
+  def create
+    auth_hash = request.env["omniauth.auth"]
+
+    if auth_hash.present?
+      authenticate_with_oidc(auth_hash)
+    else
+      Rails.logger.debug "OIDC data not found"
+      authentication_failed(message: "OIDC authentication failed.")
+    end
+  rescue => e
+    Rails.error.report(e, severity: :error)
+    authentication_failed(message: "Error during OIDC authentication.")
+  end
+
+  def failure
+    error_type = params[:message] || "unknown_error"
+    authentication_failed(message: "OIDC authentication failed: #{error_type}")
+  end
+end

--- a/app/controllers/sessions/oidc_controller.rb
+++ b/app/controllers/sessions/oidc_controller.rb
@@ -1,7 +1,7 @@
 class Sessions::OidcController < ApplicationController
   disallow_account_scope
   require_unauthenticated_access
-  rate_limit to: 10, within: 15.minutes, only: :create, with: :rate_limit_exceeded
+  rate_limit to: ENV.fetch("OIDC_RATE_LIMIT", 10).to_i, within: 15.minutes, only: :create, with: :rate_limit_exceeded
   skip_forgery_protection only: :create
 
   layout "public"
@@ -10,18 +10,21 @@ class Sessions::OidcController < ApplicationController
     auth_hash = request.env["omniauth.auth"]
 
     if auth_hash.present?
+      Rails.logger.info "[OIDC] Callback for #{auth_hash.info&.email}"
       authenticate_with_oidc(auth_hash)
     else
-      Rails.logger.debug "OIDC data not found"
+      Rails.logger.warn "[OIDC] Data not found"
       authentication_failed(message: "OIDC authentication failed.")
     end
   rescue => e
+    Rails.logger.error "[OIDC] Authentication error: #{e.class} - #{e.message}"
     Rails.error.report(e, severity: :error)
     authentication_failed(message: "Error during OIDC authentication.")
   end
 
   def failure
     error_type = params[:message] || "unknown_error"
+    Rails.logger.warn "[OIDC] Failure: #{error_type}"
     authentication_failed(message: "OIDC authentication failed: #{error_type}")
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -41,15 +41,6 @@ class SessionsController < ApplicationController
       params.expect(:email_address)
     end
 
-    def rate_limit_exceeded
-      rate_limit_exceeded_message = "Try again later."
-
-      respond_to do |format|
-        format.html { redirect_to new_session_path, alert: rate_limit_exceeded_message }
-        format.json { render json: { message: rate_limit_exceeded_message }, status: :too_many_requests }
-      end
-    end
-
     def sign_in(identity)
       redirect_to_session_magic_link identity.send_magic_link
     end

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -14,4 +14,12 @@ module LoginHelper
   def redirect_to_logout_url
     redirect_to logout_url, allow_other_host: true
   end
+
+  def oidc_enabled?
+    ENV["OIDC_ISSUER"].present?
+  end
+
+  def oidc_required?
+    ENV["OIDC_REQUIRED"] == "true"
+  end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,5 +1,5 @@
 class Identity < ApplicationRecord
-  include Joinable, Transferable
+  include Joinable, OidcCompatible, Transferable
 
   has_many :access_tokens, dependent: :destroy
   has_many :magic_links, dependent: :destroy
@@ -12,6 +12,7 @@ class Identity < ApplicationRecord
   before_destroy :deactivate_users, prepend: true
 
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :oidc_subject, uniqueness: { scope: :oidc_provider }, allow_nil: true
   normalizes :email_address, with: ->(value) { value.strip.downcase.presence }
 
   def self.find_by_permissable_access_token(token, method:)

--- a/app/models/identity/oidc_compatible.rb
+++ b/app/models/identity/oidc_compatible.rb
@@ -1,0 +1,42 @@
+module Identity::OidcCompatible
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def find_or_create_from_oidc(auth_hash)
+      provider = auth_hash.provider
+      subject = auth_hash.uid
+      email = auth_hash.info.email
+      email_verified = auth_hash.extra.raw_info.email_verified || false
+
+      return nil unless subject.present? && email.present?
+
+      # First, try to find existing identity by OIDC subject
+      identity = find_by(oidc_subject: subject, oidc_provider: provider)
+
+      if identity
+        if email_verified && identity.email_address != email
+          identity.update(email_address: email)
+        end
+        return identity
+      end
+
+      # Next, try to find by email and link OIDC credentials
+      identity = find_by(email_address: email)
+
+      if identity
+        identity.update(
+          oidc_subject: subject,
+          oidc_provider: provider
+        )
+        return identity
+      end
+
+      # Create new identity with OIDC
+      create(
+        email_address: email,
+        oidc_subject: subject,
+        oidc_provider: provider
+      )
+    end
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,23 +3,36 @@
 <div class="panel panel--centered flex flex-column gap-half">
   <h1 class="txt-x-large font-weight-black margin-block-end">Get into Fizzy</h1>
 
-  <%= form_with url: session_path, class: "flex flex-column gap-half txt-medium" do |form| %>
-    <div class="flex align-center gap">
-      <label class="flex align-center gap input input--actor">
-        <%= form.email_field :email_address, required: true, class: "input txt-large full-width", autofocus: true, autocomplete: "username", placeholder: "Enter your email address…" %>
-      </label>
-    </div>
+  <% if oidc_enabled? %>
+    <%= button_to "Sign in with OIDC", "/auth/oidc",
+        method: :post,
+        data: { turbo: false },
+        class: "btn btn--primary center txt-medium margin-block-end" %>
 
-    <% if Account.accepting_signups? %>
-      <p><strong>New here?</strong> <%= link_to "Sign up", new_signup_path %> to create an account. <strong>Already have an account?</strong> Enter your email and we’ll get you signed in.</p>
-    <% else %>
-      <p>Enter your email and we’ll get you signed in.</p>
+    <% unless oidc_required? %>
+      <p class="txt-small txt-center txt-muted">Or sign in with email</p>
     <% end %>
+  <% end %>
 
-    <button type="submit" id="log_in" class="btn btn--link center txt-medium">
-      <span>Let’s go</span>
-      <%= icon_tag "arrow-right" %>
-    </button>
+  <% unless oidc_required? %>
+    <%= form_with url: session_path, class: "flex flex-column gap-half txt-medium" do |form| %>
+      <div class="flex align-center gap">
+        <label class="flex align-center gap input input--actor">
+          <%= form.email_field :email_address, required: true, class: "input txt-large full-width", autofocus: true, autocomplete: "username", placeholder: "Enter your email address…" %>
+        </label>
+      </div>
+
+      <% if Account.accepting_signups? %>
+        <p><strong>New here?</strong> <%= link_to "Sign up", new_signup_path %> to create an account. <strong>Already have an account?</strong> Enter your email and we'll get you signed in.</p>
+      <% else %>
+        <p>Enter your email and we'll get you signed in.</p>
+      <% end %>
+
+      <button type="submit" id="log_in" class="btn btn--link center txt-medium">
+        <span>Let's go</span>
+        <%= icon_tag "arrow-right" %>
+      </button>
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,8 +4,7 @@
   <h1 class="txt-x-large font-weight-black margin-block-end">Get into Fizzy</h1>
 
   <% if oidc_enabled? %>
-    <%= button_to "Sign in with OIDC", "/auth/oidc",
-        method: :post,
+    <%= link_to "Sign in with OIDC", "/auth/oidc",
         data: { turbo: false },
         class: "btn btn--primary center txt-medium margin-block-end" %>
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -15,3 +15,7 @@ end
 
 OmniAuth.config.allowed_request_methods = [ :get, :post ]
 OmniAuth.config.silence_get_warning = true
+OmniAuth.config.on_failure = Proc.new { |env|
+  Rails.logger.error "[OIDC] OmniAuth failure: #{env['omniauth.error']&.message || 'unknown'} (#{env['omniauth.error.type']})"
+  Rack::Response.new([ "302 Moved" ], 302, "Location" => "/auth/failure?message=#{env['omniauth.error.type']}").finish
+}

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,17 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  if ENV["OIDC_ISSUER"].present?
+    provider :openid_connect,
+      name: :oidc,
+      discovery: true,
+      issuer: ENV["OIDC_ISSUER"],
+      client_options: {
+        identifier: ENV["OIDC_CLIENT_ID"],
+        secret: ENV["OIDC_CLIENT_SECRET"],
+        redirect_uri: ENV.fetch("OIDC_REDIRECT_URI") { "#{ENV.fetch('BASE_URL', 'http://localhost:3000')}/auth/oidc/callback" }
+      },
+      scope: ENV.fetch("OIDC_SCOPES", "openid email profile").split
+  end
+end
+
+OmniAuth.config.allowed_request_methods = [ :get, :post ]
+OmniAuth.config.silence_get_warning = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,10 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/auth/oidc/callback", to: "sessions/oidc#create"
+  post "/auth/oidc/callback", to: "sessions/oidc#create"
+  get "/auth/failure", to: "sessions/oidc#failure"
+
   get "/signup", to: redirect("/signup/new")
 
   resource :signup, only: %i[ new create ] do

--- a/db/migrate/20260111000000_add_oidc_fields_to_identities.rb
+++ b/db/migrate/20260111000000_add_oidc_fields_to_identities.rb
@@ -1,0 +1,10 @@
+class AddOidcFieldsToIdentities < ActiveRecord::Migration[8.2]
+  def change
+    add_column :identities, :oidc_subject, :string, limit: 255
+    add_column :identities, :oidc_provider, :string, limit: 255
+
+    add_index :identities, [:oidc_subject, :oidc_provider],
+      unique: true,
+      name: "index_identities_on_oidc_subject_and_provider"
+  end
+end

--- a/db/schema_sqlite.rb
+++ b/db/schema_sqlite.rb
@@ -329,9 +329,12 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
   create_table "identities", id: :uuid, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email_address", limit: 255, null: false
+    t.string "oidc_provider", limit: 255
+    t.string "oidc_subject", limit: 255
     t.boolean "staff", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_identities_on_email_address", unique: true
+    t.index ["oidc_subject", "oidc_provider"], name: "index_identities_on_oidc_subject_and_provider", unique: true
   end
 
   create_table "identity_access_tokens", id: :uuid, force: :cascade do |t|

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -148,7 +148,10 @@ OIDC with a single provider is supported when the following variables are set.
 - `OIDC_CLIENT_ID`
 - `OIDC_CLIENT_SECRET`
 
-If you'd like to hide the magic-link login flow, you can set `OIDC_REQUIRED=true`.
+Optional variables
+
+- `OIDC_RATE_LIMIT` (defaults to 10; set to configure allowed OIDC login attempts within 15 minutes)
+- `OIDC_REQUIRED` (defaults to `false`; set to `true` to hide magic link login)
 
 #### Multi-tenant mode
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -140,6 +140,16 @@ If you're using a provider other than AWS, you will also need some of the follow
 - `S3_REQUEST_CHECKSUM_CALCULATION`
 - `S3_RESPONSE_CHECKSUM_VALIDATION`
 
+#### OIDC / OAuth2 Authentication
+
+OIDC with a single provider is supported when the following variables are set.
+
+- `OIDC_ISSUER`
+- `OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET`
+
+If you'd like to hide the magic-link login flow, you can set `OIDC_REQUIRED=true`.
+
 #### Multi-tenant mode
 
 By default, when you run the Fizzy Docker image you'll be limited to creating a single account (although that account can have as many users as you like).

--- a/docs/kamal-deployment.md
+++ b/docs/kamal-deployment.md
@@ -121,4 +121,5 @@ To enable OAuth2 login, set:
 
 Optional:
 
+- `OIDC_RATE_LIMIT` (defaults to 10; set to configure allowed OIDC login attempts within 15 minutes)
 - `OIDC_REQUIRED` (defaults to `false`; set to `true` to hide magic link login)

--- a/docs/kamal-deployment.md
+++ b/docs/kamal-deployment.md
@@ -111,3 +111,14 @@ Optional for S3-compatible endpoints:
 - `S3_REQUEST_CHECKSUM_CALCULATION` (defaults to `when_supported`)
 - `S3_RESPONSE_CHECKSUM_VALIDATION` (defaults to `when_supported`)
 
+### Configuring OIDC / OAuth2 authentication
+
+To enable OAuth2 login, set:
+
+- `OIDC_ISSUER`
+- `OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET`
+
+Optional:
+
+- `OIDC_REQUIRED` (defaults to `false`; set to `true` to hide magic link login)

--- a/test/controllers/sessions/oidc_controller_test.rb
+++ b/test/controllers/sessions/oidc_controller_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class Sessions::OidcControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:oidc] = nil
+  end
+
+  test "successful authentication creates session" do
+    sign_in_via_oidc(
+      uid: "oidc-123",
+      email: "test@example.com",
+      email_verified: true
+    )
+
+    untenanted do
+      identity = Identity.find_by(email_address: "test@example.com")
+      assert identity.present?
+      assert_equal "oidc-123", identity.oidc_subject
+      assert_equal "oidc", identity.oidc_provider
+    end
+  end
+
+  test "links OIDC to existing identity by email" do
+    existing = identities(:david)
+
+    sign_in_via_oidc(
+      uid: "oidc-456",
+      email: existing.email_address,
+      email_verified: true
+    )
+
+    untenanted do
+      existing.reload
+      assert_equal "oidc-456", existing.oidc_subject
+      assert_equal "oidc", existing.oidc_provider
+    end
+  end
+
+  test "handles authentication failure" do
+    OmniAuth.config.mock_auth[:oidc] = :invalid_credentials
+
+    untenanted do
+      get "/auth/failure", params: { message: "invalid_credentials" }
+
+      assert_redirected_to new_session_path
+      assert_not cookies[:session_token].present?
+    end
+  end
+
+  test "handles missing auth hash" do
+    untenanted do
+      # auth_hash will be nil
+      post "/auth/oidc/callback"
+
+      assert_redirected_to new_session_path
+      assert_match flash[:alert], "OIDC authentication failed."
+    end
+  end
+
+  test "handles identity creation failure" do
+    auth_hash = OmniAuth::AuthHash.new(
+      provider: "oidc",
+      uid: ""
+    )
+
+    OmniAuth.config.mock_auth[:oidc] = auth_hash
+
+    untenanted do
+      post "/auth/oidc/callback", env: { "omniauth.auth" => auth_hash }
+
+      assert_redirected_to new_session_path
+      assert_not cookies[:session_token].present?
+      assert_match flash[:alert], "Error during OIDC authentication."
+    end
+  end
+end

--- a/test/fixtures/identities.yml
+++ b/test/fixtures/identities.yml
@@ -15,3 +15,5 @@ kevin:
 
 mike:
   email_address: mike@37signals.com
+  oidc_subject: "google-oauth2|mike123"
+  oidc_provider: "oidc"

--- a/test/integration/oidc_authentication_flow_test.rb
+++ b/test/integration/oidc_authentication_flow_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class OidcAuthenticationFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:oidc] = nil
+  end
+
+  test "complete OIDC sign in flow for new user" do
+    sign_in_via_oidc(uid: "cory-123", email: "cory@73signals.com")
+
+    identity = Identity.find_by(email_address: "cory@73signals.com")
+    assert identity.present?
+    assert_equal "cory-123", identity.oidc_subject
+    assert_equal "oidc", identity.oidc_provider
+  end
+
+  test "OIDC sign in links to existing magic link user" do
+    existing = identities(:david)
+    original_count = Identity.count
+
+    sign_in_via_oidc(uid: "link-789", email: existing.email_address)
+
+    # Should link to existing Identity
+    assert_equal original_count, Identity.count
+
+    existing.reload
+    assert_equal "link-789", existing.oidc_subject
+    assert_equal "oidc", existing.oidc_provider
+  end
+
+  test "OIDC user can sign in multiple times" do
+    existing = identities(:mike)
+
+    sign_in_via_oidc(uid: "repeat-user", email: existing.email_address)
+    first_session_token = cookies[:session_token]
+
+    sign_out
+
+    sign_in_via_oidc(uid: "repeat-user", email: existing.email_address)
+    second_session_token = cookies[:session_token]
+
+    assert_not_equal first_session_token, second_session_token
+  end
+end

--- a/test/integration/oidc_multi_tenant_test.rb
+++ b/test/integration/oidc_multi_tenant_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class OidcMultiTenantTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:oidc] = nil
+  end
+
+  test "User created through OIDC flow can access their account in multi-tenant mode" do
+    with_multi_tenant_mode(true) do
+      sign_in_via_oidc(uid: "multi-tenant-user", email: "multitenant@example.com")
+
+      identity = Identity.find_by(email_address: "multitenant@example.com")
+      assert identity.present?
+      assert_equal "multi-tenant-user", identity.oidc_subject
+
+      account = accounts("37s")
+
+      Current.without_account do
+        identity.join(account)
+      end
+
+      get "#{account.slug}/cards"
+      assert_response :success, "User should be able to access their account after OIDC auth"
+    end
+  end
+
+  test "OIDC user with multiple accounts can access session menu" do
+    with_multi_tenant_mode(true) do
+      sign_in_via_oidc(uid: "multi-account-user", email: "multiaccounts@example.com")
+
+      identity = Identity.find_by(email_address: "multiaccounts@example.com")
+
+      account1 = accounts("37s")
+      account2 = accounts(:initech)
+
+      Current.without_account do
+        identity.join(account1)
+        identity.join(account2)
+      end
+
+      untenanted do
+        get session_menu_path
+        assert_response :success, "User should be able to access session menu"
+      end
+    end
+  end
+
+  test "OIDC links existing magic link user in multi-tenant mode" do
+    with_multi_tenant_mode(true) do
+      existing = identities(:david)
+      account = accounts("37s")
+      user = users(:david)
+
+      assert_equal account, user.account
+      assert_equal existing, user.identity
+
+      sign_in_via_oidc(uid: "david-oidc-link", email: existing.email_address)
+
+      existing.reload
+      assert_equal "david-oidc-link", existing.oidc_subject
+      assert_equal "oidc", existing.oidc_provider
+
+      get "#{account.slug}/cards"
+      assert_response :success, "User has access to their original account"
+    end
+  end
+end

--- a/test/models/identity/oidc_compatible_test.rb
+++ b/test/models/identity/oidc_compatible_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Identity::OidcCompatibleTest < ActiveSupport::TestCase
+  test "find_or_create_from_oidc creates new identity" do
+    auth_hash = build_oidc_auth_hash(
+      uid: "new-user-123",
+      email: "newoidc@example.com"
+    )
+
+    identity = Identity.find_or_create_from_oidc(auth_hash)
+
+    assert identity.persisted?
+    assert_equal "newoidc@example.com", identity.email_address
+    assert_equal "new-user-123", identity.oidc_subject
+    assert_equal "oidc", identity.oidc_provider
+  end
+
+  test "find_or_create_from_oidc links to existing identity by email" do
+    existing = identities(:david)
+
+    auth_hash = build_oidc_auth_hash(
+      uid: "link-123",
+      email: existing.email_address
+    )
+
+    identity = Identity.find_or_create_from_oidc(auth_hash)
+
+    assert_equal existing.id, identity.id
+    assert_equal "link-123", identity.oidc_subject
+  end
+
+  test "find_or_create_from_oidc finds by oidc_subject" do
+    existing = identities(:mike)
+
+    auth_hash = build_oidc_auth_hash(
+      uid: existing.oidc_subject,
+      email: "different@example.com", # Different email
+      email_verified: false
+    )
+
+    identity = Identity.find_or_create_from_oidc(auth_hash)
+
+    assert_equal existing.id, identity.id
+    # Email should NOT change if not verified
+    assert_equal existing.email_address, identity.email_address
+  end
+
+  test "find_or_create_from_oidc updates email when verified" do
+    existing = identities(:mike)
+    new_email = "updated@example.com"
+
+    auth_hash = build_oidc_auth_hash(
+      uid: existing.oidc_subject,
+      email: new_email,
+      email_verified: true
+    )
+
+    identity = Identity.find_or_create_from_oidc(auth_hash)
+
+    assert_equal existing.id, identity.id
+    assert_equal new_email, identity.email_address
+  end
+
+  test "find_or_create_from_oidc returns nil when missing required fields" do
+    # Missing uid
+    auth_hash = build_oidc_auth_hash(uid: nil, email: "test@example.com")
+    assert_nil Identity.find_or_create_from_oidc(auth_hash)
+
+    # Missing email
+    auth_hash = build_oidc_auth_hash(uid: "123", email: nil)
+    assert_nil Identity.find_or_create_from_oidc(auth_hash)
+  end
+
+  private
+    def build_oidc_auth_hash(uid:, email:, email_verified: true, name: "Test User")
+      OmniAuth::AuthHash.new(
+        provider: "oidc",
+        uid: uid,
+        info: { email: email, name: name },
+        extra: { raw_info: { email_verified: email_verified } }
+      )
+    end
+end


### PR DESCRIPTION
- Enable both initial registration via OIDC and automatic linking for previously created users
- Tested with Google Cloud OAuth2 and self-hosted Authentik
- Did some DRYing with standard `authentication_failed` and `rate_limit_exceeded` methods
- Updated Docker and Kamal instructions with appropriate variables


Optional env var `OIDC_REQUIRED=true` removes magic link login:

<img width="1632" height="1406" alt="image" src="https://github.com/user-attachments/assets/90a8a1bb-c7c2-4e31-93d7-1a0c6eb56952" />

But by default, when OIDC is configured, both are shown:

<img width="1752" height="1386" alt="image" src="https://github.com/user-attachments/assets/f9e15862-ee10-4f87-a56c-0ab86565491a" />
