### PR TITLE
Stub DNS in notification delivery tests

### DIFF
--- a/test/controllers/api/flat_json_params_test.rb
+++ b/test/controllers/api/flat_json_params_test.rb
@@ -53,7 +53,7 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
   end
 
   test "create push subscription with flat JSON" do
-    stub_fcm_dns_resolution
+    stub_web_push_dns_resolution
 
     post user_push_subscriptions_path(users(:kevin)),
       params: { endpoint: "https://fcm.googleapis.com/fcm/send/abc123", p256dh_key: "key1", auth_key: "key2" },

--- a/test/controllers/api/flat_json_params_test.rb
+++ b/test/controllers/api/flat_json_params_test.rb
@@ -53,7 +53,7 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
   end
 
   test "create push subscription with flat JSON" do
-    stub_dns_resolution("142.250.185.206")
+    stub_fcm_dns_resolution
 
     post user_push_subscriptions_path(users(:kevin)),
       params: { endpoint: "https://fcm.googleapis.com/fcm/send/abc123", p256dh_key: "key1", auth_key: "key2" },

--- a/test/controllers/users/push_subscriptions_controller_test.rb
+++ b/test/controllers/users/push_subscriptions_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Users::PushSubscriptionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in_as :david
-    stub_fcm_dns_resolution
+    stub_web_push_dns_resolution
   end
 
   test "create new push subscription" do

--- a/test/controllers/users/push_subscriptions_controller_test.rb
+++ b/test/controllers/users/push_subscriptions_controller_test.rb
@@ -1,11 +1,9 @@
 require "test_helper"
 
 class Users::PushSubscriptionsControllerTest < ActionDispatch::IntegrationTest
-  PUBLIC_TEST_IP = "142.250.185.206"
-
   setup do
     sign_in_as :david
-    stub_dns_resolution(PUBLIC_TEST_IP)
+    stub_fcm_dns_resolution
   end
 
   test "create new push subscription" do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
 class NotificationDeliveryTest < ActiveSupport::TestCase
-  PUBLIC_TEST_IP = "142.250.185.206"
+  # Use a stable, publicly-routable IP so DNS stubbing satisfies public-host/SSRF
+  # validation for the FCM endpoint and remains deterministic across runs.
+  FCM_PUBLIC_TEST_IP = "142.250.185.206"
 
   setup do
     @assigner = users(:david)
@@ -18,7 +20,7 @@ class NotificationDeliveryTest < ActiveSupport::TestCase
     Notification.register_push_target(:web)
     Notification.register_push_target(push_target_with_tracking)
 
-    stub_dns_resolution(PUBLIC_TEST_IP)
+    stub_dns_resolution(FCM_PUBLIC_TEST_IP)
 
     # Give assignee a web push subscription
     @assignee.push_subscriptions.create!(

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class NotificationDeliveryTest < ActiveSupport::TestCase
+  PUBLIC_TEST_IP = "142.250.185.206"
+
   setup do
     @assigner = users(:david)
     @assignee = users(:kevin)
@@ -15,6 +17,8 @@ class NotificationDeliveryTest < ActiveSupport::TestCase
     Notification.push_targets = []
     Notification.register_push_target(:web)
     Notification.register_push_target(push_target_with_tracking)
+
+    stub_dns_resolution(PUBLIC_TEST_IP)
 
     # Give assignee a web push subscription
     @assignee.push_subscriptions.create!(

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -16,7 +16,7 @@ class NotificationDeliveryTest < ActiveSupport::TestCase
     Notification.register_push_target(:web)
     Notification.register_push_target(push_target_with_tracking)
 
-    stub_fcm_dns_resolution
+    stub_web_push_dns_resolution
 
     # Give assignee a web push subscription
     @assignee.push_subscriptions.create!(

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
 class NotificationDeliveryTest < ActiveSupport::TestCase
-  # Use a stable, publicly-routable IP so DNS stubbing satisfies public-host/SSRF
-  # validation for the FCM endpoint and remains deterministic across runs.
-  FCM_PUBLIC_TEST_IP = "142.250.185.206"
-
   setup do
     @assigner = users(:david)
     @assignee = users(:kevin)
@@ -20,7 +16,7 @@ class NotificationDeliveryTest < ActiveSupport::TestCase
     Notification.register_push_target(:web)
     Notification.register_push_target(push_target_with_tracking)
 
-    stub_dns_resolution(FCM_PUBLIC_TEST_IP)
+    stub_fcm_dns_resolution
 
     # Give assignee a web push subscription
     @assignee.push_subscriptions.create!(

--- a/test/lib/web_push/persistent_request_test.rb
+++ b/test/lib/web_push/persistent_request_test.rb
@@ -5,7 +5,7 @@ class WebPush::PersistentRequestTest < ActiveSupport::TestCase
 
   test "pins connection to endpoint_ip" do
     request = stub_request(:post, ENDPOINT)
-      .with(ipaddr: DnsTestHelper::FCM_PUBLIC_TEST_IP)
+      .with(ipaddr: DnsTestHelper::WEB_PUSH_PUBLIC_TEST_IP)
       .to_return(status: 201)
 
     notification = WebPush::Notification.new(
@@ -14,7 +14,7 @@ class WebPush::PersistentRequestTest < ActiveSupport::TestCase
       url: "/test",
       badge: 0,
       endpoint: ENDPOINT,
-      endpoint_ip: DnsTestHelper::FCM_PUBLIC_TEST_IP,
+      endpoint_ip: DnsTestHelper::WEB_PUSH_PUBLIC_TEST_IP,
       p256dh_key: "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM",
       auth_key: "tBHItJI5svbpez7KI4CCXg"
     )

--- a/test/lib/web_push/persistent_request_test.rb
+++ b/test/lib/web_push/persistent_request_test.rb
@@ -1,12 +1,11 @@
 require "test_helper"
 
 class WebPush::PersistentRequestTest < ActiveSupport::TestCase
-  PUBLIC_TEST_IP = "142.250.185.206"
   ENDPOINT = "https://fcm.googleapis.com/fcm/send/test123"
 
   test "pins connection to endpoint_ip" do
     request = stub_request(:post, ENDPOINT)
-      .with(ipaddr: PUBLIC_TEST_IP)
+      .with(ipaddr: DnsTestHelper::FCM_PUBLIC_TEST_IP)
       .to_return(status: 201)
 
     notification = WebPush::Notification.new(
@@ -15,7 +14,7 @@ class WebPush::PersistentRequestTest < ActiveSupport::TestCase
       url: "/test",
       badge: 0,
       endpoint: ENDPOINT,
-      endpoint_ip: PUBLIC_TEST_IP,
+      endpoint_ip: DnsTestHelper::FCM_PUBLIC_TEST_IP,
       p256dh_key: "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM",
       auth_key: "tBHItJI5svbpez7KI4CCXg"
     )

--- a/test/models/notification/push_target/web_test.rb
+++ b/test/models/notification/push_target/web_test.rb
@@ -5,7 +5,7 @@ class Notification::PushTarget::WebTest < ActiveSupport::TestCase
     @user = users(:david)
     @notification = notifications(:logo_mentioned_david)
 
-    stub_fcm_dns_resolution
+    stub_web_push_dns_resolution
 
     @user.push_subscriptions.create!(
       endpoint: "https://fcm.googleapis.com/fcm/send/test123",

--- a/test/models/notification/push_target/web_test.rb
+++ b/test/models/notification/push_target/web_test.rb
@@ -5,7 +5,7 @@ class Notification::PushTarget::WebTest < ActiveSupport::TestCase
     @user = users(:david)
     @notification = notifications(:logo_mentioned_david)
 
-    stub_dns_resolution("142.250.185.206")
+    stub_fcm_dns_resolution
 
     @user.push_subscriptions.create!(
       endpoint: "https://fcm.googleapis.com/fcm/send/test123",

--- a/test/models/push/subscription_test.rb
+++ b/test/models/push/subscription_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Push::SubscriptionTest < ActiveSupport::TestCase
   setup do
-    stub_fcm_dns_resolution
+    stub_web_push_dns_resolution
   end
 
   test "valid subscription with permitted endpoint" do
@@ -90,7 +90,7 @@ class Push::SubscriptionTest < ActiveSupport::TestCase
       auth_key: "test_auth"
     )
 
-    assert_equal DnsTestHelper::FCM_PUBLIC_TEST_IP, subscription.resolved_endpoint_ip
+    assert_equal DnsTestHelper::WEB_PUSH_PUBLIC_TEST_IP, subscription.resolved_endpoint_ip
   end
 
   test "accepts all permitted push service domains" do

--- a/test/models/push/subscription_test.rb
+++ b/test/models/push/subscription_test.rb
@@ -1,10 +1,8 @@
 require "test_helper"
 
 class Push::SubscriptionTest < ActiveSupport::TestCase
-  PUBLIC_TEST_IP = "142.250.185.206" # google.com IP
-
   setup do
-    stub_dns_resolution(PUBLIC_TEST_IP)
+    stub_fcm_dns_resolution
   end
 
   test "valid subscription with permitted endpoint" do
@@ -92,7 +90,7 @@ class Push::SubscriptionTest < ActiveSupport::TestCase
       auth_key: "test_auth"
     )
 
-    assert_equal PUBLIC_TEST_IP, subscription.resolved_endpoint_ip
+    assert_equal DnsTestHelper::FCM_PUBLIC_TEST_IP, subscription.resolved_endpoint_ip
   end
 
   test "accepts all permitted push service domains" do

--- a/test/test_helpers/dns_test_helper.rb
+++ b/test/test_helpers/dns_test_helper.rb
@@ -1,5 +1,5 @@
 module DnsTestHelper
-  FCM_PUBLIC_TEST_IP = "142.250.185.206" # stable public IP for FCM DNS stubs in tests
+  WEB_PUSH_PUBLIC_TEST_IP = "142.250.185.206" # stable public IP for web push DNS stubs in tests
 
   private
 
@@ -9,7 +9,7 @@ module DnsTestHelper
     Resolv::DNS.stubs(:open).yields(dns_mock)
   end
 
-  def stub_fcm_dns_resolution
-    stub_dns_resolution(FCM_PUBLIC_TEST_IP)
+  def stub_web_push_dns_resolution
+    stub_dns_resolution(WEB_PUSH_PUBLIC_TEST_IP)
   end
 end

--- a/test/test_helpers/dns_test_helper.rb
+++ b/test/test_helpers/dns_test_helper.rb
@@ -1,9 +1,15 @@
 module DnsTestHelper
+  FCM_PUBLIC_TEST_IP = "142.250.185.206" # stable public IP for FCM DNS stubs in tests
+
   private
 
   def stub_dns_resolution(*ips)
     dns_mock = mock("dns")
     dns_mock.stubs(:each_address).multiple_yields(*ips)
     Resolv::DNS.stubs(:open).yields(dns_mock)
+  end
+
+  def stub_fcm_dns_resolution
+    stub_dns_resolution(FCM_PUBLIC_TEST_IP)
   end
 end


### PR DESCRIPTION
## Summary
`NotificationDeliveryTest` creates a push subscription for `fcm.googleapis.com` but was relying on live DNS resolution during the test. That makes the test nondeterministic under the SSRF validation added to `Push::Subscription`, and it recently failed in CI here: https://github.com/basecamp/fizzy/actions/runs/24322726747/job/71011847248. This change makes the test deterministic by stubbing DNS to a known public IP, which matches the existing project pattern for push-subscription tests and prevents unrelated PRs from tripping this flaky setup.

## Changes
- define a public test IP constant in `NotificationDeliveryTest`
- call `stub_dns_resolution(...)` before creating the test push subscription
- keep the test exercising notification delivery behavior without depending on external DNS

## Notes
- this does not change production behavior
- it aligns the integration test with other existing tests that already stub DNS around push subscription validation
