### PR TITLE
Add timeout to system package install step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: Tests (${{ matrix.mode }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
   test:
     name: Tests (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -55,6 +54,7 @@ jobs:
 
     steps:
       - name: Install system packages
+        timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libsqlite3-0 libvips curl ffmpeg
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
A recent PR run got stuck in the reusable test workflow while installing system packages and never progressed to checkout or test execution: https://github.com/basecamp/fizzy/actions/runs/24347433051/job/71092098634. This updates the shared `test.yml` workflow to put a timeout on that specific step so OSS and SaaS test jobs fail cleanly instead of hanging indefinitely when apt/package installation wedges.

## Changes
- add `timeout-minutes: 10` to the `Install system packages` step in `.github/workflows/test.yml`
- keep the timeout targeted to the step that has shown the stall behavior

## Notes
- this does not change application behavior or test logic
- the timeout choice is based on recent workflow history rather than an arbitrary cap
- in a sample of the last 20 OSS and last 20 SaaS runs, the `Install system packages` step had:
  - overall median: ~0.42 minutes
  - overall p95: ~1.90 minutes
- for the OSS workflow most relevant to PRs like the linked stuck run:
  - `Test (OSS) / Tests (MySQL)` median: ~0.41 minutes
  - `Test (OSS) / Tests (MySQL)` p95: ~0.93 minutes
  - `Test (OSS) / Tests (MySQL)` max in the sample: ~8.17 minutes
- a 10 minute timeout leaves cushion above the sampled OSS maximum while still treating 10+ minute apt stalls as infrastructure failures rather than normal test variance
