### PR TITLE
Add since/until date filtering to activities endpoint

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -25,6 +25,8 @@ class ActivitiesController < ApplicationController
         .where(action: ACTIONS)
         .for_creators(params[:creator_ids])
         .for_boards(params[:board_ids])
+        .since_date(params[:since])
+        .until_date(params[:until])
         .reverse_chronologically
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,8 +12,8 @@ class Event < ApplicationRecord
   scope :reverse_chronologically, -> { order created_at: :desc, id: :desc }
   scope :for_creators, ->(ids) { where(creator_id: ids) if ids.present? }
   scope :for_boards, ->(ids) { where(board_id: ids) if ids.present? }
-  scope :since_date, ->(date) { where("events.created_at >= ?", Date.parse(date).beginning_of_day) if date.present? }
-  scope :until_date, ->(date) { where("events.created_at <= ?", Date.parse(date).end_of_day) if date.present? }
+  scope :since_date, ->(date) { where("events.created_at >= ?", Date.iso8601(date).beginning_of_day) if date.present? rescue nil }
+  scope :until_date, ->(date) { where("events.created_at <= ?", Date.iso8601(date).end_of_day) if date.present? rescue nil }
   scope :preloaded, -> {
     includes(:creator, :board, {
       eventable: [

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,8 @@ class Event < ApplicationRecord
   scope :reverse_chronologically, -> { order created_at: :desc, id: :desc }
   scope :for_creators, ->(ids) { where(creator_id: ids) if ids.present? }
   scope :for_boards, ->(ids) { where(board_id: ids) if ids.present? }
+  scope :since_date, ->(date) { where("events.created_at >= ?", Date.parse(date).beginning_of_day) if date.present? }
+  scope :until_date, ->(date) { where("events.created_at <= ?", Date.parse(date).end_of_day) if date.present? }
   scope :preloaded, -> {
     includes(:creator, :board, {
       eventable: [

--- a/docs/api/sections/activities.md
+++ b/docs/api/sections/activities.md
@@ -12,6 +12,8 @@ __Query Parameters:__
 |-----------|-------------|
 | `creator_ids[]` | Filter to activities created by specific user ID(s). Multiple values are ORed. |
 | `board_ids[]` | Filter to activities on specific board ID(s). Multiple values are ORed. |
+| `since` | Return activities created on or after this date (ISO 8601: `YYYY-MM-DD`). |
+| `until` | Return activities created on or before this date (ISO 8601: `YYYY-MM-DD`). |
 
 Different filter params are ANDed together: `creator_ids[]=A&board_ids[]=X` means activities created by A on board X.
 

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -264,6 +264,75 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal total, all_ids.uniq.count
   end
 
+  test "index filters by since date" do
+    card = cards(:logo)
+    old_event = card.board.events.create!(
+      action: "card_published",
+      creator: users(:kevin),
+      eventable: card,
+      account: accounts("37s"),
+      created_at: 2.days.ago
+    )
+
+    get activities_path(since: Date.today.iso8601), as: :json
+    assert_response :success
+
+    ids = @response.parsed_body.map { |e| e["id"] }
+    assert_not_includes ids, old_event.id
+  end
+
+  test "index filters by until date" do
+    card = cards(:logo)
+    future_event = card.board.events.create!(
+      action: "card_published",
+      creator: users(:kevin),
+      eventable: card,
+      account: accounts("37s"),
+      created_at: 2.days.from_now
+    )
+
+    get activities_path(until: Date.today.iso8601), as: :json
+    assert_response :success
+
+    ids = @response.parsed_body.map { |e| e["id"] }
+    assert_not_includes ids, future_event.id
+  end
+
+  test "index filters by since and until together" do
+    card = cards(:logo)
+    board = card.board
+
+    old_event = board.events.create!(
+      action: "card_published",
+      creator: users(:kevin),
+      eventable: card,
+      account: accounts("37s"),
+      created_at: 5.days.ago
+    )
+    matching_event = board.events.create!(
+      action: "card_published",
+      creator: users(:kevin),
+      eventable: card,
+      account: accounts("37s"),
+      created_at: 2.days.ago
+    )
+    future_event = board.events.create!(
+      action: "card_published",
+      creator: users(:kevin),
+      eventable: card,
+      account: accounts("37s"),
+      created_at: 2.days.from_now
+    )
+
+    get activities_path(since: 3.days.ago.to_date.iso8601, until: Date.today.iso8601), as: :json
+    assert_response :success
+
+    ids = @response.parsed_body.map { |e| e["id"] }
+    assert_includes ids, matching_event.id
+    assert_not_includes ids, old_event.id
+    assert_not_includes ids, future_event.id
+  end
+
   private
     def next_page_from_link_header(link_header)
       url = link_header&.match(/<([^>]+)>;\s*rel="next"/)&.captures&.first

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -266,35 +266,47 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
 
   test "index filters by since date" do
     card = cards(:logo)
-    old_event = card.board.events.create!(
-      action: "card_published",
-      creator: users(:kevin),
-      eventable: card,
-      account: accounts("37s"),
+    board = card.board
+
+    old_event = board.events.create!(
+      action: "card_published", creator: users(:kevin),
+      eventable: card, account: accounts("37s"),
       created_at: 2.days.ago
     )
+    matching_event = board.events.create!(
+      action: "card_published", creator: users(:kevin),
+      eventable: card, account: accounts("37s"),
+      created_at: 12.hours.ago
+    )
 
-    get activities_path(since: Date.today.iso8601), as: :json
+    get activities_path(since: Date.current.iso8601), as: :json
     assert_response :success
 
     ids = @response.parsed_body.map { |e| e["id"] }
+    assert_includes ids, matching_event.id
     assert_not_includes ids, old_event.id
   end
 
   test "index filters by until date" do
     card = cards(:logo)
-    future_event = card.board.events.create!(
-      action: "card_published",
-      creator: users(:kevin),
-      eventable: card,
-      account: accounts("37s"),
+    board = card.board
+
+    matching_event = board.events.create!(
+      action: "card_published", creator: users(:kevin),
+      eventable: card, account: accounts("37s"),
+      created_at: 12.hours.ago
+    )
+    future_event = board.events.create!(
+      action: "card_published", creator: users(:kevin),
+      eventable: card, account: accounts("37s"),
       created_at: 2.days.from_now
     )
 
-    get activities_path(until: Date.today.iso8601), as: :json
+    get activities_path(until: Date.current.iso8601), as: :json
     assert_response :success
 
     ids = @response.parsed_body.map { |e| e["id"] }
+    assert_includes ids, matching_event.id
     assert_not_includes ids, future_event.id
   end
 


### PR DESCRIPTION
## Summary
Adds `since` and `until` query parameters to the `GET /:account_slug/activities` endpoint so API clients can filter the activity feed by date range.

Requested in #2832.

## Changes

- `app/controllers/activities_controller.rb` - filter activities by since and until params
- `app/models/event.rb` - add since_date and until_date scopes to Event
- `docs/api/sections/activities.md` - document the new query parameters
- `test/controllers/activities_controller_test.rb` - add controller tests for date filtering

## Usage
`GET /:account_slug/activities?since=2026-04-01`
`GET /:account_slug/activities?until=2026-04-21`
`GET /:account_slug/activities?since=2026-04-01&until=2026-04-21`

Dates are ISO 8601 (YYYY-MM-DD)