### PR TITLE
Add Yabeda::ActiveSupportCache metrics

### DIFF
--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -112,6 +112,9 @@ module Fizzy
         require "yabeda/gvl"
         Yabeda::GVL.install!
 
+        require "yabeda/active_support_cache"
+        Yabeda::ActiveSupportCache.install!
+
         require_relative "metrics"
       end
 

--- a/saas/lib/yabeda/active_support_cache.rb
+++ b/saas/lib/yabeda/active_support_cache.rb
@@ -1,0 +1,44 @@
+module Yabeda
+  module ActiveSupportCache
+    def self.install!
+      Yabeda.configure do
+        tag_names = %i[ store operation ]
+
+        group :active_support
+
+        counter :cache_requests_total, comment: "Active Support cache requests", tags: tag_names
+        counter :cache_hits_total, comment: "Active Support cache hits", tags: tag_names
+        counter :cache_operations_total, comment: "Count of Active Support cache operations", tags: tag_names
+        counter :cache_operations_seconds_total, comment: "Seconds spent on Active Support cache operations", tags: tag_names
+
+        ActiveSupport::Notifications.monotonic_subscribe /cache_[a-z_]+\.active_support/ do |name, start, finish, id, payload|
+          store = payload[:store]
+          next if store == "ActiveSupport::Cache::FileStore" # sprockets
+
+          operation = name.match(/^cache_([^.]*)/)[1]
+          tags = { store: store, operation: operation }
+          requests, hits = ActiveSupportCache.requests_and_hits(operation, payload)
+
+          next if operation == "read_multi" && requests == 0 # no-op
+
+          active_support_cache_requests_total.increment(tags, by: requests) if requests > 0
+          active_support_cache_hits_total.increment(tags, by: hits) if hits > 0
+          active_support_cache_operations_total.increment(tags)
+          active_support_cache_operations_seconds_total.increment(tags, by: finish - start)
+        end
+      end
+    end
+
+    private
+      def self.requests_and_hits(operation, payload)
+        case operation
+        when "read"
+          [ 1, payload[:hit] ? 1 : 0 ]
+        when "read_multi"
+          [ payload[:key]&.count || 0, payload[:hits]&.count || 0 ]
+        else
+          [ 0, 0 ]
+        end
+      end
+  end
+end

--- a/saas/test/lib/yabeda/active_support_cache_test.rb
+++ b/saas/test/lib/yabeda/active_support_cache_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+require "yabeda/testing"
+
+class Yabeda::ActiveSupportCacheTest < ActiveSupport::TestCase
+  setup do
+    Yabeda::TestAdapter.instance.reset!
+  end
+
+  test "counts operations" do
+    with_caching_enabled do
+      Rails.cache.write("entry1", 1)
+
+      assert_equal 1, count(:cache_operations_total, operation: "write")
+      assert_operator count(:cache_operations_seconds_total, operation: "write"), :>, 0
+    end
+  end
+
+  test "counts hits from read" do
+    with_caching_enabled do
+      Rails.cache.write("entry1", 1)
+      Rails.cache.read("entry1")
+      Rails.cache.read("entry2")
+      Rails.cache.read("entry3")
+
+      assert_equal 1, count(:cache_hits_total, operation: "read")
+      assert_equal 3, count(:cache_requests_total, operation: "read")
+    end
+  end
+
+  test "counts hits from read_multi" do
+    with_caching_enabled do
+      Rails.cache.write("entry1", 1)
+      Rails.cache.write("entry3", 3)
+      Rails.cache.read_multi("entry1", "entry2", "entry3")
+
+      assert_equal 2, count(:cache_hits_total, operation: "read_multi")
+      assert_equal 3, count(:cache_requests_total, operation: "read_multi")
+    end
+  end
+
+  private
+    def with_caching_enabled
+      old_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+      yield
+    ensure
+      Rails.cache = old_cache
+    end
+
+    def count(metric, operation:)
+      tags = { store: "ActiveSupport::Cache::MemoryStore", operation: operation }
+      Yabeda::TestAdapter.instance.counters.fetch(Yabeda.active_support.public_send(metric))[tags]
+    end
+end


### PR DESCRIPTION
Card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10060778298

## Problem

Fizzy couldn't be added to the [Rails Cache breakdown dashboard](https://grafana.37signals.com/d/f1b953e9-d67c-4706-ba77-6f8f37e42e19/rails-cache-breakdown) because it wasn't writing any Active Support cache metrics: the `fizzy_saas.yabeda` initializer installs `Yabeda::ActiveJob`, `Yabeda::SolidQueue`, `Yabeda::ActionCable` and `Yabeda::GVL`, but not `Yabeda::ActiveSupportCache`.

## Why we didn't have it

There's no public yabeda gem for Active Support cache instrumentation — `Yabeda::ActiveSupportCache` is a module bc4 and HEY each vendor under `lib/yabeda/active_support_cache.rb`. When Fizzy vendored its other yabeda integrations (`yabeda/solid_queue.rb`, `yabeda/gvl.rb`), this one simply never got ported over. No deeper reason.

## Fix

* Vendor the same `Yabeda::ActiveSupportCache` module at `saas/lib/yabeda/active_support_cache.rb` (HEY's copy, which is bc4's plus a no-op guard for empty `read_multi` calls) and install it from the `fizzy_saas.yabeda` initializer, matching how the other vendored integrations are wired. No new gem dependencies.
* Port bc4's unit test for the module to `saas/test/lib/yabeda/active_support_cache_test.rb`.

It subscribes to `cache_*.active_support` notifications and exports the exact counters the dashboard queries — `active_support_cache_requests_total`, `active_support_cache_hits_total`, `active_support_cache_operations_total`, `active_support_cache_operations_seconds_total` — tagged with `store`/`operation`. The `store="SolidCache::Store"` label the dashboard filters on comes straight from the instrumentation payload, so no extra configuration is needed (verified against the dashboard's panel queries).

Tests: `SAAS=1 BUNDLE_GEMFILE=Gemfile.saas bin/rails test saas/test/lib` passes; rubocop clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)