### PR TITLE
Update docker-deployment.md with additional info for SSL/TLS setup

### DIFF
--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -70,7 +70,7 @@ If you aren't using SSL at all (for example, if you want to run it locally on yo
 docker run --publish 80:80 --env DISABLE_SSL=true ...
 ```
 
-The TLS_DOMAIN setting uses Thunder and LetsEncrypt to automatically provide SSL/TLS access (https://github.com/basecamp/thruster)
+The TLS_DOMAIN setting uses Thruster and LetsEncrypt to automatically provide SSL/TLS access (https://github.com/basecamp/thruster)
 
 #### SMTP Email
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -70,7 +70,7 @@ If you aren't using SSL at all (for example, if you want to run it locally on yo
 docker run --publish 80:80 --env DISABLE_SSL=true ...
 ```
 
-The TLS_domain setting uses Thunder and LetsEncrypt to automatically provide SSL/TLS access (https://github.com/basecamp/thruster)
+The TLS_DOMAIN setting uses Thunder and LetsEncrypt to automatically provide SSL/TLS access (https://github.com/basecamp/thruster)
 
 #### SMTP Email
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -52,7 +52,7 @@ docker run --env SECRET_KEY_BASE=abcdefabcdef ...
 
 If you want the Fizzy container to handle its own SSL automatically, you just need to specify the domain name that you're running it on.
 You can do that with the `TLS_DOMAIN` environment variable.
-Note that if you're using SSL, you'll want to allow traffic on ports 80 and 443.
+Note that if you're using SSL, you'll want to allow traffic on ports 80 and 443 and allow access from the internet.
 So if you were running on `fizzy.example.com` you could enable SSL like this:
 
 ```sh
@@ -69,6 +69,8 @@ If you aren't using SSL at all (for example, if you want to run it locally on yo
 ```sh
 docker run --publish 80:80 --env DISABLE_SSL=true ...
 ```
+
+The TLS_domain setting uses Thunder and LetsEncrypt to automatically provide SSL/TLS access (https://github.com/basecamp/thruster)
 
 #### SMTP Email
 


### PR DESCRIPTION
More info to make it clear that ports 80 and 443 need to be published to the internet and that certificates are issued via LetsEncrypt.

