### PR TITLE
Add fizzy_solid_cache_* metrics via vendored Yabeda exporter

### DIFF
--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -115,6 +115,9 @@ module Fizzy
         require "yabeda/active_support_cache"
         Yabeda::ActiveSupportCache.install!
 
+        require "yabeda/solid_cache"
+        Yabeda::SolidCache.install!
+
         require_relative "metrics"
       end
 

--- a/saas/lib/yabeda/solid_cache.rb
+++ b/saas/lib/yabeda/solid_cache.rb
@@ -1,0 +1,116 @@
+module Yabeda
+  module SolidCache
+    SECONDS_PER_DAY = 86_400
+    DEFAULT_METRIC_VALUE = 0
+
+    def self.install!
+      Yabeda.configure do
+        group :fizzy
+
+        gauge :solid_cache_max_age_seconds, comment: "Solid Cache max age in seconds", tags: %i[ shard ], aggregation: :most_recent
+        gauge :solid_cache_oldest_age_seconds, comment: "Solid Cache oldest entry age in seconds", tags: %i[ shard ], aggregation: :most_recent
+        gauge :solid_cache_max_entries, comment: "Solid Cache max entries", tags: %i[ shard ], aggregation: :most_recent
+        gauge :solid_cache_entries_total, comment: "Solid Cache entries", tags: %i[ shard ], aggregation: :most_recent
+
+        collect do
+          Yabeda::SolidCache.collect_stats if defined?(::SolidCache::Entry)
+        end
+      end
+    end
+
+    def self.collect_stats
+      return unless ::Rails.cache.is_a?(::SolidCache::Store)
+
+      enrichment = enrichment_from_cache_stats
+      ages = oldest_ages_per_shard
+
+      (enrichment.keys + ages.keys).uniq.each do |shard|
+        set_shard_metrics(shard, enrichment[shard], ages[shard])
+      end
+    rescue => error
+      ::Rails.logger.warn "Failed to collect Solid Cache stats: #{error.message}"
+    end
+
+    private
+      # Active shards contribute enrichment data via ::Rails.cache.stats; every shard
+      # (including inactive ones) contributes an oldest-entry age via each_shard. We
+      # set whatever metrics we have for each shard we find in either source.
+      def self.set_shard_metrics(shard, enrichment, age_days)
+        if enrichment && age_days
+          set_metrics shard,
+            max_age: enrichment[:max_age],
+            oldest_age: (age_days * SECONDS_PER_DAY).to_i,
+            entries: enrichment[:entries],
+            max_entries: enrichment[:max_entries]
+        elsif enrichment
+          set_metrics shard,
+            max_age: enrichment[:max_age],
+            oldest_age: enrichment[:oldest_age],
+            entries: enrichment[:entries],
+            max_entries: enrichment[:max_entries]
+        elsif age_days
+          oldest_age = (age_days * SECONDS_PER_DAY).to_i
+          set_metrics shard,
+            max_age: oldest_age,
+            oldest_age: oldest_age,
+            entries: DEFAULT_METRIC_VALUE,
+            max_entries: DEFAULT_METRIC_VALUE
+        end
+      rescue => error
+        ::Rails.logger.warn "Failed to collect Solid Cache stats for shard #{shard}: #{error.message}"
+      end
+
+      def self.set_metrics(shard, max_age:, oldest_age:, entries:, max_entries:)
+        tags = { shard: shard }
+        Yabeda.fizzy.solid_cache_max_age_seconds.set(tags, max_age)
+        Yabeda.fizzy.solid_cache_oldest_age_seconds.set(tags, oldest_age)
+        Yabeda.fizzy.solid_cache_entries_total.set(tags, entries)
+        Yabeda.fizzy.solid_cache_max_entries.set(tags, max_entries)
+      end
+
+      def self.enrichment_from_cache_stats
+        connection_stats = ::Rails.cache.stats&.dig(:connection_stats)
+        return {} unless connection_stats
+
+        connection_stats.each_with_object({}) do |(shard, stats), enrichment|
+          enrichment[shard.to_s] = normalize_shard_stats(stats) if stats
+        end
+      rescue => error
+        ::Rails.logger.warn "Failed to read Solid Cache stats: #{error.message}"
+        {}
+      end
+
+      def self.oldest_ages_per_shard
+        return {} unless ::SolidCache::Record.respond_to?(:each_shard)
+
+        {}.tap do |ages|
+          ::SolidCache::Record.each_shard do
+            shard = ::SolidCache::Record.connection_db_config.name
+            if age_days = oldest_entry_age_in_days
+              ages[shard] = age_days
+            end
+          rescue => error
+            ::Rails.logger.warn "Failed to read Solid Cache age for a shard: #{error.message}"
+          end
+        end
+      rescue => error
+        ::Rails.logger.warn "Failed to read Solid Cache shard ages: #{error.message}"
+        {}
+      end
+
+      def self.oldest_entry_age_in_days
+        if oldest_entry = ::SolidCache::Entry.order(:id).first
+          (Time.current - oldest_entry.created_at) / SECONDS_PER_DAY
+        end
+      end
+
+      def self.normalize_shard_stats(stats)
+        {
+          max_age: stats[:max_age]&.to_i || DEFAULT_METRIC_VALUE,
+          oldest_age: stats[:oldest_age]&.to_i || DEFAULT_METRIC_VALUE,
+          max_entries: stats[:max_entries]&.to_i || DEFAULT_METRIC_VALUE,
+          entries: stats[:entries]&.to_i || DEFAULT_METRIC_VALUE
+        }
+      end
+  end
+end

--- a/saas/test/lib/yabeda/solid_cache_test.rb
+++ b/saas/test/lib/yabeda/solid_cache_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+require "yabeda/testing"
+
+class Yabeda::SolidCacheTest < ActiveSupport::TestCase
+  setup do
+    Yabeda::TestAdapter.instance.reset!
+  end
+
+  test "sets gauges from cache stats and shard ages" do
+    freeze_time do
+      stub_solid_cache \
+        connection_stats: { cache: { max_age: 100, oldest_age: 200, max_entries: 50, entries: 10 } },
+        oldest_entry_created_at: 3.days.ago
+
+      Yabeda::SolidCache.collect_stats
+
+      assert_equal 100, gauge(:solid_cache_max_age_seconds)
+      assert_equal 3.days.to_i, gauge(:solid_cache_oldest_age_seconds)
+      assert_equal 10, gauge(:solid_cache_entries_total)
+      assert_equal 50, gauge(:solid_cache_max_entries)
+    end
+  end
+
+  test "is a no-op when not using the Solid Cache store" do
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+
+    Yabeda::SolidCache.collect_stats
+
+    assert_nil gauge(:solid_cache_max_age_seconds)
+  end
+
+  test "swallows stats errors so a scrape never fails" do
+    store = ::SolidCache::Store.allocate
+    store.stubs(:stats).raises(StandardError.new("boom"))
+    Rails.stubs(:cache).returns(store)
+    ::SolidCache::Record.stubs(:each_shard)
+
+    assert_nothing_raised { Yabeda::SolidCache.collect_stats }
+    assert_nil gauge(:solid_cache_max_age_seconds)
+  end
+
+  private
+    def stub_solid_cache(connection_stats:, oldest_entry_created_at:)
+      store = ::SolidCache::Store.allocate
+      store.stubs(:stats).returns(connection_stats: connection_stats)
+      Rails.stubs(:cache).returns(store)
+
+      ::SolidCache::Record.stubs(:each_shard).yields
+      ::SolidCache::Record.stubs(:connection_db_config).returns(stub(name: "cache"))
+      ::SolidCache::Entry.stubs(:order).returns(stub(first: stub(created_at: oldest_entry_created_at)))
+    end
+
+    def gauge(metric, shard: "cache")
+      Yabeda::TestAdapter.instance.gauges[Yabeda.fizzy.public_send(metric)][{ shard: shard }]
+    end
+end


### PR DESCRIPTION
## What

Ports bc4/HEY's SolidCache entry-statistics exporter to Fizzy so it emits the `fizzy_solid_cache_*` gauge family:

- `fizzy_solid_cache_max_age_seconds`
- `fizzy_solid_cache_oldest_age_seconds`
- `fizzy_solid_cache_max_entries`
- `fizzy_solid_cache_entries_total`

All tagged `shard` with `aggregation: :most_recent`.

Card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10060778298

## Why

This completes the follow-up to #2957, which shipped the **first** half of "[Fizzy] Add solidcache metrics" — the `active_support_cache_*` family (hit rate, entry read rate, operation rate/duration). Those panels now work.

The Rails Cache Breakdown Grafana dashboard also has three panels — **Total cache size per DC**, **Cache age per shard type**, and **Primary Shard Balance Score by Datacenter** — powered by a *different* metric family, `solid_cache_*`, which for Fizzy resolves to `fizzy_solid_cache_*`. Those series never existed in Thanos for Fizzy (only `bc4_solid_cache_*` and `hey_solid_cache_*` did), so the panels were empty. The reason: this exporter introspects the SolidCache MySQL database and was separately vendored into bc3/bc4 and HEY but never into Fizzy. This PR vendors it here.

## How

Mirrors the `saas/lib/yabeda/active_support_cache.rb` vendoring pattern:

- `saas/lib/yabeda/solid_cache.rb` — self-contained `Yabeda::SolidCache.install!` defines the four gauges under `group :fizzy` (which is what produces the `fizzy_` prefix) and registers a `collect do … end` block guarded by `if defined?(::SolidCache::Entry)`.
- Wired in `saas/lib/fizzy/saas/engine.rb` right after `Yabeda::ActiveSupportCache.install!`.
- Collection logic is inlined as module methods (no `SolidCache::Entry` monkey-patch), preserving the source semantics: `Rails.cache.stats[:connection_stats]` enrichment + `SolidCache::Record.each_shard` oldest-entry ages, active/inactive-shard fallbacks, and rescue guards so a stats failure can never break a metrics scrape. The bc4/HEY version's heavy `Rails.logger.info` tracing and its global `Rails.logger =` reassignment were trimmed to match Fizzy's style.

## Single-connection adaptation

bc4/HEY run a shard-1..4 × multi-DC cache. Fizzy uses a **single** cache connection (`database: cache` in `config/cache.yml`, one `cache` connection in `saas/config/database.yml` — no shards). The exporter is shard-agnostic: it enumerates whatever `connection_stats` and `each_shard` yield, so on Fizzy it emits **one** series with `shard="cache"`. Both the `Rails.cache.stats` enrichment key (`Entry.current_shard` → `:cache`) and `each_shard`'s `connection_db_config.name` (`"cache"`) resolve to the same value, so there's a single clean series (sparse but correct — the panels will populate).

## Tests

`saas/test/lib/yabeda/solid_cache_test.rb` (follows #2957's test style/location):
- gauges are set from stubbed cache stats + shard ages
- no-op when the store isn't SolidCache
- a stats error is swallowed and never raised out of a scrape

All 3 pass locally (`SAAS=1 BUNDLE_GEMFILE=Gemfile.saas bin/rails test saas/test/lib/yabeda/solid_cache_test.rb`). Rubocop clean.

## Note

Fizzy uses stock `solid_cache ~> 1.0` (1.0.10) from rubygems, whereas bc3/HEY use Basecamp's `rails/solid_cache` git fork + `solid_cache-relay`. Verified the API this exporter relies on exists in 1.0.10 (`SolidCache::Record.each_shard`, `SolidCache::Entry`, and `Rails.cache.stats` returning `connection_stats`). One nicety of 1.0.10: its `connection_stats` already computes `oldest_age` from the DB, so the `each_shard` age pass is somewhat redundant here — it's kept for parity and to cover inactive shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)