### PR TITLE
fix: Post button still disabled after pasting text

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -76,6 +76,7 @@ export default class extends Controller {
 
   async disableSubmitWhenInvalid(event) {
     await nextFrame()
+    await nextFrame()
 
     if (this.element.checkValidity()) {
       this.submitTarget.removeAttribute("disabled")


### PR DESCRIPTION
The checkValidity() is always one step behind ( this might be an issue with lexxy that fires the change event too soon )

## The issue
This is not much of an issue when typing a comment, as that is generally more than 1 character.
But when pasting content is an issue, as demonstated here:
<img width="1170" height="842" alt="fizzy-paste" src="https://github.com/user-attachments/assets/4d478ab4-7682-4509-aae2-076fb3aacbf4" />

# Fix
The fix was to wait two frames, instead of one, so the checkValidity() is based on contents after the command has been processed.
