### PR TITLE
Return updated column on PUT /boards/:id/columns/:id

### DIFF
--- a/app/controllers/boards/columns_controller.rb
+++ b/app/controllers/boards/columns_controller.rb
@@ -29,7 +29,7 @@ class Boards::ColumnsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream
-      format.json { head :no_content }
+      format.json { render :show }
     end
   end
 

--- a/docs/api/sections/columns.md
+++ b/docs/api/sections/columns.md
@@ -170,7 +170,7 @@ __Request:__
 
 __Response:__
 
-Returns `204 No Content` on success.
+Returns `200 OK` with the updated column in the same shape as `GET /:account_slug/boards/:board_id/columns/:column_id`.
 
 ## `DELETE /:account_slug/boards/:board_id/columns/:column_id`
 

--- a/test/controllers/api/flat_json_params_test.rb
+++ b/test/controllers/api/flat_json_params_test.rb
@@ -127,8 +127,10 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
 
     put board_column_path(column.board, column), params: { name: "Flat Updated" }, as: :json
 
-    assert_response :no_content
+    assert_response :success
     assert_equal "Flat Updated", column.reload.name
+    assert_equal column.id, @response.parsed_body["id"]
+    assert_equal "Flat Updated", @response.parsed_body["name"]
   end
 
   test "create step with flat JSON" do

--- a/test/controllers/boards/columns_controller_test.rb
+++ b/test/controllers/boards/columns_controller_test.rb
@@ -86,8 +86,12 @@ class Boards::ColumnsControllerTest < ActionDispatch::IntegrationTest
 
     put board_column_path(column.board, column), params: { column: { name: "Updated Name" } }, as: :json
 
-    assert_response :no_content
+    assert_response :success
     assert_equal "Updated Name", column.reload.name
+
+    json = @response.parsed_body
+    assert_equal column.id, json["id"]
+    assert_equal "Updated Name", json["name"]
   end
 
   test "destroy as JSON" do


### PR DESCRIPTION
## Summary

The JSON response for `PUT /:account_slug/boards/:board_id/columns/:column_id` was `204 No Content`, forcing clients to follow up with a `GET` to see their own update. The Smithy contract that the SDKs are generated from already declares `UpdateColumn` returns a Column, so the server was out of sync with the documented shape.

Rendering the `show` template on the JSON path makes the update return the same payload as `GET /:account_slug/boards/:board_id/columns/:column_id`. The Turbo Stream path is unchanged.

Discovered during a fizzy-cli QA sweep. Same class of issue as #2848 (boards) and #2849 (card move).

## Changes

- `app/controllers/boards/columns_controller.rb` — `format.json { head :no_content }` → `format.json { render :show }`
- `test/controllers/boards/columns_controller_test.rb` — "update as JSON" test now asserts the returned body
- `docs/api/sections/columns.md` — replaced "Returns 204 No Content" with the 200 response shape

## Mobile App check

- Neither mobile app has native client code calling `PUT /boards/:id/columns/:id`
- Neither mobile app has code paths that depend on this endpoint returning `204 No Content`
- Neither mobile app is affected by this response change to `200 OK` with the updated column
