### PR TITLE
Return updated board on PUT /boards/:id

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -50,7 +50,7 @@ class BoardsController < ApplicationController
           redirect_to root_path, notice: "Saved (you were removed from the board)"
         end
       end
-      format.json { head :no_content }
+      format.json { render :show }
     end
   end
 

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -54,7 +54,7 @@ class BoardsController < ApplicationController
         if @board.accessible_to?(Current.user)
           render :show
         else
-          head :forbidden
+          head :no_content
         end
       end
     end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -50,7 +50,13 @@ class BoardsController < ApplicationController
           redirect_to root_path, notice: "Saved (you were removed from the board)"
         end
       end
-      format.json { render :show }
+      format.json do
+        if @board.accessible_to?(Current.user)
+          render :show
+        else
+          head :forbidden
+        end
+      end
     end
   end
 

--- a/docs/api/sections/boards.md
+++ b/docs/api/sections/boards.md
@@ -152,6 +152,8 @@ Returns `200 OK` with the updated board in the same shape as `GET /:account_slug
 }
 ```
 
+If the update succeeds but removes the requesting user's own access to the board, the endpoint instead returns `204 No Content`.
+
 ## `DELETE /:account_slug/boards/:board_id`
 
 Deletes a Board. Only board administrators can delete a board.

--- a/docs/api/sections/boards.md
+++ b/docs/api/sections/boards.md
@@ -126,7 +126,31 @@ __Request:__
 
 __Response:__
 
-Returns `204 No Content` on success.
+Returns `200 OK` with the updated board in the same shape as `GET /:account_slug/boards/:board_id`:
+
+```json
+{
+  "id": "03f5v9zkft4hj9qq0lsn9ohcm",
+  "name": "Updated board name",
+  "all_access": false,
+  "created_at": "2025-12-05T19:36:35.534Z",
+  "auto_postpone_period_in_days": 30,
+  "url": "http://app.fizzy.localhost:3006/897362094/boards/03f5v9zkft4hj9qq0lsn9ohcm",
+  "creator": {
+    "id": "03f5v9zjw7pz8717a4no1h8a7",
+    "name": "David Heinemeier Hansson",
+    "role": "owner",
+    "active": true,
+    "email_address": "david@example.com",
+    "created_at": "2025-12-05T19:36:35.401Z",
+    "url": "http://app.fizzy.localhost:3006/897362094/users/03f5v9zjw7pz8717a4no1h8a7"
+  },
+  "user_ids": [
+    "03f5v9zppzlksuj4mxba2nbzn",
+    "03f5v9zjw7pz8717a4no1h8a7"
+  ]
+}
+```
 
 ## `DELETE /:account_slug/boards/:board_id`
 

--- a/test/controllers/api/flat_json_params_test.rb
+++ b/test/controllers/api/flat_json_params_test.rb
@@ -104,11 +104,13 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
       params: { name: "Flat board", auto_postpone_period_in_days: 7, public_description: "<p>Flat public desc</p>" },
       as: :json
 
-    assert_response :no_content
+    assert_response :success
     board.reload
     assert_equal "Flat board", board.name
     assert_equal 7.days, board.entropy.auto_postpone_period
     assert_equal "Flat public desc", board.public_description.to_plain_text
+    assert_equal board.id, @response.parsed_body["id"]
+    assert_equal "Flat board", @response.parsed_body["name"]
   end
 
   test "create column with flat JSON" do

--- a/test/controllers/boards_controller_test.rb
+++ b/test/controllers/boards_controller_test.rb
@@ -353,6 +353,20 @@ class BoardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal board.creator.id, json["creator"]["id"]
   end
 
+  test "update as JSON returns forbidden when user removes themselves from board" do
+    board = boards(:writebook)
+
+    put board_path(board), params: {
+      board: { name: "Updated Name", all_access: false },
+      user_ids: users(:david, :jz).pluck(:id)
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal "Updated Name", board.reload.name
+    assert_not board.users.include?(users(:kevin))
+    assert_empty response.body
+  end
+
   test "destroy as JSON" do
     board = boards(:writebook)
 

--- a/test/controllers/boards_controller_test.rb
+++ b/test/controllers/boards_controller_test.rb
@@ -344,8 +344,13 @@ class BoardsControllerTest < ActionDispatch::IntegrationTest
 
     put board_path(board), params: { board: { name: "Updated Name" } }, as: :json
 
-    assert_response :no_content
+    assert_response :success
     assert_equal "Updated Name", board.reload.name
+
+    json = @response.parsed_body
+    assert_equal board.id, json["id"]
+    assert_equal "Updated Name", json["name"]
+    assert_equal board.creator.id, json["creator"]["id"]
   end
 
   test "destroy as JSON" do

--- a/test/controllers/boards_controller_test.rb
+++ b/test/controllers/boards_controller_test.rb
@@ -353,7 +353,7 @@ class BoardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal board.creator.id, json["creator"]["id"]
   end
 
-  test "update as JSON returns forbidden when user removes themselves from board" do
+  test "update as JSON returns no content when user removes themselves from board" do
     board = boards(:writebook)
 
     put board_path(board), params: {
@@ -361,7 +361,7 @@ class BoardsControllerTest < ActionDispatch::IntegrationTest
       user_ids: users(:david, :jz).pluck(:id)
     }, as: :json
 
-    assert_response :forbidden
+    assert_response :no_content
     assert_equal "Updated Name", board.reload.name
     assert_not board.users.include?(users(:kevin))
     assert_empty response.body


### PR DESCRIPTION
## Summary

The JSON response for `PUT /:account_slug/boards/:board_id` was `204 No Content`, forcing clients to do a follow-up `GET` to observe the result of their own write. The Smithy contract the SDKs are generated from already declares `UpdateBoard` returns a Board, so the server was out of sync with the documented shape.

This changes the JSON update path to return the same payload shape as `GET /:account_slug/boards/:board_id` when the caller still has access after the update. If the update succeeds but removes the caller's own access to the board, the endpoint returns `204 No Content` instead of returning a board they can no longer access. The HTML redirect behavior is unchanged.

Discovered via a fizzy-cli QA sweep — `fizzy board update` rendered an all-blank result because the CLI was parsing an empty body as a zero-valued Board.

## Changes

- `app/controllers/boards_controller.rb`
  - JSON board updates now render `:show` when access remains after the update
  - JSON board updates return `204 No Content` when the update removes the caller's own access
- `test/controllers/boards_controller_test.rb`
  - "update as JSON" test now asserts key fields on the returned body
  - added coverage for the self-removal JSON case
- `test/controllers/api/flat_json_params_test.rb`
  - updated the flat JSON board update test to expect the returned board body
- `docs/api/sections/boards.md`
  - documents the `200 OK` response body for successful updates
  - documents the `204 No Content` response when the update removes the caller's own access

## Mobile App check

- Neither mobile app has native client code calling `PUT /boards/:id`
- Neither mobile app has code paths that depend on this endpoint returning `204 No Content`
- Neither mobile app is affected by this response change to `200 OK` with the updated board
