### PR TITLE
Address Copilot review on Rails-edge PR (#2965 follow-up)

### DIFF
--- a/config/initializers/active_storage_purge_on_last_attachment.rb
+++ b/config/initializers/active_storage_purge_on_last_attachment.rb
@@ -29,6 +29,9 @@ module ActiveStorage
       def purge_dependent_blob
         return if @purge_mode
 
+        # `record.nil?` must be checked first: `dependent` reads `record.attachment_reflections`,
+        # so it can't be evaluated for an orphaned attachment — an absent record falls back to
+        # purge_later.
         if record.nil? || dependent == :purge_later
           purge_blob_if_last(:purge_later)
         elsif dependent == :purge

--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -107,7 +107,12 @@ module Fizzy
         ActiveSupport.on_load(:action_cable_connection) do
           if defined?(Sentry::Rails::ActionCableExtensions::Connection)
             Sentry::Rails::ActionCableExtensions::Connection.class_eval do
-              public :handle_open, :handle_close
+              # Guard per method: a future sentry-rails may rename/remove one, and calling
+              # `public` on an undefined method raises NameError — which would break SaaS
+              # boot here. Only flip the visibility of methods that actually exist.
+              %i[ handle_open handle_close ].each do |method|
+                public method if method_defined?(method) || private_method_defined?(method)
+              end
             end
           end
         end

--- a/script/import-sqlite-database.rb
+++ b/script/import-sqlite-database.rb
@@ -49,7 +49,7 @@ class Import
               ActiveStorage::Attachment.skip_callback(:commit, :after, :mirror_blob_later)
               ActiveStorage::Attachment.skip_callback(:commit, :after, :analyze_blob_later)
               ActiveStorage::Attachment.skip_callback(:commit, :after, :transform_variants_later)
-              ActiveStorage::Attachment.skip_callback(:commit, :after, :purge_dependent_blob_later)
+              ActiveStorage::Attachment.skip_callback(:commit, :after, :purge_dependent_blob)
             rescue => e
               puts "⚠️  Warning: Could not skip some callbacks: #{e.message}"
             end


### PR DESCRIPTION
## Summary

Follow-up to #2965 (Rails edge upgrade, already merged) — addresses the Copilot review comments that came in after the merge. Small and behavior-preserving except the import-script fix, which restores intended behavior on edge.

## Changes

1. **Guard the Sentry Action Cable shim** (`saas/lib/fizzy/saas/engine.rb`) — `public :handle_open, :handle_close` raises `NameError` if a method isn't defined, and it runs at boot, so a future sentry-rails rename/removal would break SaaS startup. Now only flips visibility on methods that actually exist (`method_defined?`/`private_method_defined?`). *(Copilot)*

2. **Document `purge_dependent_blob` ordering** (`config/initializers/active_storage_purge_on_last_attachment.rb`) — kept the existing `if/elsif`, added a comment on why `record.nil?` is checked first: `dependent` reads `record.attachment_reflections`, so it can't be evaluated for an orphaned attachment. The "nil record + `:purge`" case Copilot flagged is therefore unreachable and the ordering is intentional (a `dependent`-first check would `NoMethodError` on a nil record). No behavior change. *(Copilot)*

3. **Fix stale callback skip in the import script** (`script/import-sqlite-database.rb`) — skip the renamed `:purge_dependent_blob` (was `:purge_dependent_blob_later`). On edge the old name raises `ArgumentError: ...has not been defined`; it's caught by the surrounding rescue, but the skip then silently fails, re-enabling purge behavior during account imports. Verified the new name skips cleanly. *(Copilot — good catch; this callsite came from #2966 and the rename in #2965 broke it.)*

Copilot also suggested clarifying the solid_cable Gemfile comment — leaving the Gemfile as-is per preference (no comment).

## Verification

- `test/models/storage/no_reuse_test.rb`: 9 tests, 0 failures.
- SaaS boots with the guarded shim; `handle_open`/`handle_close` still public.
- `skip_callback(:commit, :after, :purge_dependent_blob)` confirmed to work on edge.
- rubocop clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
