### PR TITLE
Fix store_accessor on MariaDB by declaring JSON attribute type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,17 +25,23 @@ jobs:
             db_adapter: sqlite
           - mode: MySQL
             db_adapter: mysql
+            db_image: mysql:8.0
+            db_health: mysqladmin ping
+          - mode: MariaDB
+            db_adapter: mysql
+            db_image: mariadb:11
+            db_health: healthcheck.sh --connect --innodb_initialized
 
     services:
-      mysql:
-        image: mysql:8.0
+      db:
+        image: ${{ matrix.db_image || 'mysql:8.0' }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: fizzy_test
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="${{ matrix.db_health || 'mysqladmin ping' }}"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3

--- a/app/models/event/particulars.rb
+++ b/app/models/event/particulars.rb
@@ -2,6 +2,7 @@ module Event::Particulars
   extend ActiveSupport::Concern
 
   included do
+    attribute :particulars, :json
     store_accessor :particulars, :assignee_ids
   end
 

--- a/app/models/filter/fields.rb
+++ b/app/models/filter/fields.rb
@@ -30,6 +30,7 @@ module Filter::Fields
   end
 
   included do
+    attribute :fields, :json
     store_accessor :fields, :assignment_status, :indexed_by, :sorted_by, :terms,
       :card_ids, :creation, :closure
 

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -13,7 +13,7 @@ logo_assignment_jz:
   board: writebook_uuid
   eventable: logo_uuid (Card)
   action: card_assigned
-  particulars: <%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("jz", :uuid) ] }.to_json %>
+  particulars: '<%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("jz", :uuid) ] }.to_json %>'
   created_at: <%= 1.week.ago + 1.hour %>
   account: 37s_uuid
 
@@ -23,7 +23,7 @@ logo_assignment_david:
   board: writebook_uuid
   eventable: logo_uuid (Card)
   action: card_assigned
-  particulars: <%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("david", :uuid) ] }.to_json %>
+  particulars: '<%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("david", :uuid) ] }.to_json %>'
   created_at: <%= 1.week.ago + 1.hour %>
   account: 37s_uuid
 
@@ -33,7 +33,7 @@ logo_assignment_km:
   board: writebook_uuid
   eventable: logo_uuid (Card)
   action: card_assigned
-  particulars: <%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("kevin", :uuid) ] }.to_json %>
+  particulars: '<%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("kevin", :uuid) ] }.to_json %>'
   created_at: <%= 1.day.ago %>
   account: 37s_uuid
 
@@ -61,7 +61,7 @@ layout_assignment_jz:
   board: writebook_uuid
   eventable: layout_uuid (Card)
   action: card_assigned
-  particulars: <%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("jz", :uuid) ] }.to_json %>
+  particulars: '<%= { assignee_ids: [ ActiveRecord::FixtureSet.identify("jz", :uuid) ] }.to_json %>'
   created_at: <%= 1.hour.ago %>
   account: 37s_uuid
 

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -1,6 +1,6 @@
 jz_assignments:
   id: <%= ActiveRecord::FixtureSet.identify("jz_assignments", :uuid) %>
   creator: david_uuid
-  fields: <%= { indexed_by: :all, sorted_by: :newest }.to_json %>
+  fields: '<%= { indexed_by: :all, sorted_by: :newest }.to_json %>'
   params_digest: <%= Filter.digest_params({ indexed_by: :all, sorted_by: :newest, tag_ids: [ ActiveRecord::FixtureSet.identify("mobile", :uuid) ], assignee_ids: [ ActiveRecord::FixtureSet.identify("jz", :uuid) ] }) %>
   account: 37s_uuid


### PR DESCRIPTION
## Summary

- Fixes `store_accessor` crash when running Fizzy on MariaDB by adding explicit `attribute :column, :json` declarations to `Filter::Fields` and `Event::Particulars`
- MariaDB represents JSON columns as `LONGTEXT` internally, causing Rails to map them to `Type::Text` which is not a recognized store type
- On MySQL this change is a no-op since the columns are already typed as `Type::Json`

Fixes #2402

## The problem

MariaDB implements JSON as an alias for `LONGTEXT` with a `CHECK (json_valid(...))` constraint. When ActiveRecord introspects the column, it sees `longtext` and maps it to `Type::Text`. Calling `store_accessor` then fails because `Type::Text` is not a recognized store type:

```
ActiveRecord::ConfigurationError: the column 'fields' has not been configured as a store.
Please make sure the column is declared serializable via 'ActiveRecord.store' or, if your
database supports it, use a structured column type like hstore or json.
```

## Why `attribute :column, :json` over `store :column, coder: JSON`

The workaround suggested in the issue (`store :fields, coder: JSON`) works, but introduces unnecessary complexity on MySQL:

1. **Adds a serialization layer that isn't needed.** `store` wraps the column in `Type::Serialized` with an `IndifferentCoder`. On MySQL, where the column is already native JSON, this stacks an extra encoding/decoding layer on top of what the database handles natively.

2. **Changes the accessor type.** `Type::Json` uses `StringKeyedHashAccessor` (string keys, matching JSON semantics). `Type::Serialized` switches to `IndifferentHashAccessor` (`HashWithIndifferentAccess`) — a subtle behavior change for any code accessing the underlying attribute hash directly.

`attribute :column, :json` avoids both issues. It simply tells Rails "this column is JSON" regardless of what the database adapter reports. On MySQL it's a no-op; on MariaDB it overrides `Type::Text` with `Type::Json`. No extra layers, no behavior changes.

This is the same approach recommended in [rails/rails#44997](https://github.com/rails/rails/issues/44997), where the Rails community converged on `attribute :column, :json` as the correct fix for MariaDB's `LONGTEXT`-backed JSON columns.

## Reproduction

<details>
<summary>Standalone reproduction script (requires MariaDB on port 3307)</summary>

**Setup:**
```bash
docker run -d \
  --name fizzy-mariadb-test \
  -e MARIADB_ROOT_PASSWORD=test \
  -e MARIADB_DATABASE=fizzy_repro \
  -p 3307:3306 \
  mariadb:11

ruby repro_2402.rb
```

**Script (`repro_2402.rb`):**
```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "activerecord", github: "rails/rails", branch: "main"
  gem "trilogy"
end

require "active_record"
require "trilogy"

# Connect to MariaDB
ActiveRecord::Base.establish_connection(
  adapter:  "trilogy",
  host:     "127.0.0.1",
  port:     3307,
  username: "root",
  password: "test",
  database: "fizzy_repro"
)

# Create a table with a JSON column (MariaDB stores this as LONGTEXT internally)
ActiveRecord::Schema.define do
  create_table :filters, id: :uuid, force: true do |t|
    t.json :fields, null: false, default: -> { "(json_object())" }
  end

  create_table :events, id: :uuid, force: true do |t|
    t.json :particulars, default: -> { "(json_object())" }
  end
end

# Verify MariaDB reports the column as longtext, not json
col = ActiveRecord::Base.connection.columns("filters").find { |c| c.name == "fields" }
puts "\n=== Column metadata ==="
puts "Column: #{col.name}"
puts "SQL type: #{col.sql_type}"
puts "AR type:  #{ActiveRecord::Base.connection.send(:type_map).lookup(col.sql_type).class}"
puts ""

# -------------------------------------------------------
# STEP 1: Reproduce the error (no fix applied)
# -------------------------------------------------------
puts "=== Without fix: bare store_accessor ==="

class FilterBroken < ActiveRecord::Base
  self.table_name = "filters"
  store_accessor :fields, :indexed_by, :sorted_by
end

begin
  f = FilterBroken.new
  f.indexed_by = "all"
  puts "ERROR: should have raised, but got: #{f.indexed_by}"
rescue ActiveRecord::ConfigurationError, NoMethodError => e
  puts "Got expected error: #{e.message}"
end

# -------------------------------------------------------
# STEP 2: Verify the issue's suggested fix works
# -------------------------------------------------------
puts "\n=== With issue's workaround: store :fields, coder: JSON ==="

class FilterStoreWorkaround < ActiveRecord::Base
  self.table_name = "filters"
  before_create { self.id ||= SecureRandom.uuid }
  store :fields, coder: JSON
  store_accessor :fields, :indexed_by, :sorted_by
end

begin
  f = FilterStoreWorkaround.new
  f.indexed_by = "all"
  f.save!
  f.reload
  puts "OK: indexed_by = #{f.indexed_by.inspect}"
  puts "     Accessor type: #{FilterStoreWorkaround.type_for_attribute(:fields).class}"
rescue => e
  puts "Failed: #{e.message}"
end

# -------------------------------------------------------
# STEP 3: Verify our fix works
# -------------------------------------------------------
puts "\n=== With our fix: attribute :fields, :json ==="

class FilterFixed < ActiveRecord::Base
  self.table_name = "filters"
  before_create { self.id ||= SecureRandom.uuid }
  attribute :fields, :json
  store_accessor :fields, :indexed_by, :sorted_by
end

begin
  f = FilterFixed.new
  f.indexed_by = "all"
  f.save!
  f.reload
  puts "OK: indexed_by = #{f.indexed_by.inspect}"
  puts "     Accessor type: #{FilterFixed.type_for_attribute(:fields).class}"
rescue => e
  puts "Failed: #{e.message}"
end

# -------------------------------------------------------
# STEP 4: Compare accessor types across all approaches
# -------------------------------------------------------
puts "\n=== Comparing accessor types ==="
puts "FilterBroken    (no fix):        #{FilterBroken.type_for_attribute(:fields).class}" rescue nil
puts "FilterStoreWorkaround (store):   #{FilterStoreWorkaround.type_for_attribute(:fields).class}"
puts "FilterFixed     (attribute):     #{FilterFixed.type_for_attribute(:fields).class}"

puts "\n=== Done ==="
```

**Expected output:**
```
=== Column metadata ===
Column: fields
SQL type: longtext
AR type:  ActiveRecord::Type::Text

=== Without fix: bare store_accessor ===
Got expected error: the column 'fields' has not been configured as a store. ...

=== With issue's workaround: store :fields, coder: JSON ===
OK: indexed_by = "all"
     Accessor type: ActiveRecord::Type::Serialized

=== With our fix: attribute :fields, :json ===
OK: indexed_by = "all"
     Accessor type: ActiveRecord::Type::Json

=== Comparing accessor types ===
FilterBroken    (no fix):        ActiveRecord::Type::Text
FilterStoreWorkaround (store):   ActiveRecord::Type::Serialized
FilterFixed     (attribute):     ActiveRecord::Type::Json
```

</details>


