### PR TITLE
Add column card counts to board menu items

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -219,4 +219,28 @@
       }
     }
   }
+
+  /* Board menu column counts
+  /* -------------------------------------------------------------------------- */
+
+  .board-menu-counts {
+    display: inline-flex;
+    gap: 0.25ch;
+    margin-inline-start: auto;
+    padding-inline-start: 1ch;
+    flex-shrink: 0;
+  }
+
+  .board-menu-count {
+    --card-color: var(--color-ink-light);
+
+    background-color: color-mix(in srgb, var(--card-color) 20%, transparent);
+    border-radius: 0.3em;
+    color: color-mix(in srgb, var(--card-color) 90%, var(--color-ink));
+    font-size: var(--text-xx-small);
+    font-weight: 600;
+    min-inline-size: 1.8em;
+    padding: 0.1em 0.4em;
+    text-align: center;
+  }
 }

--- a/app/controllers/my/menus_controller.rb
+++ b/app/controllers/my/menus_controller.rb
@@ -1,7 +1,7 @@
 class My::MenusController < ApplicationController
   def show
     @filters = Current.user.filters.all
-    @boards = Current.user.boards.ordered_by_recently_accessed
+    @boards = Current.user.boards.ordered_by_recently_accessed.includes(columns: :cards)
     @tags = Current.account.tags.all.alphabetically
     @users = Current.account.users.active.alphabetically
     @accounts = Current.identity.accounts.active

--- a/app/helpers/my/menu_helper.rb
+++ b/app/helpers/my/menu_helper.rb
@@ -66,18 +66,18 @@ module My::MenuHelper
 
       tag.span(class: "board-menu-counts") do
         counts = []
-        counts << board_count_tag(maybe_count) if maybe_count > 0
+        counts << board_count_tag(maybe_count, title: "Maybe?") if maybe_count > 0
         counts += columns.filter_map do |column|
           count = column.cards.active.size
-          board_count_tag(count, color: column.color) if count > 0
+          board_count_tag(count, color: column.color, title: column.name) if count > 0
         end
         safe_join(counts)
       end
     end
 
-    def board_count_tag(count, color: nil)
+    def board_count_tag(count, color: nil, title: nil)
       formatted_count = count > 99 ? "99+" : count.to_s
       style = "--card-color: #{color};" if color
-      tag.span(formatted_count, class: "board-menu-count", style: style)
+      tag.span(formatted_count, class: "board-menu-count", style: style, title: title)
     end
 end

--- a/app/helpers/my/menu_helper.rb
+++ b/app/helpers/my/menu_helper.rb
@@ -66,8 +66,11 @@ module My::MenuHelper
 
       tag.span(class: "board-menu-counts") do
         counts = []
-        counts << board_count_tag(maybe_count) if maybe_count > 0 || columns.any?
-        counts += columns.map { |column| board_count_tag(column.cards.active.size, color: column.color) }
+        counts << board_count_tag(maybe_count) if maybe_count > 0
+        counts += columns.filter_map do |column|
+          count = column.cards.active.size
+          board_count_tag(count, color: column.color) if count > 0
+        end
         safe_join(counts)
       end
     end

--- a/app/helpers/my/menu_helper.rb
+++ b/app/helpers/my/menu_helper.rb
@@ -19,7 +19,10 @@ module My::MenuHelper
 
   def my_menu_board_item(board)
     my_menu_item("board", board) do
-      link_to(tag.span(board.name, class: "overflow-ellipsis"), board, class: "popup__btn btn")
+      link_to(board, class: "popup__btn btn") do
+        tag.span(board.name, class: "overflow-ellipsis") +
+        board_column_counts_tag(board)
+      end
     end
   end
 
@@ -53,4 +56,25 @@ module My::MenuHelper
       icon_tag(item, class: "popup__icon") + yield
     end
   end
+
+  private
+    def board_column_counts_tag(board)
+      columns = board.columns.sorted
+      maybe_count = board.cards.awaiting_triage.size
+
+      return tag.span if columns.empty? && maybe_count.zero?
+
+      tag.span(class: "board-menu-counts") do
+        counts = []
+        counts << board_count_tag(maybe_count) if maybe_count > 0 || columns.any?
+        counts += columns.map { |column| board_count_tag(column.cards.active.size, color: column.color) }
+        safe_join(counts)
+      end
+    end
+
+    def board_count_tag(count, color: nil)
+      formatted_count = count > 99 ? "99+" : count.to_s
+      style = "--card-color: #{color};" if color
+      tag.span(formatted_count, class: "board-menu-count", style: style)
+    end
 end

--- a/test/helpers/my/menu_helper_test.rb
+++ b/test/helpers/my/menu_helper_test.rb
@@ -8,8 +8,8 @@ class My::MenuHelperTest < ActionView::TestCase
   test "board_column_counts_tag shows awaiting triage count first" do
     html = send(:board_column_counts_tag, @board)
 
-    # First count should be awaiting triage (no color style)
-    first_count = html.match(/<span class="board-menu-count">(\d+)<\/span>/)
+    # First count should be awaiting triage (no color style, has "Maybe?" title)
+    first_count = html.match(/<span class="board-menu-count" title="Maybe\?">(\d+)<\/span>/)
     assert first_count, "Should have a count without color for awaiting triage"
     assert_equal @board.cards.awaiting_triage.count.to_s, first_count[1]
   end

--- a/test/helpers/my/menu_helper_test.rb
+++ b/test/helpers/my/menu_helper_test.rb
@@ -17,9 +17,20 @@ class My::MenuHelperTest < ActionView::TestCase
   test "board_column_counts_tag shows column counts with colors" do
     html = send(:board_column_counts_tag, @board)
 
-    @board.columns.sorted.each do |column|
-      assert_match "--card-color: #{column.color};", html
-    end
+    # Verify that at least one column with cards shows its color
+    assert_match /--card-color:/, html
+  end
+
+  test "board_column_counts_tag excludes columns with zero cards" do
+    html = send(:board_column_counts_tag, @board)
+
+    # Count the number of colored badges in the output
+    colored_badges = html.scan(/--card-color:/).count
+
+    # Count columns that have active cards
+    columns_with_cards = @board.columns.sorted.count { |c| c.cards.active.size > 0 }
+
+    assert_equal columns_with_cards, colored_badges
   end
 
   test "board_column_counts_tag returns empty span when no columns and no cards" do

--- a/test/helpers/my/menu_helper_test.rb
+++ b/test/helpers/my/menu_helper_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class My::MenuHelperTest < ActionView::TestCase
+  setup do
+    @board = boards(:writebook)
+  end
+
+  test "board_column_counts_tag shows awaiting triage count first" do
+    html = send(:board_column_counts_tag, @board)
+
+    # First count should be awaiting triage (no color style)
+    first_count = html.match(/<span class="board-menu-count">(\d+)<\/span>/)
+    assert first_count, "Should have a count without color for awaiting triage"
+    assert_equal @board.cards.awaiting_triage.count.to_s, first_count[1]
+  end
+
+  test "board_column_counts_tag shows column counts with colors" do
+    html = send(:board_column_counts_tag, @board)
+
+    @board.columns.sorted.each do |column|
+      assert_match "--card-color: #{column.color};", html
+    end
+  end
+
+  test "board_column_counts_tag returns empty span when no columns and no cards" do
+    board = Board.new
+    board.define_singleton_method(:columns) { Column.none }
+    board.define_singleton_method(:cards) { Card.none }
+
+    html = send(:board_column_counts_tag, board)
+
+    assert_equal "<span></span>", html
+  end
+
+  test "board_count_tag formats count over 99 as 99+" do
+    html = send(:board_count_tag, 150)
+
+    assert_match "99+", html
+  end
+
+  test "board_count_tag includes color style when provided" do
+    html = send(:board_count_tag, 5, color: "var(--color-card-3)")
+
+    assert_match "--card-color: var(--color-card-3);", html
+  end
+
+  test "board_count_tag omits style when no color provided" do
+    html = send(:board_count_tag, 5)
+
+    assert_no_match(/style=/, html)
+  end
+end


### PR DESCRIPTION
<img width="497" height="235" alt="Снимок экрана 2026-01-15 в 19 04 18" src="https://github.com/user-attachments/assets/a1a6a703-f7b1-46f3-8e60-9ea43fb30d66" />

## Summary
- Display colored badge-style counts showing active cards per column in the jump menu
- Shows triage ("Maybe?") count first, followed by each column's count with its respective color
- Hides columns with zero active cards to keep the menu clean
- Adds native browser tooltips to show the column name on hover

## Changes
- Add `board_column_counts_tag` helper to render count badges
- Eager load columns and cards in menus controller for performance
- Add CSS styling for `.board-menu-counts` and `.board-menu-count`
- Add helper tests for the new functionality

## Test plan
- [ ] Visit the boards jump menu (press J)
- [ ] Verify each board shows colored counts for columns with active cards
- [ ] Verify zero-count columns are hidden
- [ ] Hover over counts to see column name tooltips
- [ ] Run `bin/rails test test/helpers/my/menu_helper_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)