### PR TITLE
Add indexed_by=maybe to cards

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -30,6 +30,7 @@ class Card < ApplicationRecord
     when "stalled" then stalled
     when "postponing_soon" then postponing_soon
     when "closed" then closed
+    when "maybe" then awaiting_triage
     when "not_now" then postponed.latest
     when "golden" then golden
     when "draft" then drafted

--- a/docs/api/sections/cards.md
+++ b/docs/api/sections/cards.md
@@ -17,7 +17,7 @@ __Query Parameters:__
 | `closer_ids[]` | Filter by user ID(s) who closed the cards |
 | `card_ids[]` | Filter to specific card ID(s) |
 | `column_ids[]` | Filter by workflow column ID(s) |
-| `indexed_by` | Filter by: `all` (default), `closed`, `not_now`, `stalled`, `postponing_soon`, `golden` |
+| `indexed_by` | Filter by: `all` (default), `maybe`, `closed`, `not_now`, `stalled`, `postponing_soon`, `golden` |
 | `sorted_by` | Sort order: `latest` (default), `newest`, `oldest` |
 | `assignment_status` | Filter by assignment status: `unassigned` |
 | `creation` | Filter by creation date: `today`, `yesterday`, `thisweek`, `lastweek`, `thismonth`, `lastmonth`, `thisyear`, `lastyear` |

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -29,6 +29,13 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ cards(:logo).number, cards(:layout).number, cards(:text).number ].sort, @response.parsed_body.pluck("number").sort
   end
 
+  test "index as JSON can filter by maybe index" do
+    get cards_path(format: :json), params: { indexed_by: "maybe" }
+    assert_response :success
+
+    assert_equal [ cards(:buy_domain).number ], @response.parsed_body.pluck("number")
+  end
+
   test "create a new draft" do
     assert_difference -> { Card.count }, 1 do
       post board_cards_path(boards(:writebook))

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -23,6 +23,9 @@ class FilterTest < ActiveSupport::TestCase
     filter = users(:david).filters.new indexed_by: "closed"
     assert_equal [ cards(:shipping) ], filter.cards
 
+    filter = users(:david).filters.new indexed_by: "maybe", board_ids: [ boards(:writebook).id ]
+    assert_equal [ cards(:buy_domain) ], filter.cards
+
     cards(:shipping).postpone
     filter = users(:david).filters.new indexed_by: "not_now"
     assert_includes filter.cards, cards(:shipping)


### PR DESCRIPTION
### Summary
This adds `indexed_by=maybe` to `GET /:account_slug/cards` so API clients can ask the cards endpoint for awaiting-triage / "Maybe?" cards.

### What wasn't possible before
Before this change, `GET /:account_slug/cards` supported `indexed_by=closed` and `indexed_by=not_now`, but there was no equivalent way to ask that same endpoint for awaiting-triage cards.

Clients that wanted "Maybe?" cards had to either:
- fetch a broader `/cards` result set and filter client-side for cards with no workflow column, or
- switch to the board-scoped stream endpoint instead of using `/cards`

That made the cards endpoint asymmetric: Done and Not Now were directly filterable there, but Maybe? was not.

### What this PR adds
- support `indexed_by=maybe` on `GET /:account_slug/cards`
- route that filter to awaiting-triage cards
- document the new `indexed_by` value
- add model and controller coverage

### Example
- `GET /:account_slug/cards?indexed_by=maybe`
