### PR TITLE
Update last_active_at when steps are created, edited, toggled, or del…

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,8 +2,8 @@ class Step < ApplicationRecord
   belongs_to :account, default: -> { card.account }
   belongs_to :card
 
-after_save    -> { card.touch_last_active_at }
-after_destroy -> { card.touch_last_active_at unless destroyed_by_association }
+  after_save    -> { card.touch_last_active_at }
+  after_destroy -> { card.touch_last_active_at unless destroyed_by_association }
 
   scope :completed, -> { where(completed: true) }
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,6 +1,9 @@
 class Step < ApplicationRecord
   belongs_to :account, default: -> { card.account }
-  belongs_to :card, touch: true
+  belongs_to :card
+
+  after_save    -> { card.touch_last_active_at }
+  after_destroy -> { card.touch_last_active_at }
 
   scope :completed, -> { where(completed: true) }
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,8 +2,8 @@ class Step < ApplicationRecord
   belongs_to :account, default: -> { card.account }
   belongs_to :card
 
-  after_save    -> { card.touch_last_active_at }
-  after_destroy -> { card.touch_last_active_at }
+after_save    -> { card.touch_last_active_at }
+after_destroy -> { card.touch_last_active_at unless destroyed_by_association }
 
   scope :completed, -> { where(completed: true) }
 

--- a/test/controllers/cards/steps_controller_test.rb
+++ b/test/controllers/cards/steps_controller_test.rb
@@ -9,8 +9,10 @@ class Cards::StepsControllerTest < ActionDispatch::IntegrationTest
     card = cards(:logo)
 
     assert_difference -> { card.steps.count }, +1 do
-      post card_steps_path(card), params: { step: { content: "Research alternatives" } }, as: :turbo_stream
-      assert_turbo_stream action: :before, target: dom_id(card, :new_step)
+      assert_changes -> { card.reload.last_active_at } do
+        post card_steps_path(card), params: { step: { content: "Research alternatives" } }, as: :turbo_stream
+        assert_turbo_stream action: :before, target: dom_id(card, :new_step)
+      end
     end
 
     assert_equal "Research alternatives", card.steps.last.content
@@ -21,8 +23,10 @@ class Cards::StepsControllerTest < ActionDispatch::IntegrationTest
     step = card.steps.create!(content: "Original content")
 
     assert_changes -> { step.reload.content }, from: "Original content", to: "Updated content" do
-      put card_step_path(card, step), params: { step: { content: "Updated content" } }, as: :turbo_stream
-      assert_turbo_stream action: :replace, target: dom_id(step)
+      assert_changes -> { card.reload.last_active_at } do
+        put card_step_path(card, step), params: { step: { content: "Updated content" } }, as: :turbo_stream
+        assert_turbo_stream action: :replace, target: dom_id(step)
+      end
     end
   end
 
@@ -31,8 +35,10 @@ class Cards::StepsControllerTest < ActionDispatch::IntegrationTest
     step = card.steps.create!(content: "Step to delete")
 
     assert_difference -> { card.steps.count }, -1 do
-      delete card_step_path(card, step), as: :turbo_stream
-      assert_turbo_stream action: :remove, target: dom_id(step)
+      assert_changes -> { card.reload.last_active_at } do
+        delete card_step_path(card, step), as: :turbo_stream
+        assert_turbo_stream action: :remove, target: dom_id(step)
+      end
     end
   end
 
@@ -42,8 +48,10 @@ class Cards::StepsControllerTest < ActionDispatch::IntegrationTest
 
     # Toggle to completed
     assert_changes -> { step.reload.completed? }, from: false, to: true do
-      put card_step_path(card, step), params: { step: { completed: "1" } }, as: :turbo_stream
-      assert_turbo_stream action: :replace, target: dom_id(step)
+      assert_changes -> { card.reload.last_active_at } do
+        put card_step_path(card, step), params: { step: { completed: "1" } }, as: :turbo_stream
+        assert_turbo_stream action: :replace, target: dom_id(step)
+      end
     end
 
     # Toggle back to incomplete


### PR DESCRIPTION
Fixes #2876

Step (checkbox) interactions — creating, editing text, checking/unchecking,
and deleting — now update the card's `last_active_at` timestamp via
`card.touch_last_active_at`. Previously only `updated_at` changed (via
`belongs_to :card, touch: true`), which meant the entropy/auto-postponement
system was blind to checkbox activity.