### PR TITLE
Fix search returning no results for non-Latin (Cyrillic/CJK/Greek/…) queries

### DIFF
--- a/app/models/search/query.rb
+++ b/app/models/search/query.rb
@@ -33,7 +33,7 @@ class Search::Query < ApplicationRecord
     end
 
     def remove_invalid_search_characters(terms)
-      terms.gsub(/[^\w"]/, " ")
+      terms.gsub(/[^[[:word:]]"]/, " ")
     end
 
     def remove_unbalanced_quotes(terms)

--- a/app/models/search/stemmer.rb
+++ b/app/models/search/stemmer.rb
@@ -5,7 +5,7 @@ module Search::Stemmer
 
   def stem(value)
     if value.present?
-      value.gsub(/[^\w\s]/, " ").split(/\s+/).map { |word| STEMMER.stem(word.downcase) }.join(" ")
+      value.gsub(/[^[[:word:]]\s]/, " ").split(/\s+/).map { |word| STEMMER.stem(word.downcase) }.join(" ")
     else
       value
     end

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -42,4 +42,11 @@ class SearchTest < ActiveSupport::TestCase
     results = Search::Record.for(@user.account_id).search("BC3-IOS-1D8B", user: @user)
     assert results.find { |it| it.card_id == card.id }
   end
+
+  test "search for non-Latin (e.g. Cyrillic) strings" do
+    card = @board.cards.create!(title: "фільтрувати картки", creator: @user, status: "published")
+
+    results = Search::Record.for(@user.account_id).search("картки", user: @user)
+    assert results.find { |it| it.card_id == card.id }
+  end
 end


### PR DESCRIPTION
Search and filter return zero results for any query containing non-Latin characters (Ukrainian/Russian Cyrillic, CJK, Greek, Arabic, …), even when matching cards exist.

### Root cause

`Search::Query#remove_invalid_search_characters` sanitises input with `terms.gsub(/[^\w"]/, " ")`. In Ruby (Onigmo) `\w` matches **ASCII** `[a-zA-Z0-9_]` only — it does not match Unicode letters. So a non-Latin query is reduced to whitespace, `terms` becomes blank → `Search::Query` fails its `presence` validation → `Search::Record.for_query` takes the `else none` branch → no results.

The FTS index itself is fine: non-Latin content is indexed and raw `MATCH` works. The bug is purely in query sanitisation, so it affects both the SQLite and Trilogy adapters.

### Fix

Use the POSIX `[[:word:]]` class, which **is** Unicode-aware in Ruby, so word characters in any script are preserved:

```ruby
- terms.gsub(/[^\w"]/, " ")
+ terms.gsub(/[^[[:word:]]"]/, " ")
```

The same ASCII-only `\w` appears in `Search::Stemmer.stem` (used on the Trilogy/MySQL path for both indexing and querying), fixed here too for consistency.

### Test

Added a Cyrillic case to `SearchTest` mirroring the existing hyphenated-string test. It fails on `main` (zero results) and passes with this change.

### Verification

Confirmed on a live self-hosted deployment (`ghcr.io/basecamp/fizzy:main`): before the patch a Cyrillic query returns `terms => nil` and `0` results; after, the same query returns the expected cards (e.g. `search("картки")` → 294 results), while Latin search is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)