### PR TITLE
fix: Add tooltip controller to reactions trigger button

### DIFF
--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -6,8 +6,8 @@
 
     <%= turbo_frame_tag reactable, :new_reaction do %>
       <%= link_to new_polymorphic_path([ *reaction_path_prefix_for(reactable), :reaction ]), role: "button",
-            class: "reactions__trigger btn btn--circle", action: "soft-keyboard#open",
-            data: { controller: "tooltip", turbo_frame: dom_id(reactable, :new_reaction), action: "dialog#close" } do %>
+            class: "reactions__trigger btn btn--circle",
+            data: { controller: "tooltip soft-keyboard", turbo_frame: dom_id(reactable, :new_reaction), action: "dialog#close soft-keyboard#open" } do %>
         <%= image_tag "boost-color.svg", aria: { hidden: true } %>
         <span class="for-screen-reader">Add your own reaction</span>
       <% end %>

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -7,7 +7,7 @@
     <%= turbo_frame_tag reactable, :new_reaction do %>
       <%= link_to new_polymorphic_path([ *reaction_path_prefix_for(reactable), :reaction ]), role: "button",
             class: "reactions__trigger btn btn--circle", action: "soft-keyboard#open",
-            data: { turbo_frame: dom_id(reactable, :new_reaction), action: "dialog#close" } do %>
+            data: { controller: "tooltip", turbo_frame: dom_id(reactable, :new_reaction), action: "dialog#close" } do %>
         <%= image_tag "boost-color.svg", aria: { hidden: true } %>
         <span class="for-screen-reader">Add your own reaction</span>
       <% end %>


### PR DESCRIPTION
add a missing data-controller="tooltip" attribute on the reactions trigger button

<img width="343" height="309" alt="Screenshot 2026-03-27 at 10 10 37" src="https://github.com/user-attachments/assets/e3c07c89-b963-4352-abb9-15494c219c6d" />
