### PR TITLE
Fix comment-typing freeze: scope drag-strum keydown + fix listener leak (#2926)

### DIFF
--- a/app/javascript/controllers/drag_and_strum_controller.js
+++ b/app/javascript/controllers/drag_and_strum_controller.js
@@ -69,11 +69,17 @@ export default class extends Controller {
     }
   }
 
-  #isEditingText(element) {
+  #isEditingText(target) {
+    const element = target ?? document.activeElement
     if (!element) { return false }
     if (element.isContentEditable) { return true }
+    if (element.closest?.("textarea, select, lexxy-editor")) { return true }
 
-    return element.closest?.("input, textarea, select, lexxy-editor") != null
+    const input = element.closest?.("input")
+    if (!input) { return false }
+
+    const NON_TEXT_INPUT_TYPES = [ "button", "submit", "reset", "checkbox", "radio", "file", "image", "range", "color" ]
+    return !NON_TEXT_INPUT_TYPES.includes((input.type || "text").toLowerCase())
   }
 
   dragEnter(event) {

--- a/app/javascript/controllers/drag_and_strum_controller.js
+++ b/app/javascript/controllers/drag_and_strum_controller.js
@@ -49,14 +49,17 @@ export default class extends Controller {
   connect() {
     this.instrumentIndex = 0
     this.preloadedAudioFiles = []
-    document.addEventListener("keydown", this.handleKeyDown.bind(this));
+    this.handleKeyDown = this.handleKeyDown.bind(this)
+    document.addEventListener("keydown", this.handleKeyDown);
   }
 
   disconnect() {
-    document.removeEventListener("keydown", this.handleKeyDown.bind(this));
+    document.removeEventListener("keydown", this.handleKeyDown);
   }
 
   handleKeyDown(event) {
+    if (this.#isEditingText(event.target)) { return }
+
     if (event.shiftKey) {
       this.instrumentIndex = this.#getInstrumentIndex(event)
 
@@ -64,6 +67,13 @@ export default class extends Controller {
         this.#preloadAudioFiles(this.instrumentIndex)
       }
     }
+  }
+
+  #isEditingText(element) {
+    if (!element) { return false }
+    if (element.isContentEditable) { return true }
+
+    return element.closest?.("input, textarea, select, lexxy-editor") != null
   }
 
   dragEnter(event) {


### PR DESCRIPTION
Fixes #2926 — typing in a card's comment box freezes Safari (macOS + iOS) for 5–10s, worsening over a session.

`drag_and_strum_controller` adds a global `keydown` listener to play an instrument while a card is dragged between columns. Two problems make typing janky:

### 1. Listener leak (`bind` reference mismatch)

```js
connect()    { document.addEventListener("keydown", this.handleKeyDown.bind(this)) }
disconnect() { document.removeEventListener("keydown", this.handleKeyDown.bind(this)) }
```

`.bind(this)` returns a **new** function each time, so `removeEventListener` never matches the listener added in `connect`. Every Turbo reconnect leaks another permanent global `keydown` listener; they accumulate over a session and all fire on each keystroke. This matches the reported "~15 `keydown` per typed character, worsens during a session".

Fix: bind once, store the reference, reuse it for add/remove.

### 2. Handler runs while typing

The handler fired on **every** document `keydown`, including inside the comment editor. Typing capital letters / shifted keys (`event.shiftKey`) repeatedly hit `#preloadAudioFiles`, constructing `new Audio()` in a loop on each keystroke. The strum is only meaningful during a drag, so keydown originating from a text field / `contenteditable` / the `lexxy-editor` is now ignored via a small `#isEditingText` guard (`isContentEditable` + `closest("input, textarea, select, lexxy-editor")`).

### Notes

- The drag/strum easter-egg behaviour during an actual drag is unchanged.
- The repo has no JS controller test harness (no existing tests for this or sibling controllers), so this is a code-only change; `node --check` passes. The diagnosis and profiling are in #2926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)