### PR TITLE
Serialize card numbering with a per-account row lock

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -90,6 +90,6 @@ class Card < ApplicationRecord
     end
 
     def assign_number
-      self.number ||= account.increment!(:cards_count).cards_count
+      self.number ||= account.with_lock { account.increment!(:cards_count).cards_count }
     end
 end


### PR DESCRIPTION
## Problem

Production 500s from a unique-constraint violation on card creation:

> `Trilogy::ProtocolError: 1062: Duplicate entry '...-486' for key 'cards.index_cards_on_account_id_and_number'`

Cards are numbered by a per-account `number` column so the same number is available across accounts; the primary key is a UUID used as the ID. Because MySQL isn't assigning the number for us via an auto-increment PK, concurrent card creation races on it and two cards can get the same `account_id`+`number`, colliding on `index_cards_on_account_id_and_number`, raising `Trilogy::ProtocolError 1062` and 500ing the request.

### Log evidence

All 97 duplicate-entry errors come from a **single account** (`account.queenbee_id 6,215,625`) via user agent `fizzy-sdk-ts/0.2.1 (api:2026-03-01)`, clustered tightly in time — e.g. request pairs at `47.754/47.820/47.931` and `22.330/22.335` within milliseconds on Jun 30 2026 ~07:07-07:08 UTC. That's one API client firing concurrent card-create requests that race on the per-account `number`, exactly the race described above.

## Fix

The collision was never a lost database increment. `account.increment!(:cards_count)` compiles to an atomic `UPDATE accounts SET cards_count = cards_count + 1`, so the DB counter is always correct. The collision came from the **in-memory return value**: two concurrent requests both read `cards_count = 100`, each compute `101` locally, and assign both cards number `101`.

The fix is a one-line change to `Card#assign_number` — wrap the existing increment in a lock on the account row:

```ruby
def assign_number
  self.number ||= account.with_lock { account.increment!(:cards_count).cards_count }
end
```

`with_lock` issues `SELECT ... FOR UPDATE` on the account row, serializing numbering per account: the second concurrent request blocks until the first commits, then reads the already-incremented value. This provably eliminates the collision without retries.

## Tests

The existing `test/models/card_test.rb` "create assigns a number to the card" test already covers that a new card is assigned `account.cards_count` as its number and the counter advances. No concurrency/lock test is included: the test env uses SQLite, which can't exercise real row locking, so such a test would assert nothing.

Card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10052106837

🤖 Generated with [Claude Code](https://claude.com/claude-code)