### PR TITLE
Fix missing partial when editing comments with @mentions

### DIFF
--- a/app/models/user/mentionable.rb
+++ b/app/models/user/mentionable.rb
@@ -8,6 +8,10 @@ module User::Mentionable
     def to_attachable_partial_path
       "users/attachable"
     end
+
+    def to_editor_content_attachment_partial_path
+      to_attachable_partial_path
+    end
   end
 
   def mentioned_by(mentioner, at:)

--- a/test/controllers/cards/comments_controller_test.rb
+++ b/test/controllers/cards/comments_controller_test.rb
@@ -113,6 +113,22 @@ class Cards::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated comment", comment.reload.body.to_plain_text
   end
 
+  test "edit a comment that contains a mention" do
+    card = cards(:logo)
+    mentioned_user = users(:jz)
+    mention_html = ActionText::Attachment.from_attachable(mentioned_user).to_html
+    comment = card.comments.create!(creator: users(:kevin), body: "#{mention_html} hello")
+
+    get edit_card_comment_path(card, comment)
+    assert_response :success
+    assert_select "lexxy-editor" do |editors|
+      value = editors.first["value"]
+      attachment = Nokogiri::HTML.fragment(value).at_css("action-text-attachment")
+      assert_equal mentioned_user.attachable_sgid, attachment["sgid"]
+      assert_includes attachment["content"], mentioned_user.first_name
+    end
+  end
+
   test "destroy as JSON" do
     comment = comments(:logo_agreement_kevin)
 


### PR DESCRIPTION
## Summary

- Edge Rails introduced `ActionText::Attachable#to_editor_content_attachment_partial_path` which defaults to `to_partial_path` ("users/user"). When editing a comment containing @mentions, the new editor adapter system calls this method to render mention content inside the rich text editor. Since `users/_user.html.erb` doesn't exist, this raises `ActionView::Template::Error`.
- Override `to_editor_content_attachment_partial_path` in `User::Mentionable` to delegate to `to_attachable_partial_path` ("users/attachable"), matching the existing display rendering path.

The Rails change was introduced as part of the edge Rails bump in #2820 (Lexxy 0.9.5.beta), which incidentally upgraded Rails from `12e24eaf` to `75f9e28379ac`. The new `to_editor_content_attachment_partial_path` method was added as part of the editor adapter system. See the [upgrade analysis](https://github.com/basecamp/37signals-hq/blob/main/upgrade-analysis/fizzy-20260409-rails_12e24eaf..75f9e283.md) for full details on changes in this Rails bump.

## Test plan

- [x] Regression test: edit a comment containing an @mention, assert the editor renders the mention attachment with the correct SGID and user name
- [x] Verified test fails without the fix (`Missing partial users/_user`)
- [x] Verified test passes with the fix
- [x] All existing comment controller tests pass