### PR TITLE
Return updated user on PUT /users/:id

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       respond_to do |format|
         format.html { redirect_to @user }
-        format.json { head :no_content }
+        format.json { render :show }
       end
     else
       respond_to do |format|

--- a/docs/api/sections/users.md
+++ b/docs/api/sections/users.md
@@ -88,7 +88,7 @@ __Request:__
 
 __Response:__
 
-Returns `204 No Content` on success.
+Returns `200 OK` with the updated user in the same shape as `GET /:account_slug/users/:user_id`.
 
 ## `DELETE /:account_slug/users/:user_id/avatar`
 

--- a/test/controllers/api/flat_json_params_test.rb
+++ b/test/controllers/api/flat_json_params_test.rb
@@ -184,8 +184,10 @@ class FlatJsonParamsTest < ActionDispatch::IntegrationTest
   test "update user with flat JSON" do
     put user_path(users(:david)), params: { name: "Flat Name" }, as: :json
 
-    assert_response :no_content
+    assert_response :success
     assert_equal "Flat Name", users(:david).reload.name
+    assert_equal users(:david).id, @response.parsed_body["id"]
+    assert_equal "Flat Name", @response.parsed_body["name"]
   end
 
   test "create webhook with flat JSON" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -120,8 +120,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     put user_path(users(:david)), params: { user: { name: "New David" } }, as: :json
 
-    assert_response :no_content
+    assert_response :success
     assert_equal "New David", users(:david).reload.name
+
+    json = @response.parsed_body
+    assert_equal users(:david).id, json["id"]
+    assert_equal "New David", json["name"]
   end
 
   test "update as JSON with invalid avatar returns errors" do


### PR DESCRIPTION
## Summary

The JSON response for `PUT /:account_slug/users/:user_id` was `204 No Content`, forcing clients to follow up with a `GET`. The Smithy contract that the SDKs are generated from already declares `UpdateUser` returns a User, so the server was out of sync with the documented shape.

Rendering the `show` template on the JSON path makes the update return the same payload as `GET /:account_slug/users/:user_id`. The HTML redirect is unchanged.

This endpoint only accepts `name` and `avatar` — neither of which can revoke the acting user's access — so (unlike #2848 for boards) no access-check branch is needed.

Discovered during a fizzy-cli QA sweep — same class of issue as #2848, #2849, #2851, #2852.

## Changes

- `app/controllers/users_controller.rb` — `format.json { head :no_content }` → `format.json { render :show }`
- `test/controllers/users_controller_test.rb` — "update as JSON" test now asserts id and name on the returned body
- `docs/api/sections/users.md` — replaced "Returns 204 No Content" with the 200 response shape

## Mobile App check

- Neither mobile app has native client code calling `PUT /users/:id`
- Neither mobile app uses `/users/:id` as this JSON update endpoint; it is only used for navigation/web routes
- Neither mobile app is affected by this response change from `204 No Content` to `200 OK` with the updated user
