### PR TITLE
Fix Card.auto_postpone_all_due DB timeout

### DIFF
--- a/app/models/card/entropic.rb
+++ b/app/models/card/entropic.rb
@@ -2,14 +2,6 @@ module Card::Entropic
   extend ActiveSupport::Concern
 
   included do
-    scope :due_to_be_postponed, -> do
-      active
-        .joins(board: :account)
-        .left_outer_joins(board: :entropy)
-        .joins("LEFT OUTER JOIN entropies AS account_entropies ON account_entropies.account_id = accounts.id AND account_entropies.container_type = 'Account' AND account_entropies.container_id = accounts.id")
-        .where("last_active_at <= #{connection.date_subtract('?', 'COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period)')}", Time.now)
-    end
-
     scope :postponing_soon, -> do
       now = Time.now
       active
@@ -24,9 +16,21 @@ module Card::Entropic
   end
 
   class_methods do
-    def auto_postpone_all_due
-      due_to_be_postponed.find_each do |card|
-        card.auto_postpone(user: card.account.system_user)
+    # Iterates per account, grouping the account's boards by their effective
+    # auto-postpone period (board override, else account default). Each group
+    # queries with a single constant cutoff, so `account_id = ? AND
+    # last_active_at <= ?` rides the existing index instead of computing the
+    # threshold per row across every card in the system.
+    def auto_postpone_all_due(as_of: Time.now)
+      Account.find_each do |account|
+        account.boards.includes(:entropy).group_by(&:auto_postpone_period).each do |period, boards|
+          account.cards.active
+            .where(board_id: boards.map(&:id))
+            .where(last_active_at: ..(as_of - period))
+            .find_each do |card|
+              card.auto_postpone(user: account.system_user)
+            end
+        end
       end
     end
   end

--- a/test/models/card/entropic_test.rb
+++ b/test/models/card/entropic_test.rb
@@ -69,11 +69,14 @@ class Card::EntropicTest < ActiveSupport::TestCase
     assert_not_includes Card.postponing_soon, cards(:shipping)
   end
 
-  test "due_to_be_postponed scope works properly cross-account" do
+  test "auto postpone all due works properly cross-account" do
     cards(:logo).update!(last_active_at: entropies(:writebook_board).auto_postpone_period.seconds.ago - 2.days)
     cards(:radio).update!(last_active_at: entropies(:miltons_wish_list_board).auto_postpone_period.seconds.ago - 2.days)
 
-    assert_equal(cards(:logo, :radio).to_set, Card.due_to_be_postponed.to_set)
+    Card.auto_postpone_all_due
+
+    assert cards(:logo).reload.postponed?
+    assert cards(:radio).reload.postponed?
   end
 
   test "postponing_soon scope works properly cross-account" do

--- a/test/models/card/stallable_test.rb
+++ b/test/models/card/stallable_test.rb
@@ -58,7 +58,7 @@ class Card::StallableTest < ActiveSupport::TestCase
     assert_includes Card.stalled, card
 
     travel_to Time.now + card.board.entropy.auto_postpone_period + 1.day
-    assert_includes Card.due_to_be_postponed, card
+    assert_operator card.entropy.auto_clean_at, :<=, Time.now
 
     Card.auto_postpone_all_due
 


### PR DESCRIPTION
## Problem

The hourly `Card.auto_postpone_all_due` job ([On Call card](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/9993347227)) has been intermittently failing with `ActiveRecord::StatementTimeout` — succeeding on retry, then failing again on a later run.

The `due_to_be_postponed` scope produced a single query whose `last_active_at` filter compares against a **per-row** threshold:

```sql
WHERE last_active_at <= DATE_SUB(now, INTERVAL COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period) SECOND)
```

The cutoff is computed per row from the joined entropy tables, and there's no `account_id`/`board_id` equality to anchor an index, so MySQL can't range-scan `last_active_at` — it full-scans every published, open, non-postponed card **across all accounts**. As the table grows this eventually exceeds the statement timeout.

## Fix

Resolve each board's effective period in Ruby and iterate **per account**, grouping the account's boards by period so each query filters `last_active_at` against a single **constant** cutoff:

```ruby
def auto_postpone_all_due(as_of: Time.now)
  Account.find_each do |account|
    account.boards.includes(:entropy).group_by(&:auto_postpone_period).each do |period, boards|
      account.cards.active
        .where(board_id: boards.map(&:id))
        .where(last_active_at: ..(as_of - period))
        .find_each do |card|
          card.auto_postpone(user: account.system_user)
        end
    end
  end
end
```

Now `account_id = ? AND last_active_at <= ?` rides the existing `index_cards_on_account_id_and_last_active_at_and_status` index, scanning straight to the stale tail rather than every card.

### Notes
- **No schema change.** The query was deliberately shaped to use the index we already have (`account_id` + `last_active_at` prefix), rather than adding a new index to a large table.
- **Fallback preserved.** The board-override-vs-account-default logic (old SQL `COALESCE`) is handled by `Board#entropy` (`super || account.entropy`), so a board with no own entropy still uses the account default. The `account.entropy` lookup is single-query per account thanks to `inverse_of`.
- The now-unused `due_to_be_postponed` scope was removed; `postponing_soon` is left untouched (it only ever runs scoped to a single account/board in the UI).

## Testing
- Updated the two tests that referenced the removed scope, preserving their cross-account coverage.
- `bin/rails test test/models/card/entropic_test.rb test/models/card/stallable_test.rb` → 16 tests, 54 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)