### PR TITLE
dep: update queenbee and audits1984 to avoid deprecation warnings

### DIFF
--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -8,7 +8,7 @@ gem "actionpack-xml_parser" # needed by queenbee for XML request body parsing
 gem "queenbee", bc: "queenbee-plugin"
 gem "fizzy-saas", path: "saas"
 gem "console1984", bc: "console1984"
-gem "audits1984", bc: "audits1984", branch: "flavorjones/coworker-api"
+gem "audits1984", bc: "audits1984"
 
 # Native push notifications (iOS/Android)
 gem "action_push_native"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/basecamp/audits1984
-  revision: 422b8ff25820c828b7cf09aff4923fd8cc2c6795
-  branch: flavorjones/coworker-api
+  revision: 4271a8e1f02f0f35d749c938bf4dcccf902b4190
   specs:
     audits1984 (0.1.7)
       console1984
@@ -23,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/queenbee-plugin
-  revision: 14312a940471e20617b38cdec7c092a01567d18b
+  revision: c0119be5940edb3739d4bb591c1a5c7064881638
   specs:
     queenbee (3.2.0)
       activeresource


### PR DESCRIPTION
In SaaS mode, we're getting `require_dependency` deprecation warnings from `queenbee` and `audits1984`. I've fixed those gems, let's update.