### PR TITLE
Flush auto-save before publishing card on Cmd (Ctrl) + Enter

### DIFF
--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -5,6 +5,7 @@ const AUTOSAVE_INTERVAL = 3000
 
 export default class extends Controller {
   #timer
+  #savePromise
 
   // Lifecycle
 
@@ -17,6 +18,8 @@ export default class extends Controller {
   async submit() {
     if (this.#dirty) {
       await this.#save()
+    } else if (this.#savePromise) {
+      await this.#savePromise
     }
   }
 
@@ -34,7 +37,12 @@ export default class extends Controller {
 
   async #save() {
     this.#resetTimer()
-    await submitForm(this.element)
+    this.#savePromise = submitForm(this.element)
+    try {
+      await this.#savePromise
+    } finally {
+      this.#savePromise = null
+    }
   }
 
   #resetTimer() {

--- a/app/javascript/controllers/clicker_controller.js
+++ b/app/javascript/controllers/clicker_controller.js
@@ -3,8 +3,13 @@ import { nextFrame } from "helpers/timing_helpers";
 
 export default class extends Controller {
   static targets = [ "clickable" ]
+  static outlets = [ "auto-save" ]
 
   async click() {
+    if (this.hasAutoSaveOutlet) {
+      await this.autoSaveOutlet.submit()
+    }
+
     await nextFrame()
     this.#clickable.click()
   }

--- a/app/views/cards/container/footer/_create.html.erb
+++ b/app/views/cards/container/footer/_create.html.erb
@@ -3,13 +3,15 @@
     <%= button_to card_publish_path(card), name: "creation_type", value: "add", class: "btn",
           title: "Create card (#{ hotkey_label(["ctrl", "enter"]) })",
           form: { data: { controller: "form bridge--form" } },
-          data: { form_target: "submit", bridge__form_target: "submit", controller: "clicker", action: "keydown.ctrl+enter@document->clicker#click keydown.meta+enter@document->clicker#click" } do %>
+          data: { form_target: "submit", bridge__form_target: "submit", controller: "clicker", clicker_auto_save_outlet: "#card_form",
+                  action: "keydown.ctrl+enter@document->clicker#click keydown.meta+enter@document->clicker#click" } do %>
       <span>Create card</span>
     <% end %>
 
     <%= button_to card_publish_path(card), method: :post, class: "btn btn--reversed", name: "creation_type", value: "add_another",
           title: "Create and add another (#{ hotkey_label(["ctrl", "shift", "enter"]) })", form: { data: { controller: "form" } },
-          data: { form_target: "submit", controller: "clicker", action: "keydown.ctrl+shift+enter@document->clicker#click keydown.meta+shift+enter@document->clicker#click" } do %>
+          data: { form_target: "submit", controller: "clicker", clicker_auto_save_outlet: "#card_form",
+                  action: "keydown.ctrl+shift+enter@document->clicker#click keydown.meta+shift+enter@document->clicker#click" } do %>
       <span>Create and add another</span>
     <% end %>
   </div>


### PR DESCRIPTION
Fixes #2778

Typing a card title quickly and hitting Cmd (Ctrl) + Enter could publish the card before auto-save finished, showing a stale title on the board (correct after reload).

Cmd+Enter fires two concurrent async handlers: `auto-save#submit` starts the PATCH, and `clicker#click` waits one animation frame (~16ms) then clicks the publish button. The publish redirect renders the board before the save round-trip completes.

**Solution**: wire the clicker to the auto-save controller via a Stimulus outlet so it awaits the pending save before clicking publish.

**Before:**

https://github.com/user-attachments/assets/76d94e3e-9ec4-4ce4-93bd-4e0634fb870c

**After:**

https://github.com/user-attachments/assets/0cd4b701-e0d1-4858-a18d-1b7ab05b0a2b


