### PR TITLE
Add :account_slug prefix to account, my/pins and my/timezone API doc paths

### DIFF
--- a/docs/api/sections/account.md
+++ b/docs/api/sections/account.md
@@ -1,6 +1,6 @@
 # Account
 
-## `GET /account/settings`
+## `GET /:account_slug/account/settings`
 
 Returns the current account.
 
@@ -18,7 +18,7 @@ __Response:__
 
 The `auto_postpone_period_in_days` is the account-level default in days (e.g. `30`). Cards are automatically moved to "Not Now" after this period of inactivity. Each board can override this with its own value.
 
-## `GET /account/join_code`
+## `GET /:account_slug/account/join_code`
 
 Returns the account's join code for inviting new users. The join code URL can be shared with people to let them join the account.
 
@@ -36,7 +36,7 @@ __Response:__
 
 A join code is `active` when `usage_count` is less than `usage_limit`.
 
-## `PUT /account/join_code`
+## `PUT /:account_slug/account/join_code`
 
 Updates the join code's usage limit. Requires admin role.
 
@@ -58,7 +58,7 @@ __Response:__
 
 Returns `204 No Content` on success.
 
-## `DELETE /account/join_code`
+## `DELETE /:account_slug/account/join_code`
 
 Resets the join code, generating a new one and invalidating the old code. Requires admin role.
 
@@ -66,7 +66,7 @@ __Response:__
 
 Returns `204 No Content` on success.
 
-## `PUT /account/entropy`
+## `PUT /:account_slug/account/entropy`
 
 Updates the account-level default auto close period. Requires admin role.
 

--- a/docs/api/sections/exports.md
+++ b/docs/api/sections/exports.md
@@ -10,7 +10,7 @@ Possible export statuses are:
 
 Completed export files expire after 24 hours. When that happens, request a new export.
 
-## `POST /account/exports`
+## `POST /:account_slug/account/exports`
 
 Starts an account export for the current account. Only account admins and owners can create account exports.
 
@@ -26,7 +26,7 @@ Returns `201 Created` with the export object:
 }
 ```
 
-## `GET /account/exports/:id`
+## `GET /:account_slug/account/exports/:id`
 
 Returns the status of an account export created by the current user.
 

--- a/docs/api/sections/identity.md
+++ b/docs/api/sections/identity.md
@@ -45,7 +45,7 @@ __Response:__
 }
 ```
 
-## `PATCH /my/timezone`
+## `PATCH /:account_slug/my/timezone`
 
 Updates the current user's timezone. This affects how times are displayed in notification emails.
 

--- a/docs/api/sections/pins.md
+++ b/docs/api/sections/pins.md
@@ -18,7 +18,7 @@ __Response:__
 
 Returns `204 No Content` on success.
 
-## `GET /my/pins`
+## `GET /:account_slug/my/pins`
 
 Returns the current user's pinned cards. This endpoint is not paginated and returns up to 100 cards.
 


### PR DESCRIPTION
Nine paths in `docs/api/sections/{account,exports,pins,identity}.md` are documented without the `:account_slug` prefix, but the routes are mounted inside the per-account scope (see `namespace :account` and `namespace :my` in `config/routes.rb`). The other paths in the same files already use `/:account_slug/...`; this PR fixes the ones that don't.

| File | Documented as | Should be |
|---|---|---|
| `pins.md` | `GET /my/pins` | `GET /:account_slug/my/pins` |
| `account.md` | `GET /account/settings` | `GET /:account_slug/account/settings` |
| `account.md` | `GET /account/join_code` | `GET /:account_slug/account/join_code` |
| `account.md` | `PUT /account/join_code` | `PUT /:account_slug/account/join_code` |
| `account.md` | `DELETE /account/join_code` | `DELETE /:account_slug/account/join_code` |
| `account.md` | `PUT /account/entropy` | `PUT /:account_slug/account/entropy` |
| `exports.md` | `POST /account/exports` | `POST /:account_slug/account/exports` |
| `exports.md` | `GET /account/exports/:id` | `GET /:account_slug/account/exports/:id` |
| `identity.md` | `PATCH /my/timezone` | `PATCH /:account_slug/my/timezone` |

**AI Use Disclaimer:** this issue was found by an AI coding agent while working on a project that uses the Fizzy API.