### PR TITLE
Return moved card on PUT /cards/:number/board

### DIFF
--- a/app/controllers/cards/boards_controller.rb
+++ b/app/controllers/cards/boards_controller.rb
@@ -14,7 +14,7 @@ class Cards::BoardsController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to @card }
-      format.json { head :no_content }
+      format.json { render "cards/show" }
     end
   end
 

--- a/docs/api/sections/cards.md
+++ b/docs/api/sections/cards.md
@@ -251,6 +251,26 @@ __Response:__
 
 Returns `204 No Content` on success.
 
+## `PUT /:account_slug/cards/:card_number/board`
+
+Moves a card to a different board.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `board_id` | string | Yes | The ID of the board to move the card to |
+
+__Request:__
+
+```json
+{
+  "board_id": "03f5v9zkft4hj9qq0lsn9ohcm"
+}
+```
+
+__Response:__
+
+Returns `200 OK` with the moved card in the same shape as `GET /:account_slug/cards/:card_number`. The `board` field reflects the new board.
+
 ## `POST /:account_slug/cards/:card_number/triage`
 
 Moves a card into a column.

--- a/test/controllers/cards/boards_controller_test.rb
+++ b/test/controllers/cards/boards_controller_test.rb
@@ -26,7 +26,13 @@ class Cards::BoardsControllerTest < ActionDispatch::IntegrationTest
 
     put card_board_path(card), params: { board_id: new_board.id }, as: :json
 
-    assert_response :no_content
+    assert_response :success
     assert_equal new_board, card.reload.board
+
+    json = @response.parsed_body
+    assert_equal card.id, json["id"]
+    assert_equal card.number, json["number"]
+    assert_equal card.title, json["title"]
+    assert_equal new_board.id, json["board"]["id"]
   end
 end


### PR DESCRIPTION
## Summary

The JSON response for `PUT /:account_slug/cards/:card_number/board` was `204 No Content`, which forced clients to make a follow-up `GET` to see the card on its new board. The Smithy contract the SDKs are generated from already declares `MoveCard` returns a Card, so the server was out of sync with the documented shape.

Rendering `cards/show` on the JSON path means the response now carries the moved card (with its new `board` reference) directly. The HTML redirect behavior is unchanged.

Discovered via a fizzy-cli QA sweep — `fizzy card move` rendered a zero-valued Card and emitted `Card #N "" moved to board X` (blank title) because the CLI was parsing the empty 204 body as a Card struct.

## Changes

- `app/controllers/cards/boards_controller.rb` — `format.json { head :no_content }` → `format.json { render "cards/show" }`
- `test/controllers/cards/boards_controller_test.rb` — "update as JSON" test now asserts `id`, `number`, `title`, and `board.id` on the returned body
- `docs/api/sections/cards.md` — added a section documenting `PUT /:account_slug/cards/:card_number/board`, which was previously undocumented

## Mobile App check

- Neither mobile app has native client code calling `PUT /cards/:number/board`
- Neither mobile app has code paths that depend on this endpoint returning `204 No Content`
- Neither mobile app is affected by this response change to `200 OK` with the moved card
