### PR TITLE
Reload target column frame after card drop to fix stale drop zone

### DIFF
--- a/app/javascript/controllers/drag_and_drop_controller.js
+++ b/app/javascript/controllers/drag_and_drop_controller.js
@@ -49,7 +49,8 @@ export default class extends Controller {
     const sourceContainer = this.sourceContainer
     this.#insertDraggedItem(targetContainer, this.dragItem)
     await this.#submitDropRequest(this.dragItem, targetContainer)
-    this.#reloadSourceFrame(sourceContainer)
+    this.#reloadFrame(sourceContainer)
+    this.#reloadFrame(targetContainer)
   }
 
   dragEnd() {
@@ -143,8 +144,8 @@ export default class extends Controller {
     return post(url, { body, headers: { Accept: "text/vnd.turbo-stream.html" } })
   }
 
-  #reloadSourceFrame(sourceContainer) {
-    const frame = sourceContainer.querySelector("[data-drag-and-drop-refresh]")
+  #reloadFrame(container) {
+    const frame = container.querySelector("[data-drag-and-drop-refresh]")
     if (frame) frame.reload()
   }
 }


### PR DESCRIPTION
## Problem

Card: [[Fizzy] Drag drop zone doesn't collapse in Chrome on PC](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10036823625) (#10036823625)

After dragging a card into a previously empty column, the "Drag cards here" drop zone failed to collapse on **Windows Chrome**. It stayed visible, peeking out at the bottom of the column and pushing the column headings up so they were obscured. A full page refresh was the only fix. Reported by multiple users at UW-Madison Libraries on Chrome on PC; not reproducible on Mac.

## Root cause

The blank-slate placeholder's visibility is driven entirely by CSS:

```css
.cards__list:has(.card) { .blank-slate { display: none } }
```

On drop, `drag-and-drop#drop` inserts the dragged card — an already-existing DOM node, *moved* from the source column — into the target column's card list, and relies on that `:has()` rule to hide the placeholder.

Chromium's `:has()` style invalidation can fail to re-evaluate when a subtree is **moved** between containers (as opposed to a freshly created node being inserted). On affected builds (Windows Chrome 149.x in the report) the target `.cards__list` was not re-matched against the rule, so the placeholder stayed visible. This is consistent with the report reproducing on Windows Chrome but not on Mac.

## Fix

We already reload the **source** column's frame after a drop. This change also reloads the **target** column's frame. The frame morph-renders the column from the server — which is authoritative and contains no blank slate, since the card now persists in that column — removing the stale placeholder regardless of any `:has()` invalidation quirk.

- The column frame uses Turbo morph rendering, so this is a minimal child reconciliation (it removes the now-unwanted placeholder node), not a full re-render or visible flicker.
- The existing nil-guard means columns without a refresh frame (e.g. the stream/"Maybe?" column, which never shows a placeholder) are unaffected.
- `#reloadSourceFrame` was renamed to `#reloadFrame` since it now applies to both containers.

## Testing

This repo has no JS unit-test harness, and system tests are reserved for critical flows; a drop-zone collapse glitch is a non-critical UI fix, so no automated test was added. The bug is platform-specific (Windows Chrome) and does not reproduce on the dev environment, but the fix is deterministic by design: it no longer depends on `:has()` re-evaluation at all — the target column is re-rendered from the server, which has no placeholder for a non-empty column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)