### PR TITLE
Pretty-print dev server URL and login in `bin/dev`

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -4,6 +4,15 @@ PORT=3006
 USE_TAILSCALE=0
 USE_PUSH=0
 
+if [ -t 1 ]; then
+  c_bar='\033[2m▎\033[0m'    # dim bar
+  c_label='\033[37m'         # gray
+  c_url='\033[96m'           # light blue
+  c_reset='\033[0m'
+else
+  c_bar='▎' c_label='' c_url='' c_reset=''
+fi
+
 for arg in "$@"; do
   case $arg in
     --tailscale) USE_TAILSCALE=1 ;;
@@ -58,9 +67,15 @@ if [ "$USE_TAILSCALE" = "1" ]; then
     echo "Error: tailscale serve failed. On Linux, run once: sudo tailscale set --operator=\$USER" >&2
     exit 1
   fi
-  echo "Login with david@example.com to: https://$TS_HOSTNAME:$TS_PORT/"
+  printf "\n"
+  printf " ${c_bar} ${c_label}URL${c_reset}     ${c_url}https://$TS_HOSTNAME:$TS_PORT/${c_reset}\n"
+  printf " ${c_bar} ${c_label}Login${c_reset}   david@example.com\n"
+  printf "\n"
 else
-  echo "Login with david@example.com to: http://fizzy.localhost:$PORT/"
+  printf "\n"
+  printf " ${c_bar} ${c_label}URL${c_reset}     ${c_url}http://fizzy.localhost:$PORT/${c_reset}\n"
+  printf " ${c_bar} ${c_label}Login${c_reset}   david@example.com\n"
+  printf "\n"
 fi
 
 ./bin/rails server -b 0.0.0.0 -p $PORT

--- a/bin/dev
+++ b/bin/dev
@@ -4,7 +4,6 @@ PORT=3006
 USE_TAILSCALE=0
 USE_PUSH=0
 
-# Set up colors for terminal output
 if [ -t 1 ]; then
   c_bar='\033[2m▎\033[0m'    # dim
   c_label='\033[37m'         # gray

--- a/bin/dev
+++ b/bin/dev
@@ -67,15 +67,14 @@ if [ "$USE_TAILSCALE" = "1" ]; then
     echo "Error: tailscale serve failed. On Linux, run once: sudo tailscale set --operator=\$USER" >&2
     exit 1
   fi
-  printf "\n"
-  printf " ${c_bar} ${c_label}URL${c_reset}     ${c_url}https://$TS_HOSTNAME:$TS_PORT/${c_reset}\n"
-  printf " ${c_bar} ${c_label}Login${c_reset}   david@example.com\n"
-  printf "\n"
+  DEV_URL="https://$TS_HOSTNAME:$TS_PORT/"
 else
-  printf "\n"
-  printf " ${c_bar} ${c_label}URL${c_reset}     ${c_url}http://fizzy.localhost:$PORT/${c_reset}\n"
-  printf " ${c_bar} ${c_label}Login${c_reset}   david@example.com\n"
-  printf "\n"
+  DEV_URL="http://fizzy.localhost:$PORT/"
 fi
+
+printf "\n"
+printf " ${c_bar} ${c_label}URL${c_reset}     ${c_url}${DEV_URL}${c_reset}\n"
+printf " ${c_bar} ${c_label}Login${c_reset}   david@example.com\n"
+printf "\n"
 
 ./bin/rails server -b 0.0.0.0 -p $PORT

--- a/bin/dev
+++ b/bin/dev
@@ -4,10 +4,11 @@ PORT=3006
 USE_TAILSCALE=0
 USE_PUSH=0
 
+# Set up colors for terminal output
 if [ -t 1 ]; then
-  c_bar='\033[2m▎\033[0m'    # dim bar
+  c_bar='\033[2m▎\033[0m'    # dim
   c_label='\033[37m'         # gray
-  c_url='\033[96m'           # light blue
+  c_url='\033[96m'           # cyan
   c_reset='\033[0m'
 else
   c_bar='▎' c_label='' c_url='' c_reset=''


### PR DESCRIPTION
This PR improves the appearance of the URL and login info when running `bin/dev`.

**Before:**

<img width="741" alt="Screenshot 2026-04-07 at 18 22 09@2x" src="https://github.com/user-attachments/assets/2a5a4ccf-090e-45d8-b7a0-e0fbf495d681" /><br/>

**After:**

<img width="741" alt="Screenshot 2026-04-07 at 18 21 41@2x" src="https://github.com/user-attachments/assets/db716239-eac7-4cad-8333-e283d4052fad" />

