### PR TITLE
Update dependencies: erb 6.0.4, marcel 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     ed25519 (1.4.0)
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     mini_magick (5.3.1)
       logger

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -281,7 +281,7 @@ GEM
     drb (2.2.3)
     dry-initializer (3.2.0)
     ed25519 (1.4.0)
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -379,7 +379,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     mini_magick (5.3.1)
       logger


### PR DESCRIPTION
## Summary

Routine dependency updates (2026-05-31). Each gem analyzed commit-by-commit; full unit suite green after each.

| Gem | From | To | Commits | Mitigations | Transitive |
|-----|------|----|---------|-------------|------------|
| erb | 6.0.2 | 6.0.4 | 12 | 0 | 0 |
| marcel | 1.1.0 | 1.2.1 | 37 | 0 | 0 |

- **erb**: range is mostly CI/dependabot noise. Lone runtime change (`9d017be4`, block `def_method` on marshal-loaded ERB) doesn't affect Fizzy.
- **marcel**: transitive dep via ActiveStorage; public API unchanged. None of the changed MIME detections intersect Fizzy's accepted upload types. Also clears the frozen-string-literal warnings emitted by marcel 1.1.0.

Tests: 1506 runs, 5729 assertions, 0 failures after each upgrade.

## Upgrade Plans

Full per-gem analysis in 37signals-hq `upgrade-analysis/` and posted as PR comments below.

🤖 Assisted by Claude
