### PR TITLE
Fix race between auto-save and publish on Cmd+Enter

### DIFF
--- a/app/javascript/controllers/clicker_controller.js
+++ b/app/javascript/controllers/clicker_controller.js
@@ -3,8 +3,12 @@ import { nextFrame } from "helpers/timing_helpers";
 
 export default class extends Controller {
   static targets = [ "clickable" ]
+  static outlets = [ "auto-save" ]
 
   async click() {
+    if (this.hasAutoSaveOutlet) {
+      await this.autoSaveOutlet.submit()
+    }
     await nextFrame()
     this.#clickable.click()
   }

--- a/app/views/cards/container/footer/_create.html.erb
+++ b/app/views/cards/container/footer/_create.html.erb
@@ -3,13 +3,13 @@
     <%= button_to card_publish_path(card), name: "creation_type", value: "add", class: "btn",
           title: "Create card (#{ hotkey_label(["ctrl", "enter"]) })",
           form: { data: { controller: "form bridge--form" } },
-          data: { form_target: "submit", bridge__form_target: "submit", controller: "clicker", action: "keydown.ctrl+enter@document->clicker#click keydown.meta+enter@document->clicker#click" } do %>
+          data: { form_target: "submit", bridge__form_target: "submit", controller: "clicker", clicker_auto_save_outlet: "#card_form", action: "keydown.ctrl+enter@document->clicker#click keydown.meta+enter@document->clicker#click" } do %>
       <span>Create card</span>
     <% end %>
 
     <%= button_to card_publish_path(card), method: :post, class: "btn btn--reversed", name: "creation_type", value: "add_another",
           title: "Create and add another (#{ hotkey_label(["ctrl", "shift", "enter"]) })", form: { data: { controller: "form" } },
-          data: { form_target: "submit", controller: "clicker", action: "keydown.ctrl+shift+enter@document->clicker#click keydown.meta+shift+enter@document->clicker#click" } do %>
+          data: { form_target: "submit", controller: "clicker", clicker_auto_save_outlet: "#card_form", action: "keydown.ctrl+shift+enter@document->clicker#click keydown.meta+shift+enter@document->clicker#click" } do %>
       <span>Create and add another</span>
     <% end %>
   </div>

--- a/test/system/card_creation_race_test.rb
+++ b/test/system/card_creation_race_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class CardCreationRaceTest < ApplicationSystemTestCase
+  # Reproduces the race documented in #2778: when the user types a title in a
+  # new draft and immediately presses Cmd/Ctrl+Enter, the publish request can
+  # reach the server before the auto-save PATCH commits the title. The publish
+  # callback then writes "Untitled", which the late PATCH rewrites — generating
+  # a phantom `card_title_changed` event and a system comment as a side effect.
+  setup do
+    CardsController.class_eval do
+      alias_method :_update_without_test_delay, :update
+      def update
+        sleep 0.5
+        _update_without_test_delay
+      end
+    end
+  end
+
+  teardown do
+    CardsController.class_eval do
+      alias_method :update, :_update_without_test_delay
+      remove_method :_update_without_test_delay
+    end
+  end
+
+  test "Cmd+Enter on a new draft preserves the typed title without phantom events or system comments" do
+    sign_in_as(users(:david))
+
+    visit board_url(boards(:writebook))
+    click_on "Add a card"
+
+    title_field = find("textarea[name='card[title]']")
+    title_field.send_keys "Race fix verified"
+    title_field.send_keys [ :control, :enter ]
+
+    assert_current_path board_path(boards(:writebook))
+    assert_text "Race fix verified" # wait for late PATCH to commit before assertions
+
+    card = Card.where(creator: users(:david)).order(:created_at).last
+    assert_equal "Race fix verified", card.reload.title
+    assert card.published?, "card should be published"
+    refute Event.exists?(action: "card_title_changed", eventable: card),
+      "publish should not generate a phantom card_title_changed event"
+    refute card.comments.any? { |c| c.body.to_plain_text.include?("changed the title") },
+      "publish should not generate a phantom 'changed the title' system comment"
+  end
+end


### PR DESCRIPTION
## Summary

When the user types a title and immediately presses Cmd+Enter on a new draft, the publish request can reach the server before the auto-save PATCH commits the title. The `before_save` callback in `Card` then writes `"Untitled"` (since `card.title` is still `nil` in memory), and the late PATCH overwrites it with the typed value. The intermediate state has several visible side effects:

- Phantom `card_title_changed` event is recorded.
- System comment _"changed the title from 'Untitled' to '<typed>'"_ is created on the brand-new card.
- Webhook subscribers receive a fake `card_title_changed` delivery.
- The board view shows `"Untitled"` until the Turbo Stream broadcast from the late PATCH replaces it — which is why the bug is hard to notice on fast setups but stuck-visible on slow self-hosted instances (#2778).

## Fix

Add an optional `auto-save` outlet to `clicker_controller`. When wired up via `clicker_auto_save_outlet="#card_form"` on the **Create card** / **Create and add another** buttons, `clicker` awaits the auto-save submit before triggering the publish click. Backwards-compatible: `clicker` without the outlet behaves exactly as before.

## Reproduction

Adding `sleep 0.6` to `CardsController#update` widens the race window and reliably reproduces the bug. The included system test uses the same technique.

## Test plan

- [x] System test in `test/system/card_creation_race_test.rb` — TDD-validated (fails on `main`, passes with this commit).
- [x] Asserts: typed title preserved on the board view, no phantom `card_title_changed` event, no `"changed the title from..."` system comment.
- [x] All existing tests remain green (`bin/ci`).

## Prior art

@LuisMSAmorim outlined the same root cause and proposed a similar outlet-based approach in #2362; this PR extends that analysis with a reliable repro and documents the data-pollution side effects.

Closes #2778