### PR TITLE
Add a simple way to open Cards by number

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -4,7 +4,7 @@ class SearchesController < ApplicationController
   def show
     @query = params[:q].blank? ? nil : params[:q]
 
-    if card = Current.user.accessible_cards.find_by_id(@query)
+    if card = find_card(@query)
       respond_to do |format|
         format.html { @card = card }
         format.json { set_page_and_extract_portion_from Current.user.accessible_cards.where(id: card.id) }
@@ -23,4 +23,16 @@ class SearchesController < ApplicationController
       end
     end
   end
+
+  private
+    def find_card(query)
+      return if query.blank?
+
+      if query.to_s.match?(/\A#?\d+\z/)
+        number = query.to_s.delete_prefix("#").to_i
+        Current.user.accessible_cards.find_by(number: number)
+      else
+        Current.user.accessible_cards.find_by(id: query)
+      end
+    end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -28,7 +28,7 @@ class SearchesController < ApplicationController
     def find_card(query)
       return if query.blank?
 
-      if query.to_s.match?(/\A#?\d+\z/)
+      if query.to_s.match?(/\A#\d+\z/)
         number = query.to_s.delete_prefix("#").to_i
         Current.user.accessible_cards.find_by(number: number)
       else

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -4,7 +4,7 @@ class SearchesController < ApplicationController
   def show
     @query = params[:q].blank? ? nil : params[:q]
 
-    if card = find_card(@query)
+    if card = Current.user.accessible_cards.find_by(number: @query)
       respond_to do |format|
         format.html { @card = card }
         format.json { set_page_and_extract_portion_from Current.user.accessible_cards.where(id: card.id) }
@@ -23,16 +23,4 @@ class SearchesController < ApplicationController
       end
     end
   end
-
-  private
-    def find_card(query)
-      return if query.blank?
-
-      if query.to_s.match?(/\A#\d+\z/)
-        number = query.to_s.delete_prefix("#").to_i
-        Current.user.accessible_cards.find_by(number: number)
-      else
-        Current.user.accessible_cards.find_by(id: query)
-      end
-    end
 end

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -40,6 +40,14 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     get search_path(q: @card.id, script_name: "/#{@account.external_account_id}")
     assert_select "form[data-controller='auto-submit']"
 
+    # Searching by card number
+    get search_path(q: @card.number, script_name: "/#{@account.external_account_id}")
+    assert_select "form[data-controller='auto-submit']"
+
+    # Searching by card number with hash prefix
+    get search_path(q: "##{@card.number}", script_name: "/#{@account.external_account_id}")
+    assert_select "form[data-controller='auto-submit']"
+
     # Searching with non-existent card id
     get search_path(q: "999999", script_name: "/#{@account.external_account_id}")
     assert_select "form[data-controller='auto-submit']", count: 0

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -40,9 +40,9 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     get search_path(q: @card.id, script_name: "/#{@account.external_account_id}")
     assert_select "form[data-controller='auto-submit']"
 
-    # Searching by card number
+    # Searching by card number without prefix uses full search (no direct redirect)
     get search_path(q: @card.number, script_name: "/#{@account.external_account_id}")
-    assert_select "form[data-controller='auto-submit']"
+    assert_select "form[data-controller='auto-submit']", count: 0
 
     # Searching by card number with hash prefix
     get search_path(q: "##{@card.number}", script_name: "/#{@account.external_account_id}")

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -36,19 +36,16 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_select "li .search__excerpt--comment", text: /I love haggis/ # one entry for the comment
     assert_match(/<mark class="circled-text"><span><\/span>haggis<\/mark>/, response.body)
 
-    # Searching by card id
-    get search_path(q: @card.id, script_name: "/#{@account.external_account_id}")
-    assert_select "form[data-controller='auto-submit']"
-
-    # Searching by card number without prefix uses full search (no direct redirect)
+    # Searching by card number
     get search_path(q: @card.number, script_name: "/#{@account.external_account_id}")
-    assert_select "form[data-controller='auto-submit']", count: 0
-
-    # Searching by card number with hash prefix
-    get search_path(q: "##{@card.number}", script_name: "/#{@account.external_account_id}")
     assert_select "form[data-controller='auto-submit']"
 
-    # Searching with non-existent card id
+    # Searching by the number of a card the user cannot access
+    get search_path(q: hidden_card.number, script_name: "/#{@account.external_account_id}")
+    assert_select "form[data-controller='auto-submit']", count: 0
+    assert_select ".search__blank-slate", text: "No matches"
+
+    # Searching with non-existent card number
     get search_path(q: "999999", script_name: "/#{@account.external_account_id}")
     assert_select "form[data-controller='auto-submit']", count: 0
     assert_select ".search__blank-slate", text: "No matches"
@@ -64,8 +61,8 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Layout is broken", body.first["title"]
   end
 
-  test "search by card ID as JSON returns array" do
-    get search_path(q: @card.id, script_name: "/#{@account.external_account_id}"), as: :json
+  test "search by card number as JSON returns array" do
+    get search_path(q: @card.number, script_name: "/#{@account.external_account_id}"), as: :json
     assert_response :success
 
     body = @response.parsed_body
@@ -106,4 +103,11 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     # But should preserve highlight marks around "testing"
     assert_match(/<mark class="circled-text"><span><\/span>testing<\/mark>/, response.body)
   end
+
+  private
+    def hidden_card
+      hidden_board = Board.create!(name: "Hidden Board", account: @account, creator: @user)
+      hidden_board.accesses.revoke_from(@user)
+      hidden_board.cards.create!(title: "Hidden card", status: "published", creator: @user)
+    end
 end


### PR DESCRIPTION
Following up on the discussion in https://github.com/basecamp/fizzy/discussions/2190 i added a possibility to easy open a ticket by entering the number.

## Summary

- Extend the global search behavior so that numeric queries (e.g. `#123`) are interpreted as card numbers.
- Reuse the existing redirect behavior used for `card.id` lookups so that searching by ticket number jumps straight to the card page.
- Add controller tests to cover searching by card id, card number, and card number with a `#` prefix.

## Details

The `SearchesController` previously only tried to treat the query (`q`) as a `card.id` via:

- `Current.user.accessible_cards.find_by_id(@query)`

This meant that users could not quickly jump to a card by the visible ticket number they see in the UI.

This change introduces a small `find_card` helper in `SearchesController`:

- If `q` matches `\A#?\d+\z`, we treat it as a card **number** (with an optional `#` prefix) and look it up via `Current.user.accessible_cards.find_by(number: number)`.
- Otherwise, we fall back to the existing behavior of looking up by `id`.

If a card is found, the search page behaves as before and auto-submits a form that redirects to the card show page.

## Testing

- `mise exec -- bin/rails test test/controllers/searches_controller_test.rb`

The controller test now verifies:

- Searching by card id still redirects correctly.
- Searching by `q: "#{@card.number}"` redirects to the card.
- Nonexistent ids still show the “No matches” blank slate.

https://github.com/user-attachments/assets/3fe52d75-a9cb-404d-a27a-4af18a7f0789

