### PR TITLE
Compute day boundaries in the user's timezone, not the browser's

### DIFF
--- a/app/javascript/helpers/date_helpers.js
+++ b/app/javascript/helpers/date_helpers.js
@@ -1,3 +1,5 @@
+import { getMetaContent } from "helpers/meta_helpers"
+
 export function differenceInDays(fromDate, toDate) {
   return Math.round(Math.abs((beginningOfDay(toDate) - beginningOfDay(fromDate)) / (1000 * 60 * 60 * 24)))
 }
@@ -15,9 +17,9 @@ export function secondsToDate(seconds) {
   return new Date(seconds * 1000)
 }
 
-// Snap a timestamp to midnight using the user's timezone (from the `timezone`
-// cookie the server reads too), so client day boundaries match the server's
-// and don't follow the browser's resolved timezone, which can differ in a PWA.
+// Snap a timestamp to midnight using the timezone the server rendered with (the
+// `timezone` meta tag), so client day boundaries match the server's instead of
+// following the browser's resolved timezone, which can differ in a PWA.
 function datePartsInTimezone(date) {
   return dateFormatter().formatToParts(date).reduce((parts, { type, value }) => {
     if (type !== "literal") parts[type] = parseInt(value, 10)
@@ -29,7 +31,7 @@ let dateFormatterCache
 let dateFormatterTimezone
 
 function dateFormatter() {
-  const timezone = currentTimezone()
+  const timezone = getMetaContent("timezone")
 
   if (!dateFormatterCache || dateFormatterTimezone !== timezone) {
     dateFormatterTimezone = timezone
@@ -47,9 +49,4 @@ function buildDateFormatter(timezone) {
   } catch {
     return new Intl.DateTimeFormat("en-US", options)
   }
-}
-
-function currentTimezone() {
-  const cookie = document.cookie.split("; ").find(entry => entry.startsWith("timezone="))
-  return cookie ? decodeURIComponent(cookie.split("=")[1]) : undefined
 }

--- a/app/javascript/helpers/date_helpers.js
+++ b/app/javascript/helpers/date_helpers.js
@@ -7,9 +7,49 @@ export function signedDifferenceInDays(fromDate, toDate) {
 }
 
 export function beginningOfDay(date) {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const { year, month, day } = datePartsInTimezone(date)
+  return new Date(Date.UTC(year, month - 1, day))
 }
 
 export function secondsToDate(seconds) {
   return new Date(seconds * 1000)
+}
+
+// Snap a timestamp to midnight using the user's timezone (from the `timezone`
+// cookie the server reads too), so client day boundaries match the server's
+// and don't follow the browser's resolved timezone, which can differ in a PWA.
+function datePartsInTimezone(date) {
+  return dateFormatter().formatToParts(date).reduce((parts, { type, value }) => {
+    if (type !== "literal") parts[type] = parseInt(value, 10)
+    return parts
+  }, {})
+}
+
+let dateFormatterCache
+let dateFormatterTimezone
+
+function dateFormatter() {
+  const timezone = currentTimezone()
+
+  if (!dateFormatterCache || dateFormatterTimezone !== timezone) {
+    dateFormatterTimezone = timezone
+    dateFormatterCache = buildDateFormatter(timezone)
+  }
+
+  return dateFormatterCache
+}
+
+function buildDateFormatter(timezone) {
+  const options = { year: "numeric", month: "2-digit", day: "2-digit" }
+
+  try {
+    return new Intl.DateTimeFormat("en-US", { ...options, timeZone: timezone })
+  } catch {
+    return new Intl.DateTimeFormat("en-US", options)
+  }
+}
+
+function currentTimezone() {
+  const cookie = document.cookie.split("; ").find(entry => entry.startsWith("timezone="))
+  return cookie ? decodeURIComponent(cookie.split("=")[1]) : undefined
 }

--- a/app/javascript/helpers/meta_helpers.js
+++ b/app/javascript/helpers/meta_helpers.js
@@ -1,0 +1,3 @@
+export function getMetaContent(name) {
+  return document.querySelector(`meta[name="${name}"]`)?.getAttribute("content")
+}

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -11,6 +11,7 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= tag.meta name: "current-user-id", content: Current.user.id if Current.user %>
+  <%= tag.meta name: "timezone", content: Time.zone.name %>
   <%= tag.meta name: "vapid-public-key", content: Rails.configuration.x.vapid.public_key %>
 
   <% turbo_refreshes_with method: :morph, scroll: :preserve %>


### PR DESCRIPTION
## Summary

Fixes the recurring bug where cards (and other relative dates) display as **one day earlier** for users in UTC-negative timezones — most recently reported by a customer in `America/Indianapolis` who saw cards created earlier the same day flip to "yesterday" after their local 7 PM.

Card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/9749169131

## Background

This is the third attempt at this bug:

- **Original** — `beginningOfDay()` snapped to midnight with the browser's local `Date` methods.
- **#2790** — swapped to UTC methods. Fixed UTC-negative users in one direction but broke the symmetric case (cards created earlier the same day showing "yesterday" after local 7 PM), so it was reverted in `6d7138584` (that revert also added `Time.zone.name` to the day-timeline fragment cache keys — kept here).

## Root cause

Both prior attempts share the same flaw: the **client** chose a day boundary that could disagree with the **server**.

- The server groups and renders days using the timezone resolved from the `timezone` cookie (`CurrentTimezone#set_current_timezone`).
- The client (`beginningOfDay`) followed the browser's *resolved* timezone — which in a PWA/webview can resolve to UTC even when the cookie correctly holds the user's IANA zone.

So around the local-vs-UTC midnight boundary, client and server disagreed by a day. Picking local vs UTC just moved which side broke.

## Fix

Make the **server the single source of truth** for the timezone and have the client snap day boundaries to that exact zone:

- The server already resolves the cookie into `Time.zone`. Expose it as a `<meta name="timezone">` tag in the shared head (`Time.zone.name`, which is the IANA identifier, or `UTC` when there's no cookie).
- Add a small `getMetaContent` helper (mirrors the bc3 pattern) and have `beginningOfDay()` read the meta tag — no cookie parsing in JS.
- `beginningOfDay()` uses `Intl.DateTimeFormat({ timeZone })` → `formatToParts` to read Y/M/D in that zone, then anchors to `Date.UTC(...)` (both comparison anchors constructed the same way → exact, DST-proof day deltas). Falls back to the runtime timezone if the tag is missing or invalid.

The client now always agrees with the server, whatever zone the server rendered with.

## Verification

No JS unit-test harness exists in this repo (importmap, no `package.json`), so the logic was checked standalone against the reported scenarios:

| Scenario | Result |
|---|---|
| Earlier card, now past midnight UTC (Lee's "before 7, update after 7") | today ✓ |
| Symmetric case the UTC fix broke | today ✓ |
| Genuinely yesterday's card | yesterday ✓ |
| No cookie (server + client both UTC) | consistent ✓ |
| Missing / invalid meta tag | graceful fallback, no crash ✓ |

Confirmed `ActiveSupport::TimeZone["America/New_York"].name` returns the IANA identifier (`"America/New_York"`), so `Time.zone.name` is safe to feed to `Intl.DateTimeFormat`. Worth a manual check in the PWA before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)