### PR TITLE
Source vapid subject from vapid_subject env var

### DIFF
--- a/config/initializers/vapid.rb
+++ b/config/initializers/vapid.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
   config.x.vapid.private_key = ENV["VAPID_PRIVATE_KEY"]
   config.x.vapid.public_key = ENV["VAPID_PUBLIC_KEY"]
+  config.x.vapid.subject = ENV.fetch("VAPID_SUBJECT") { config.x.vapid.subject || "mailto:support@fizzy.do" }
 end

--- a/lib/web_push/notification.rb
+++ b/lib/web_push/notification.rb
@@ -15,8 +15,7 @@ class WebPush::Notification
 
   private
     def vapid_identification
-      { subject: "mailto:support@fizzy.do" }.merge \
-        Rails.configuration.x.vapid.symbolize_keys
+      Rails.configuration.x.vapid.symbolize_keys
     end
 
     def encoded_message


### PR DESCRIPTION
## Problem

The VAPID JWT subject defaulted to `mailto:support@fizzy.do`. It could already be overridden by setting `config.x.vapid.subject` via the `initializers/vapid.rb` (the merge in `vapid_identification` method took care of that), but for self-hosted deployments this wasn't very obvious and could easily be missed, so it would be silently shipped with the `support@fizzy.do` address.

## Fix

This change mainly makes the `subject` more visible for users to be able to change, it also keeps the current default in case the env var is not set.