### PR TITLE
Fix potentially uninitialized locals

### DIFF
--- a/app/views/prompts/commands/_command.html.erb
+++ b/app/views/prompts/commands/_command.html.erb
@@ -1,8 +1,8 @@
-<% command, description, editor_version = command %>
+<% command_name, description, editor_version = prompt_command %>
 
-<lexxy-prompt-item search="<%= description %> <%= command %>">
+<lexxy-prompt-item search="<%= description %> <%= command_name %>">
   <template type="menu">
-    <code><%= command %></code> <%= description %>
+    <code><%= command_name %></code> <%= description %>
   </template>
   <template type="editor">
     <%= editor_version.gsub(/ +$/, "&nbsp;").html_safe %>

--- a/app/views/prompts/commands/index.html.erb
+++ b/app/views/prompts/commands/index.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "prompts/commands/command", collection: @commands %>
+<%= render partial: "prompts/commands/command", collection: @commands, as: :prompt_command %>

--- a/test/models/account/data_transfer/action_text/rich_text_record_set_test.rb
+++ b/test/models/account/data_transfer/action_text/rich_text_record_set_test.rb
@@ -167,16 +167,24 @@ class Account::DataTransfer::ActionText::RichTextRecordSetTest < ActiveSupport::
 
   private
     def with_default_url_host(host)
+      options = nil
+      had_key = false
+      original = nil
+      changed_host = false
+
       options = Rails.application.routes.default_url_options
       had_key = options.key?(:host)
       original = options[:host]
       options[:host] = host
+      changed_host = true
       yield
     ensure
-      if had_key
-        options[:host] = original
-      else
-        options.delete(:host)
+      if changed_host
+        if had_key
+          options[:host] = original
+        else
+          options.delete(:host)
+        end
       end
     end
 end


### PR DESCRIPTION
## Summary

Fixes #2845.

- Rename the prompt command partial collection local to avoid shadowing itself during destructuring
- Guard the rich text data transfer test helper cleanup so it only restores URL options after setup succeeds

## Testing

- `bin/rails test test/models/account/data_transfer/action_text/rich_text_record_set_test.rb`
- `bin/rails test`