### PR TITLE
Support tag_ids on JSON card create/update

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -24,6 +24,8 @@ class CardsController < ApplicationController
         render :show, status: :created, location: card_path(@card, format: :json)
       end
     end
+  rescue ActiveRecord::RecordInvalid
+    head :unprocessable_entity
   end
 
   def show
@@ -39,6 +41,8 @@ class CardsController < ApplicationController
       format.turbo_stream
       format.json { render :show }
     end
+  rescue ActiveRecord::RecordInvalid
+    head :unprocessable_entity
   end
 
   def destroy

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -20,12 +20,15 @@ class CardsController < ApplicationController
       end
 
       format.json do
-        @card = @board.cards.create! card_params.merge(creator: Current.user, status: "published")
-        render :show, status: :created, location: card_path(@card, format: :json)
+        @card = @board.cards.new card_params.merge(creator: Current.user, status: "published")
+
+        if @card.save
+          render :show, status: :created, location: card_path(@card, format: :json)
+        else
+          render json: @card.errors, status: :unprocessable_entity
+        end
       end
     end
-  rescue ActiveRecord::RecordInvalid
-    head :unprocessable_entity
   end
 
   def show
@@ -35,14 +38,15 @@ class CardsController < ApplicationController
   end
 
   def update
-    @card.update! card_params
-
     respond_to do |format|
-      format.turbo_stream
-      format.json { render :show }
+      if @card.update(card_params)
+        format.turbo_stream
+        format.json { render :show }
+      else
+        format.turbo_stream { render :edit, status: :unprocessable_entity }
+        format.json { render json: @card.errors, status: :unprocessable_entity }
+      end
     end
-  rescue ActiveRecord::RecordInvalid
-    head :unprocessable_entity
   end
 
   def destroy

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,5 +1,5 @@
 class CardsController < ApplicationController
-  wrap_parameters :card, include: %i[ title description image created_at last_active_at ]
+  wrap_parameters :card, include: %i[ title description image created_at last_active_at tag_ids ]
 
   include FilterScoped
 
@@ -68,6 +68,6 @@ class CardsController < ApplicationController
     end
 
     def card_params
-      params.expect(card: [ :title, :description, :image, :created_at, :last_active_at ])
+      params.expect(card: [ :title, :description, :image, :created_at, :last_active_at, tag_ids: [] ])
     end
 end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -43,7 +43,7 @@ class CardsController < ApplicationController
         format.turbo_stream
         format.json { render :show }
       else
-        format.turbo_stream { render :edit, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @card.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/card/taggable.rb
+++ b/app/models/card/taggable.rb
@@ -6,13 +6,8 @@ module Card::Taggable
     has_many :tags, through: :taggings
 
     scope :tagged_with, ->(tags) { joins(:taggings).where(taggings: { tag: tags }) }
-  end
 
-  def tag_ids=(ids)
-    ids = Array(ids).compact_blank
-    account_scope = account || board&.account || Current.account
-
-    self.tags = ids.present? ? account_scope.tags.find(ids) : []
+    validate :tags_belong_to_account
   end
 
   def toggle_tag_with(title)
@@ -30,4 +25,11 @@ module Card::Taggable
   def tagged_with?(tag)
     tags.include? tag
   end
+
+  private
+    def tags_belong_to_account
+      return if tags.all? { it.account_id == account_id }
+
+      errors.add(:tags, "must belong to the card account")
+    end
 end

--- a/app/models/card/taggable.rb
+++ b/app/models/card/taggable.rb
@@ -8,6 +8,13 @@ module Card::Taggable
     scope :tagged_with, ->(tags) { joins(:taggings).where(taggings: { tag: tags }) }
   end
 
+  def tag_ids=(ids)
+    ids = Array(ids).compact_blank
+    account_scope = account || board&.account || Current.account
+
+    self.tags = ids.present? ? account_scope.tags.find(ids) : []
+  end
+
   def toggle_tag_with(title)
     tag = account.tags.find_or_create_by!(title: title)
 

--- a/app/models/card/taggable.rb
+++ b/app/models/card/taggable.rb
@@ -28,8 +28,8 @@ module Card::Taggable
 
   private
     def tags_belong_to_account
-      return if tags.all? { it.account_id == account_id }
-
-      errors.add(:tags, "must belong to the card account")
+      if tags.any? { it.account_id != account_id }
+        errors.add(:tags, "must belong to the card account")
+      end
     end
 end

--- a/test/controllers/api/flat_json_params_test.rb
+++ b/test/controllers/api/flat_json_params_test.rb
@@ -75,6 +75,21 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
     assert_equal "Flat description", card.description.to_plain_text
   end
 
+  test "create card with flat JSON and tag_ids" do
+    tag = tags(:mobile)
+
+    assert_difference -> { Card.count }, +1 do
+      post board_cards_path(boards(:writebook)),
+        params: { title: "Flat tagged card", tag_ids: [ tag.id ] },
+        as: :json
+    end
+
+    assert_response :created
+    card = Card.last
+    assert_equal [ tag ], card.reload.tags
+    assert_equal [ tag.title ], @response.parsed_body["tags"]
+  end
+
   test "update card with flat JSON" do
     card = cards(:logo)
 
@@ -86,6 +101,19 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
     card.reload
     assert_equal "Flat update", card.title
     assert_equal "Updated flat", card.description.to_plain_text
+  end
+
+  test "update card with flat JSON and tag_ids" do
+    card = cards(:logo)
+    tag = tags(:mobile)
+
+    put card_path(card),
+      params: { tag_ids: [ tag.id ] },
+      as: :json
+
+    assert_response :success
+    assert_equal [ tag ], card.reload.tags
+    assert_equal [ tag.title ], @response.parsed_body["tags"]
   end
 
   test "create board with flat JSON" do

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -319,6 +319,27 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ tag.title ], @response.parsed_body["tags"]
   end
 
+  test "update as JSON with description and tag_ids busts the card cache key" do
+    card = cards(:logo)
+    original_cache_key = card.cache_key_with_version
+    tag = tags(:mobile)
+
+    travel 1.minute do
+      put card_path(card, format: :json), params: {
+        card: {
+          description: "Updated description",
+          tag_ids: [ tag.id ]
+        }
+      }
+    end
+
+    assert_response :success
+    assert_not_equal original_cache_key, card.reload.cache_key_with_version
+    assert_equal "Updated description", card.description.to_plain_text.strip
+    assert_equal [ tag ], card.tags
+    assert_equal [ tag.title ], @response.parsed_body["tags"]
+  end
+
   test "delete as JSON" do
     card = cards(:logo)
 

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -207,6 +207,21 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Big if true", card.description.to_plain_text
   end
 
+  test "create as JSON with tag_ids applies tags to the created card" do
+    tag = tags(:mobile)
+
+    assert_difference -> { Card.count }, +1 do
+      post board_cards_path(boards(:writebook)),
+        params: { card: { title: "Tagged card", tag_ids: [ tag.id ] } },
+        as: :json
+      assert_response :created
+    end
+
+    card = Card.last
+    assert_equal [ tag ], card.reload.tags
+    assert_equal [ tag.title ], @response.parsed_body["tags"]
+  end
+
   test "create as JSON with custom created_at" do
     custom_time = Time.utc(2024, 1, 15, 10, 30, 0)
 
@@ -291,6 +306,17 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal "Update test", card.reload.title
+  end
+
+  test "update as JSON with tag_ids updates tags on the card" do
+    card = cards(:logo)
+    tag = tags(:mobile)
+
+    put card_path(card, format: :json), params: { card: { tag_ids: [ tag.id ] } }
+    assert_response :success
+
+    assert_equal [ tag ], card.reload.tags
+    assert_equal [ tag.title ], @response.parsed_body["tags"]
   end
 
   test "delete as JSON" do

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -222,6 +222,28 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ tag.title ], @response.parsed_body["tags"]
   end
 
+  test "create as JSON with nonexistent tag_ids returns not found" do
+    assert_no_difference -> { Card.count } do
+      post board_cards_path(boards(:writebook)),
+        params: { card: { title: "Tagged card", tag_ids: [ "does-not-exist" ] } },
+        as: :json
+    end
+
+    assert_response :not_found
+  end
+
+  test "create as JSON with foreign-account tag_ids returns not found" do
+    foreign_tag = accounts(:initech).tags.create!(title: "foreign")
+
+    assert_no_difference -> { Card.count } do
+      post board_cards_path(boards(:writebook)),
+        params: { card: { title: "Tagged card", tag_ids: [ foreign_tag.id ] } },
+        as: :json
+    end
+
+    assert_response :not_found
+  end
+
   test "create as JSON with custom created_at" do
     custom_time = Time.utc(2024, 1, 15, 10, 30, 0)
 
@@ -317,6 +339,16 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal [ tag ], card.reload.tags
     assert_equal [ tag.title ], @response.parsed_body["tags"]
+  end
+
+  test "update as JSON with foreign-account tag_ids returns not found" do
+    card = cards(:logo)
+    foreign_tag = accounts(:initech).tags.create!(title: "foreign")
+
+    put card_path(card, format: :json), params: { card: { tag_ids: [ foreign_tag.id ] } }
+
+    assert_response :not_found
+    assert_equal [ tags(:web) ], card.reload.tags
   end
 
   test "update as JSON with description and tag_ids busts the card cache key" do

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -101,6 +101,17 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "reactions", response.body, "Draft card should not show reactions/boost button"
   end
 
+  test "update as HTML with invalid tag_ids renders edit with unprocessable entity" do
+    card = cards(:logo)
+    foreign_tag = accounts(:initech).tags.create!(title: "foreign")
+
+    patch card_path(card), params: { card: { tag_ids: [ foreign_tag.id ] } }
+
+    assert_response :unprocessable_entity
+    assert_equal [ tags(:web) ], card.reload.tags
+    assert_match "Close editor and discard changes", response.body
+  end
+
   test "users can only see cards in boards they have access to" do
     get card_path(cards(:logo))
     assert_response :success

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -351,6 +351,17 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ tags(:web).title ], @response.parsed_body["tags"]
   end
 
+  test "update as JSON with empty tag_ids clears existing tags" do
+    card = cards(:logo)
+    assert_equal [ tags(:web) ], card.tags
+
+    put card_path(card, format: :json), params: { card: { tag_ids: [] } }
+    assert_response :success
+
+    assert_empty card.reload.tags
+    assert_empty @response.parsed_body["tags"]
+  end
+
   test "update as JSON with foreign-account tag_ids returns not found" do
     card = cards(:logo)
     foreign_tag = accounts(:initech).tags.create!(title: "foreign")

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -341,6 +341,16 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ tag.title ], @response.parsed_body["tags"]
   end
 
+  test "update as JSON without tag_ids preserves existing tags" do
+    card = cards(:logo)
+
+    put card_path(card, format: :json), params: { card: { title: "Updated title" } }
+    assert_response :success
+
+    assert_equal [ tags(:web) ], card.reload.tags
+    assert_equal [ tags(:web).title ], @response.parsed_body["tags"]
+  end
+
   test "update as JSON with foreign-account tag_ids returns not found" do
     card = cards(:logo)
     foreign_tag = accounts(:initech).tags.create!(title: "foreign")

--- a/test/controllers/cards_controller_test.rb
+++ b/test/controllers/cards_controller_test.rb
@@ -232,7 +232,7 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "create as JSON with foreign-account tag_ids returns not found" do
+  test "create as JSON with foreign-account tag_ids returns unprocessable entity" do
     foreign_tag = accounts(:initech).tags.create!(title: "foreign")
 
     assert_no_difference -> { Card.count } do
@@ -241,7 +241,7 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
         as: :json
     end
 
-    assert_response :not_found
+    assert_response :unprocessable_entity
   end
 
   test "create as JSON with custom created_at" do
@@ -362,13 +362,13 @@ class CardsControllerTest < ActionDispatch::IntegrationTest
     assert_empty @response.parsed_body["tags"]
   end
 
-  test "update as JSON with foreign-account tag_ids returns not found" do
+  test "update as JSON with foreign-account tag_ids returns unprocessable entity" do
     card = cards(:logo)
     foreign_tag = accounts(:initech).tags.create!(title: "foreign")
 
     put card_path(card, format: :json), params: { card: { tag_ids: [ foreign_tag.id ] } }
 
-    assert_response :not_found
+    assert_response :unprocessable_entity
     assert_equal [ tags(:web) ], card.reload.tags
   end
 

--- a/test/models/card/taggable_test.rb
+++ b/test/models/card/taggable_test.rb
@@ -25,4 +25,17 @@ class Card::TaggableTest < ActiveSupport::TestCase
 
     assert_not_equal cards(:logo).tags.last, cards(:paycheck).tags.last
   end
+
+  test "updating just tag_ids touches the card and board" do
+    board = @card.board
+    card_updated_at = @card.updated_at
+    board_updated_at = board.updated_at
+
+    travel 1.minute do
+      @card.update!(tag_ids: [ tags(:web).id, tags(:mobile).id ])
+    end
+
+    assert @card.reload.updated_at > card_updated_at
+    assert board.reload.updated_at > board_updated_at
+  end
 end

--- a/test/models/card/taggable_test.rb
+++ b/test/models/card/taggable_test.rb
@@ -38,6 +38,14 @@ class Card::TaggableTest < ActiveSupport::TestCase
     end
   end
 
+  test "updating tag_ids with an empty array clears tags" do
+    assert_equal [ tags(:web) ], @card.tags
+
+    @card.update!(tag_ids: [])
+
+    assert_empty @card.reload.tags
+  end
+
   test "updating tag_ids raises when a tag does not exist" do
     assert_raises(ActiveRecord::RecordNotFound) do
       @card.update!(tag_ids: [ "does-not-exist" ])

--- a/test/models/card/taggable_test.rb
+++ b/test/models/card/taggable_test.rb
@@ -52,11 +52,13 @@ class Card::TaggableTest < ActiveSupport::TestCase
     end
   end
 
-  test "updating tag_ids raises when the tag belongs to another account" do
+  test "updating tag_ids is invalid when the tag belongs to another account" do
     foreign_tag = accounts(:initech).tags.create!(title: "foreign")
 
-    assert_raises(ActiveRecord::RecordNotFound) do
+    error = assert_raises(ActiveRecord::RecordInvalid) do
       @card.update!(tag_ids: [ foreign_tag.id ])
     end
+
+    assert_includes error.record.errors[:tags], "must belong to the card account"
   end
 end

--- a/test/models/card/taggable_test.rb
+++ b/test/models/card/taggable_test.rb
@@ -38,4 +38,18 @@ class Card::TaggableTest < ActiveSupport::TestCase
     assert @card.reload.updated_at > card_updated_at
     assert board.reload.updated_at > board_updated_at
   end
+
+  test "updating tag_ids raises when a tag does not exist" do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      @card.update!(tag_ids: [ "does-not-exist" ])
+    end
+  end
+
+  test "updating tag_ids raises when the tag belongs to another account" do
+    foreign_tag = accounts(:initech).tags.create!(title: "foreign")
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      @card.update!(tag_ids: [ foreign_tag.id ])
+    end
+  end
 end

--- a/test/models/card/taggable_test.rb
+++ b/test/models/card/taggable_test.rb
@@ -28,15 +28,14 @@ class Card::TaggableTest < ActiveSupport::TestCase
 
   test "updating just tag_ids touches the card and board" do
     board = @card.board
-    card_updated_at = @card.updated_at
-    board_updated_at = board.updated_at
 
     travel 1.minute do
-      @card.update!(tag_ids: [ tags(:web).id, tags(:mobile).id ])
+      assert_changes -> { @card.reload.updated_at } do
+        assert_changes -> { board.reload.updated_at } do
+          @card.update!(tag_ids: [ tags(:web).id, tags(:mobile).id ])
+        end
+      end
     end
-
-    assert @card.reload.updated_at > card_updated_at
-    assert board.reload.updated_at > board_updated_at
   end
 
   test "updating tag_ids raises when a tag does not exist" do


### PR DESCRIPTION
## Summary
The cards JSON API already documents support for `tag_ids`, but `CardsController` was not wrapping or permitting that parameter. As a result, API clients could create or update cards successfully while tags were silently dropped from the request and the response came back with an empty `tags` array.

This change makes `tag_ids` work for JSON card create/update requests so the API behavior matches the docs and client expectations. It also validates that assigned tags belong to the card's account and returns standard unprocessable-entity responses for invalid tag assignments.

Ref: https://github.com/basecamp/fizzy/discussions/2819

## Changes
- permit `tag_ids: []` in `CardsController#card_params`
- include `tag_ids` in `wrap_parameters :card` so flat JSON payloads work too
- validate that assigned tags belong to the card account
- return validation errors with `422 Unprocessable Entity` for invalid JSON card create/update requests
- re-render the edit template with `422 Unprocessable Entity` for invalid HTML card updates
- add regression coverage for:
  - nested JSON create with `card: { tag_ids: [...] }`
  - flat JSON create with `tag_ids: [...]`
  - nested JSON update with `card: { tag_ids: [...] }`
  - flat JSON update with `tag_ids: [...]`
  - clearing tags with `tag_ids: []`
  - preserving existing tags when `tag_ids` is omitted from an update
  - invalid HTML updates rendering the edit form again

## Notes
- no docs update was needed because the API docs already list `tag_ids` for card create/update
- nonexistent tag IDs still return `404 Not Found`
- foreign-account tag IDs are treated as invalid and return `422 Unprocessable Entity`
