### PR TITLE
Fix blank iOS notifications screen: emit null column instead of omitting the key

### DIFF
--- a/app/views/notifications/_notification.json.jbuilder
+++ b/app/views/notifications/_notification.json.jbuilder
@@ -15,7 +15,11 @@ json.cache! notification do
     json.closed notification.card.closed?
     json.postponed notification.card.postponed?
     json.url card_url(notification.card)
-    json.column notification.card.column, partial: "columns/column", as: :column if notification.card.column
+    if notification.card.column
+      json.column notification.card.column, partial: "columns/column", as: :column
+    else
+      json.column nil
+    end
   end
 
   json.url notification_url(notification)

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -31,4 +31,14 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal card.closed?, notification.dig("card", "closed")
     assert_equal card.postponed?, notification.dig("card", "postponed")
   end
+
+  test "index as JSON includes an explicit null column for cards awaiting triage" do
+    get notifications_path, as: :json
+
+    notification = @response.parsed_body.find { |n| n["id"] == notifications(:buy_domain_sent_back_to_triage_kevin).id }
+
+    assert_nil notifications(:buy_domain_sent_back_to_triage_kevin).card.column
+    assert notification["card"].key?("column")
+    assert_nil notification.dig("card", "column")
+  end
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -37,6 +37,15 @@ logo_assignment_km:
   created_at: <%= 1.day.ago %>
   account: 37s_uuid
 
+buy_domain_sent_back_to_triage:
+  id: <%= ActiveRecord::FixtureSet.identify("buy_domain_sent_back_to_triage", :uuid) %>
+  creator: david_uuid
+  board: writebook_uuid
+  eventable: buy_domain_uuid (Card)
+  action: card_sent_back_to_triage
+  created_at: <%= 1.day.ago %>
+  account: 37s_uuid
+
 layout_published:
   id: <%= ActiveRecord::FixtureSet.identify("layout_published", :uuid) %>
   creator: david_uuid

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -9,6 +9,17 @@ logo_assignment_kevin:
   creator: david_uuid
   account: 37s_uuid
 
+buy_domain_sent_back_to_triage_kevin:
+  id: <%= ActiveRecord::FixtureSet.identify("buy_domain_sent_back_to_triage_kevin", :uuid) %>
+  user: kevin_uuid
+  source: buy_domain_sent_back_to_triage_uuid (Event)
+  card: buy_domain_uuid
+  unread_count: 1
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago + 1.second %>
+  creator: david_uuid
+  account: 37s_uuid
+
 layout_commented_kevin:
   id: <%= ActiveRecord::FixtureSet.identify("layout_commented_kevin", :uuid) %>
   user: kevin_uuid


### PR DESCRIPTION
## Summary
- Fixes a Help Scout report (customer diagnostic log attached in the ticket) that the iOS app's Notifications screen renders blank while the same account works fine over Safari.
- `notifications/_notification.json.jbuilder` only emitted the `column` key when `notification.card.column` was present, omitting it entirely otherwise. Cards lose their column when postponed, sent back to triage (`Card::Triageable#send_back_to_triage`), or moved to another board (`Card#handle_board_change`) — all everyday actions, and notifications resolve `card.column` live at render time, so an older notification can easily point at a now-column-less card.
- The customer's app log showed every notifications fetch failing with `The data couldn't be read because it is missing` — the default message for a Swift `DecodingError` — consistent with a Codable model that expects `column` to always be present, and Swift's all-or-nothing array decoding meaning a single malformed entry blanks the whole screen.
- Fix: always emit the `column` key, using `null` when the card has no column, matching how a nullable field should be represented in JSON.

## Test plan
- [x] Added a fixture event/notification for a card sent back to triage (no column) and a controller test asserting the JSON response includes an explicit `"column": null` rather than omitting the key.
- [x] Verified in isolation that `Jbuilder#column nil` serializes to `{"column":null}` (no `ignore_nil!` configured in this app).
- [x] Full `bin/rails test` suite could not be run in this environment due to an unrelated native-extension build failure for the `trilogy` gem (MySQL driver) under Ruby 3.4.7 — please confirm green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)