### PR TITLE
feat: allow renaming built-in board columns (Maybe?, Not Now, Done)

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -96,7 +96,7 @@ class BoardsController < ApplicationController
     end
 
     def board_params
-      params.expect(board: [ :name, :all_access, :auto_postpone_period_in_days, :public_description ])
+      params.expect(board: [ :name, :all_access, :auto_postpone_period_in_days, :public_description, :triage_column_name, :postponed_column_name, :closed_column_name ])
     end
 
     def grantees

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -6,6 +6,8 @@ class Board < ApplicationRecord
 
   has_rich_text :public_description
 
+  validates :triage_column_name, :postponed_column_name, :closed_column_name, presence: true
+
   has_many :tags, -> { distinct }, through: :cards
   has_many :events
   has_many :webhooks, dependent: :destroy

--- a/app/views/boards/edit.html.erb
+++ b/app/views/boards/edit.html.erb
@@ -20,6 +20,7 @@
           boards_form_self_removal_prompt_message_value: "Are you sure you want to remove yourself from this board? You won’t be able to get back in unless someone invites you.",
           action: "turbo:submit-start->boards-form#submitWithWarning" } do |form| %>
       <%= render "boards/edit/name", form: form, board: @board %>
+      <%= render "boards/edit/column_names", form: form, board: @board %>
       <%= render "boards/edit/users", board: @board, selected_users: @selected_users, unselected_users: @unselected_users, form: form %>
 
       <button type="submit" id="log_in" class="btn btn--link center txt-normal" data-bridge--form-target="submit" <%= "disabled" unless Current.user.can_administer_board?(@board) %>>

--- a/app/views/boards/edit/_auto_close.html.erb
+++ b/app/views/boards/edit/_auto_close.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag board, :entropy do %>
   <div class="margin-block-end">
     <h2 class="divider txt-large">Auto close</h2>
-    <p class=”margin-none-block-start”>Fizzy doesn’t let stale cards stick around forever. Cards automatically move to “<%= board.postponed_column_name %>” if no one updates, comments, or moves a card for…</p>
+    <p class="margin-none-block-start">Fizzy doesn’t let stale cards stick around forever. Cards automatically move to <%= board.postponed_column_name %> if no one updates, comments, or moves a card for…</p>
     <%= render "entropy/auto_close", model: board, url: board_entropy_path(board), disabled: !Current.user.can_administer_board?(board) %>
   </div>
 <% end %>

--- a/app/views/boards/edit/_auto_close.html.erb
+++ b/app/views/boards/edit/_auto_close.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag board, :entropy do %>
   <div class="margin-block-end">
     <h2 class="divider txt-large">Auto close</h2>
-    <p class="margin-none-block-start">Fizzy doesn’t let stale cards stick around forever. Cards automatically move to “Not now” if no one updates, comments, or moves a card for…</p>
+    <p class=”margin-none-block-start”>Fizzy doesn’t let stale cards stick around forever. Cards automatically move to “<%= board.postponed_column_name %>” if no one updates, comments, or moves a card for…</p>
     <%= render "entropy/auto_close", model: board, url: board_entropy_path(board), disabled: !Current.user.can_administer_board?(board) %>
   </div>
 <% end %>

--- a/app/views/boards/edit/_column_names.html.erb
+++ b/app/views/boards/edit/_column_names.html.erb
@@ -1,0 +1,27 @@
+<div class="margin-block-end">
+  <h2 class="divider txt-large">Column names</h2>
+  <p class="margin-none-block-start">Customize the names of the built-in columns on this board.</p>
+
+  <div class="flex flex-column gap margin-block-start">
+    <label>
+      <div class="txt-small translucent margin-block-end-half">Inbox</div>
+      <%= form.text_field :triage_column_name, class: "input full-width", required: true,
+            placeholder: "Maybe?",
+            readonly: !Current.user.can_administer_board?(board) %>
+    </label>
+
+    <label>
+      <div class="txt-small translucent margin-block-end-half">Postponed</div>
+      <%= form.text_field :postponed_column_name, class: "input full-width", required: true,
+            placeholder: "Not Now",
+            readonly: !Current.user.can_administer_board?(board) %>
+    </label>
+
+    <label>
+      <div class="txt-small translucent margin-block-end-half">Closed</div>
+      <%= form.text_field :closed_column_name, class: "input full-width", required: true,
+            placeholder: "Done",
+            readonly: !Current.user.can_administer_board?(board) %>
+    </label>
+  </div>
+</div>

--- a/app/views/boards/show/_closed.html.erb
+++ b/app/views/boards/show/_closed.html.erb
@@ -1,4 +1,4 @@
-<%= column_tag id: "closed-cards", name: "Done", drop_url: columns_card_drops_closure_path("__id__"), class: "cards--closed", style: "--card-color: var(--color-card-complete);",
+<%= column_tag id: "closed-cards", name: board.closed_column_name, drop_url: columns_card_drops_closure_path("__id__"), class: "cards--closed", style: "--card-color: var(--color-card-complete);",
   data: {
     card_hotkeys_disabled: true,
     drag_and_strum_target: "container",
@@ -6,7 +6,7 @@
     action: "focus->collapsible-columns#focusOnColumn"
   } do %>
   <header class="cards__header">
-    <%= render "boards/show/expander", title: "Done", count: board.cards.closed.count, column_id: "closed-cards" %>
+    <%= render "boards/show/expander", title: board.closed_column_name, count: board.cards.closed.count, column_id: "closed-cards" %>
     <%= render "boards/show/menu/maximize", column_path: board_columns_closed_path(board) %>
   </header>
   <%= column_frame_tag :closed_column, src: board_columns_closed_path(board) %>

--- a/app/views/boards/show/_not_now.html.erb
+++ b/app/views/boards/show/_not_now.html.erb
@@ -1,4 +1,4 @@
-<%= column_tag id: "not-now", name: "Not Now", drop_url: columns_card_drops_not_now_path("__id__"), class: "cards--on-deck", style: "--card-color: var(--color-card-complete);",
+<%= column_tag id: "not-now", name: board.postponed_column_name, drop_url: columns_card_drops_not_now_path("__id__"), class: "cards--on-deck", style: "--card-color: var(--color-card-complete);",
   data: {
     card_hotkeys_disabled: true,
     collapsible_columns_target: "column",
@@ -6,7 +6,7 @@
     action: "focus->collapsible-columns#focusOnColumn"
   } do %>
   <header class="cards__header">
-    <%= render "boards/show/expander", title: "Not Now", count: board.cards.postponed.count, column_id: "not-now" %>
+    <%= render "boards/show/expander", title: board.postponed_column_name, count: board.cards.postponed.count, column_id: "not-now" %>
     <%= render "boards/show/menu/maximize", column_path: board_columns_not_now_path(board) %>
   </header>
   <%= column_frame_tag :not_now_column, src: board_columns_not_now_path(board) %>

--- a/app/views/boards/show/_stream.html.erb
+++ b/app/views/boards/show/_stream.html.erb
@@ -1,10 +1,10 @@
-<%= column_tag id: "maybe", name: "Maybe?", drop_url: columns_card_drops_stream_path("__id__"), collapsed: false, selected: "true", class: "cards--maybe", data: {
+<%= column_tag id: "maybe", name: board.triage_column_name, drop_url: columns_card_drops_stream_path("__id__"), collapsed: false, selected: "true", class: "cards--maybe", data: {
   drag_and_strum_target: "container",
   collapsible_columns_target: "column maybeColumn",
   action: "focus->collapsible-columns#focusOnColumn"
 } do %>
   <header class="cards__header">
-    <%= render "boards/show/expander", title: "Maybe?", count: board.cards.awaiting_triage.count, column_id: "maybe" %>
+    <%= render "boards/show/expander", title: board.triage_column_name, count: board.cards.awaiting_triage.count, column_id: "maybe" %>
     <%= render "boards/show/menu/maximize", column_path: board_columns_stream_path(board) %>
   </header>
   <div data-bridge-disabled="true">

--- a/app/views/cards/columns/edit.html.erb
+++ b/app/views/cards/columns/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="card__stages" role="radiogroup" data-controller="scroll-to">
     <legend class="for-screen-reader">Choose a column for this card</legend>
 
-    <%= button_to "Not now", card_not_now_path(@card),
+    <%= button_to @card.board.postponed_column_name, card_not_now_path(@card),
         class: [ "card__column-name btn", { "card__column-name--current": @card.postponed? } ],
         style: "--column-color: var(--color-card-complete)",
         disabled: @card.postponed?,
@@ -11,7 +11,7 @@
         data: { scroll_to_target: @card.postponed? ? "target" : nil },
         form_class: "flex gap-half" %>
 
-    <%= button_to "Maybe?", card_triage_path(@card), method: :delete,
+    <%= button_to @card.board.triage_column_name, card_triage_path(@card), method: :delete,
         class: [ "card__column-name card__column-name--stream btn", { "card__column-name--current": @card.awaiting_triage? } ],
         style: "--column-color: var(--color-card-default)",
         disabled: @card.awaiting_triage?,
@@ -33,7 +33,7 @@
         data: { scroll_to_target: @card.closed? ? "target" : nil },
         form_class: "flex gap-half" do %>
           <%= icon_tag "check", class: "icon--mobile-only" %>
-          Done
+          <%= @card.board.closed_column_name %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/cards/display/common/_stamp.html.erb
+++ b/app/views/cards/display/common/_stamp.html.erb
@@ -1,24 +1,26 @@
 <% if card.postponed? %>
+  <% postponed_column_name = card.board.postponed_column_name %>
   <%= tag.div class: token_list("card__closed", "card__closed--system": card.postponed_by&.system?), data: {
     controller: "bridge--stamp",
     bridge__stamp_scope_selector_value: ".card-perma",
-    bridge_title: "Not Now",
+    bridge_title: postponed_column_name,
     bridge_description: card.postponed_at.strftime("%b %d, %Y")
   } do %>
-    <span class="card__closed-title" data-text="Not Now">Not Now</span>
+    <span class="card__closed-title" data-text="<%= postponed_column_name %>"><%= postponed_column_name %></span>
     <strong class="card__closed-date"><%= card.postponed_at.strftime("%b %d, %Y") %></strong>
     <span class="card__closed-by-line">by <span class="card__closed-by"><%= card.postponed_by&.familiar_name %></span></span>
   <% end %>
 <% end %>
 
 <% if card.closed? %>
+  <% closed_column_name = card.board.closed_column_name %>
   <%= tag.div class: "card__closed", data: {
     controller: "bridge--stamp",
     bridge__stamp_scope_selector_value: ".card-perma",
-    bridge_title: "Done",
+    bridge_title: closed_column_name,
     bridge_description: card.closed_at.strftime("%b %d, %Y")
   } do %>
-    <span class="card__closed-title" data-text="Done">Done</span>
+    <span class="card__closed-title" data-text="<%= closed_column_name %>"><%= closed_column_name %></span>
     <strong class="card__closed-date"><%= card.closed_at.strftime("%b %d, %Y") %></strong>
     <span class="card__closed-by-line">by <span class="card__closed-by"><%= card.closed_by.familiar_name %></span></span>
   <% end %>

--- a/app/views/public/boards/show/_closed.html.erb
+++ b/app/views/public/boards/show/_closed.html.erb
@@ -5,7 +5,7 @@
 
   <div class="cards__transition-container">
     <header class="cards__header">
-      <%= render "boards/show/expander", title: "Done", count: board.cards.closed.published.count, column_id: "closed-cards" %>
+      <%= render "boards/show/expander", title: board.closed_column_name, count: board.cards.closed.published.count, column_id: "closed-cards" %>
 
       <%= link_to public_board_columns_closed_url(board.publication.key), class: "cards__maximize-button btn btn--circle txt-x-small borderless", data: { turbo_frame: "_top" } do %>
         <%= icon_tag "grid", class: "translucent" %>

--- a/app/views/public/boards/show/_not_now.html.erb
+++ b/app/views/public/boards/show/_not_now.html.erb
@@ -5,7 +5,7 @@
 
   <div class="cards__transition-container">
     <header class="cards__header">
-      <%= render "boards/show/expander", title: "Not Now", count: board.cards.postponed.count, column_id: "not-now" %>
+      <%= render "boards/show/expander", title: board.postponed_column_name, count: board.cards.postponed.count, column_id: "not-now" %>
 
       <%= link_to public_board_columns_not_now_url(board.publication.key), class: "cards__maximize-button btn btn--circle txt-x-small borderless", data: { turbo_frame: "_top" } do %>
         <%= icon_tag "grid", class: "translucent" %>

--- a/app/views/public/boards/show/_stream.html.erb
+++ b/app/views/public/boards/show/_stream.html.erb
@@ -1,16 +1,16 @@
 <section id="maybe"
   class="cards cards--maybe is-expanded"
-  data-column-name="Maybe?"
+  data-column-name="<%= board.triage_column_name %>"
   data-collapsible-columns-target="column maybeColumn"
   data-action="turbo:before-morph-attribute->collapsible-columns#preventToggle">
   <div class="cards__transition-container">
     <header class="cards__header">
       <div hidden class="cards__expander">
-        <h2 class="cards__expander-title" data-collapsible-columns-target="title">Maybe?</h2>
+        <h2 class="cards__expander-title" data-collapsible-columns-target="title"><%= board.triage_column_name %></h2>
       </div>
 
       <%# render "boards/show/expander", title: "Maybe?", count: column.cards.active.count, column_id: dom_id(column) %>
-      <%= render "boards/show/expander", title: "Maybe?", count: 2, column_id: "maybe" %>
+      <%= render "boards/show/expander", title: board.triage_column_name, count: 2, column_id: "maybe" %>
 
       <%= link_to public_board_columns_stream_url(board.publication.key), class: "cards__maximize-button btn btn--circle txt-x-small borderless", data: { turbo_frame: "_top" } do %>
         <%= icon_tag "grid", class: "translucent" %>

--- a/db/migrate/20260602120000_add_custom_column_names_to_boards.rb
+++ b/db/migrate/20260602120000_add_custom_column_names_to_boards.rb
@@ -1,0 +1,7 @@
+class AddCustomColumnNamesToBoards < ActiveRecord::Migration[8.0]
+  def change
+    add_column :boards, :triage_column_name, :string, null: false, default: "Maybe?"
+    add_column :boards, :postponed_column_name, :string, null: false, default: "Not Now"
+    add_column :boards, :closed_column_name, :string, null: false, default: "Done"
+  end
+end

--- a/db/migrate/20260602120000_add_custom_column_names_to_boards.rb
+++ b/db/migrate/20260602120000_add_custom_column_names_to_boards.rb
@@ -1,4 +1,4 @@
-class AddCustomColumnNamesToBoards < ActiveRecord::Migration[8.0]
+class AddCustomColumnNamesToBoards < ActiveRecord::Migration[8.2]
   def change
     add_column :boards, :triage_column_name, :string, null: false, default: "Maybe?"
     add_column :boards, :postponed_column_name, :string, null: false, default: "Not Now"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_02_120000) do
   create_table "accesses", id: :uuid, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "accessed_at"
     t.uuid "account_id", null: false
@@ -171,9 +171,12 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
   create_table "boards", id: :uuid, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.uuid "account_id", null: false
     t.boolean "all_access", default: false, null: false
+    t.string "closed_column_name", default: "Done", null: false
     t.datetime "created_at", null: false
     t.uuid "creator_id", null: false
     t.string "name", null: false
+    t.string "postponed_column_name", default: "Not Now", null: false
+    t.string "triage_column_name", default: "Maybe?", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_boards_on_account_id"
     t.index ["creator_id"], name: "index_boards_on_creator_id"


### PR DESCRIPTION
Adds triage_column_name, postponed_column_name, and closed_column_name to boards so teams can customize the three fixed column labels per board. Defaults preserve existing behavior.