### PR TITLE
Return updated comment on PUT /cards/:n/comments/:id

### DIFF
--- a/app/controllers/cards/comments_controller.rb
+++ b/app/controllers/cards/comments_controller.rb
@@ -30,7 +30,7 @@ class Cards::CommentsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream
-      format.json { head :no_content }
+      format.json { render :show }
     end
   end
 

--- a/test/controllers/cards/comments_controller_test.rb
+++ b/test/controllers/cards/comments_controller_test.rb
@@ -102,6 +102,10 @@ class Cards::CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal "Flat update", comment.reload.body.to_plain_text
+
+    json = @response.parsed_body
+    assert_equal comment.id, json["id"]
+    assert_equal "Flat update", json["body"]["plain_text"]
   end
 
   test "update as JSON" do
@@ -111,6 +115,11 @@ class Cards::CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal "Updated comment", comment.reload.body.to_plain_text
+
+    json = @response.parsed_body
+    assert_equal comment.id, json["id"]
+    assert_equal "Updated comment", json["body"]["plain_text"]
+    assert_equal comment.creator.id, json["creator"]["id"]
   end
 
   test "edit a comment that contains a mention" do


### PR DESCRIPTION
## Summary

The JSON response for `PUT /:account_slug/cards/:card_number/comments/:comment_id` was `204 No Content`, which conflicted with both the API docs ("Returns the updated comment") and the Smithy contract the SDKs are generated from, which declares `UpdateComment` returns a Comment.

Rendering the `show` template on the JSON path makes the response match what the docs and spec already advertise. The Turbo Stream path is unchanged.

Discovered during a fizzy-cli QA sweep — same class of issue as #2848, #2849, #2851.

## Changes

- `app/controllers/cards/comments_controller.rb` — `format.json { head :no_content }` → `format.json { render :show }`
- `test/controllers/cards/comments_controller_test.rb` — both "update as JSON" tests now assert the returned body (id, body plain_text, creator)
- No docs change: `docs/api/sections/comments.md` already reads "Returns the updated comment."

## Mobile App check

- Neither mobile app has native client code calling `PUT /cards/:n/comments/:id`
- Neither mobile app has code paths that depend on this endpoint returning `204 No Content`
- Neither mobile app is affected by this response change to `200 OK` with the updated comment
