### PR TITLE
Upgrade lexxy to 0.9.14.beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "geared_pagination", "~> 1.2"
 gem "rqrcode"
 gem "rouge"
 gem "jbuilder"
-gem "lexxy", "0.9.5.beta"
+gem "lexxy", "0.9.14.beta"
 gem "image_processing", "~> 1.14"
 gem "platform_agent"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.19.3)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kamal (2.11.0)
       activesupport (>= 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.9.5.beta)
+    lexxy (0.9.14.beta)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -518,7 +518,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  lexxy (= 0.9.5.beta)
+  lexxy (= 0.9.14.beta)
   mission_control-jobs
   mittens
   mocha

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -346,7 +346,7 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.19.3)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kamal (2.11.0)
       activesupport (>= 7.0)

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -366,7 +366,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.9.5.beta)
+    lexxy (0.9.14.beta)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -723,7 +723,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  lexxy (= 0.9.5.beta)
+  lexxy (= 0.9.14.beta)
   mission_control-jobs
   mittens
   mocha

--- a/app/assets/stylesheets/lexxy.css
+++ b/app/assets/stylesheets/lexxy.css
@@ -65,11 +65,12 @@
     }
   }
 
-  .lexxy-editor__toolbar-button {
+  /* Exclude the link dropdown's action buttons — they keep the gem's accent/gray background. */
+  .lexxy-editor__toolbar-button:not(.lexxy-editor__toolbar-dropdown-actions *) {
     background: transparent;
 
     &[aria-pressed="true"],
-    [open] > & {
+    &[aria-expanded="true"] {
       background-color: oklch(var(--lch-blue-medium) / 20%);
     }
 
@@ -80,17 +81,19 @@
     }
   }
 
-  .lexxy-editor__toolbar-dropdown--chevron {
-    summary:after {
+  .lexxy-editor__toolbar-button--chevron {
+    &:after {
       block-size: 0.3rem;
       inline-size: 0.3rem;
     }
   }
 
   lexxy-link-dropdown {
-    --lexxy-toolbar-spacing: 1.5ch;
+    [data-dropdown-panel] {
+      --lexxy-toolbar-spacing: 1.5ch;
+    }
 
-    .lexxy-editor__toolbar-button {
+    .lexxy-editor__toolbar-dropdown-actions .lexxy-editor__toolbar-button {
       border-radius: 99rem;
 
       @media(any-hover: hover) {
@@ -100,12 +103,16 @@
         }
       }
 
-      &[type="submit"],
-      &[type="submit"]:hover {
+      &[value="link"] {
         background-color: var(--color-link);
+        color: var(--color-ink-inverted);
+
+        &:hover {
+          background-color: var(--color-link);
+        }
       }
 
-      &[type="button"] {
+      &[value="unlink"] {
         border: 1px solid var(--color-ink-light);
       }
     }


### PR DESCRIPTION
## Summary

Upgrade **lexxy** from `0.9.5.beta` to `0.9.14.beta` (the latest `.beta` release).

208 upstream commits analyzed — **1 definite-impact / 23 likely / 61 unlikely / 123 no impact**. lexxy reworked its toolbar dropdowns from `<details>/<summary>` into a JS-driven `<button aria-expanded>` + `<div role="menu" hidden>` structure, which broke several of fizzy's CSS overrides that hooked into the old DOM. **No transitive dependencies changed** (lexxy's only dependency, `rails (>= 8.0.2)`, was already satisfied).

## Changes

- **Bump the gem** and sync both `Gemfile.lock` (OSS) and `Gemfile.saas.lock` (SaaS).
- **Bump `jwt` 3.1.2 → 3.2.0** to clear CVE-2026-45363 (GHSA-c32j-vqhx-rx3x). Separate from lexxy — a pre-existing advisory carried along on this branch.
- **Update toolbar dropdown CSS** (`app/assets/stylesheets/lexxy.css`):
  - active-dropdown button background: `[open] > &` → `&[aria-expanded="true"]` (open state now lives on the trigger button, not a `<details open>` parent)
  - chevron sizing: `.lexxy-editor__toolbar-dropdown--chevron summary:after` → `.lexxy-editor__toolbar-button--chevron:after` (the `--chevron` modifier moved from the container to the button)
- **Scope the `lexxy-link-dropdown` overrides to the dropdown panel.** `<lexxy-link-dropdown>` now wraps the link *trigger* too (it used to wrap only the panel), so fizzy's action-button styling leaked onto the trigger — a stray pill/circle border and an inflated separator margin. Scoped the button styling to `.lexxy-editor__toolbar-dropdown-actions` and the `--lexxy-toolbar-spacing: 1.5ch` to `[data-dropdown-panel]`.
- **Fix the Link/Unlink button contrast, and give Link an accent.** fizzy's blanket `.lexxy-editor__toolbar-button { background: transparent }` was stripping the gem's intended Link/Unlink backgrounds, leaving near-invisible text on the panel. Excluded the dropdown-action buttons from that rule so their backgrounds show through, then pointed the (previously dead) primary-button override at the real selector — it targeted `&[type="submit"]`, but lexxy renders the button as `<button type="button" value="link">`, so it never matched. The Link button now uses fizzy's `--color-link` accent (matching the `.btn--link` convention) and reads as the primary action; Unlink stays muted. _The low-contrast bug was pre-existing, not caused by the bump — fixed here while in the area._

fizzy's overrides live in `@layer components`, which wins over the gem's `layer(base)` (declared order: `reset, base, components, …`), so the retargeted selectors apply just as the originals did.

## Verification

| Gate | Result |
|------|--------|
| OSS unit tests | 1505 runs, 5717 assertions, **0 failures / 0 errors** |
| SaaS unit tests | 1615 runs, 6042 assertions, **0 failures / 0 errors** |
| System tests (browser) | 12 runs, 41 assertions, **0 failures / 0 errors** |
| rubocop | 851 files, **no offenses** |
| Gemfile drift check | **in sync** (both lockfiles) |
| gem audit / importmap / brakeman / gitleaks | **all clean** (jwt advisory resolved) |

System tests exercise the editor in a real browser (the overhauled `value=` setter via `fill_in_lexxy`, the required-field validity flow through an image upload, markdown paste / `<br>` handling, attachment gallery + lightbox), confirming the editor boots and behaves on the bundled Lexical 0.42 → 0.44 bump.

The toolbar CSS was also **verified live in the dev app** (Chrome DevTools): all four dropdowns (Format / Highlight / Link / overflow) show the correct active-button background and open/close correctly; the Link trigger renders identically to a normal toolbar button (no border, normal separator spacing); and the Link/Unlink action buttons are high-contrast (Link 8.97:1 on its accent fill, Unlink 12.23:1).

## Notes

Heads-up (not a fizzy change): lexxy `0.9.14.beta` moved **Strikethrough** and **Underline** out of the Format submenu to top-level toolbar buttons (upstream commit `78ccd3a0`). Intentional upstream behavior — kept as-is.

🤖 Assisted by Claude


