### PR TITLE
Rollback plan for offline mode

### DIFF
--- a/app/controllers/pwa_controller.rb
+++ b/app/controllers/pwa_controller.rb
@@ -1,6 +1,7 @@
 class PwaController < ApplicationController
   disallow_account_scope
   skip_forgery_protection
+  allow_unauthenticated_access
 
   # We need a stable URL at the root, so we can't use the regular asset path here.
   def service_worker

--- a/app/javascript/initializers/index.js
+++ b/app/javascript/initializers/index.js
@@ -1,2 +1,3 @@
 import "initializers/current"
 import "initializers/bridge/bridge_element"
+import "initializers/offline_rollback"

--- a/app/javascript/initializers/offline_rollback.js
+++ b/app/javascript/initializers/offline_rollback.js
@@ -1,0 +1,1 @@
+navigator.serviceWorker?.register("/service-worker.js")

--- a/app/views/pwa/service_worker.js
+++ b/app/views/pwa/service_worker.js
@@ -1,3 +1,16 @@
+// Clear all offline mode caches and restore normal service worker behavior.
+// skipWaiting() ensures this activates immediately without requiring users
+// to close all tabs.
+self.addEventListener("install", (event) => {
+  self.skipWaiting()
+})
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((names) => Promise.all(names.map((name) => caches.delete(name))))
+  )
+})
+
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return
 


### PR DESCRIPTION
If offline mode (https://github.com/basecamp/fizzy/pull/2582) needs to be rolled back, deploy this branch to:
- Replace the service worker with one that clears all caches and uses `skipWaiting()` to activate immediately without requiring users to close all tabs
- Register the cleanup service worker via an initializer so browsers pick it up on next page load
- Allow unauthenticated access to the service worker endpoint since the `offline-mode` branch required auth