### PR TITLE
Card title loses focus after each keystroke when pasting into the description (Firefox)

### DIFF
--- a/app/javascript/controllers/lexxy_focus_guard_controller.js
+++ b/app/javascript/controllers/lexxy_focus_guard_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Tentative Firefox-only fix for the card title losing focus after pasting into
+// the description editor.
+//
+// When files/images are pasted into Lexxy, the editor restores focus to itself
+// one animation frame later (Lexxy's #preservingScrollPosition calls
+// editor.focus() after an awaited frame). In Firefox the deferred refocus can
+// land after the user has already moved to the title field and started typing,
+// so every keystroke bounces focus back to the description editor.
+//
+// This guard wraps the editor's focus() and skips it while the title field is
+// the intended focus target, so a stray deferred refocus can't steal focus.
+export default class extends Controller {
+  static targets = [ "title", "editor" ]
+  static values = { guardMs: { type: Number, default: 150 } }
+
+  connect() {
+    this.blockUntil = 0
+    this.originalFocus = this.editorTarget.focus.bind(this.editorTarget)
+    this.editorTarget.focus = this.#guardedFocus.bind(this)
+  }
+
+  disconnect() {
+    if (this.originalFocus) {
+      this.editorTarget.focus = this.originalFocus
+      this.originalFocus = null
+    }
+  }
+
+  // Called when the title field gains focus or receives input. Opens a short
+  // window during which the editor is not allowed to grab focus back, covering
+  // the async gap where document.activeElement may briefly not be the title.
+  arm() {
+    this.blockUntil = performance.now() + this.guardMsValue
+  }
+
+  #guardedFocus(...args) {
+    const titleFocused = document.activeElement === this.titleTarget
+    const inGuardWindow = performance.now() < this.blockUntil
+
+    if (titleFocused || inGuardWindow) return
+
+    return this.originalFocus(...args)
+  }
+}

--- a/app/views/cards/container/_content.html.erb
+++ b/app/views/cards/container/_content.html.erb
@@ -10,19 +10,19 @@
   <% end %>
   </div>
 <% else %>
-  <%= form_with model: card, id: "card_form", data: { controller: "autoresize auto-save" } do |form| %>
+  <%= form_with model: card, id: "card_form", data: { controller: "autoresize auto-save lexxy-focus-guard" } do |form| %>
     <h1 class="card__title">
       <%= form.label :title, class: "flex flex-column align-center autoresize__wrapper", data: { autoresize_target: "wrapper", autoresize_clone_value: "" } do %>
         <%= form.text_area :title, placeholder: "Name it…",
               class: "card-field__title autoresize__textarea input input--textarea full-width borderless txt-align-start hide-focus-ring hide-scrollbar",
               autofocus: card.title.blank?, rows: 1, dir: "auto", maxlength: 255,
-              data: { autoresize_target: "textarea", action: "input->autoresize#resize auto-save#change blur->auto-save#submit keydown.enter->auto-save#submit:prevent" } %>
+              data: { autoresize_target: "textarea", lexxy_focus_guard_target: "title", action: "input->autoresize#resize input->lexxy-focus-guard#arm focus->lexxy-focus-guard#arm auto-save#change blur->auto-save#submit keydown.enter->auto-save#submit:prevent" } %>
       <% end %>
     </h1>
 
     <%= form.rich_textarea :description, class: "card__description lexxy-content",
           placeholder: "Add some notes, context, pictures, or video about this…",
-          data: { action: "lexxy:change->auto-save#change focusout->auto-save#submit" } do %>
+          data: { lexxy_focus_guard_target: "editor", action: "lexxy:change->auto-save#change focusout->auto-save#submit" } do %>
       <%= general_prompts(card.board) %>
     <% end %>
   <% end %>


### PR DESCRIPTION
### Problem

On the new/draft card form, after pasting content into the description editor, typing in the **title** field loses focus after each keystroke in **Firefox** — focus jumps back to the description body, so the title can only be edited one character at a time. Reported against Firefox 152.0.4 on Windows. Does not occur in Chrome.

### Reproduction

Not reproduced in our environments (Linux Firefox 151/152, BrowserStack Windows Firefox 152 — same as Rosa's and Gab's earlier attempts). I drove Firefox with Selenium/geckodriver against a local dev instance and exercised plain-text paste, real `Ctrl+V` paste with the autosave morph firing mid-typing, and image/file paste — focus was retained each time. The trigger appears specific to the customer's Windows Firefox build/clipboard behavior, but the mechanism is clear from the code.

### Root cause

The description editor is Lexxy (`lexxy 0.9.5.beta`). When files/images are pasted, Lexxy's paste path restores focus to itself one animation frame later:

- `#handlePastedFiles` → `#uploadFilesPreservingScroll` → `#preservingScrollPosition(callback)` runs `callback(); await nextFrame(); window.scrollTo(...); this.editor.focus()`.

That `editor.focus()` is unconditional. If, during that awaited frame, the user has already clicked into the title `<textarea>` and started typing, the deferred refocus steals focus back to the body — repeating on each keystroke while paste-related work is still settling.

### Why Firefox-specific

Firefox's paste/`beforeinput` (`insertFromPaste`) timing and its lack of `InputEvent.getTargetRanges` push Lexxy/Lexical onto a mutation-observer reconciliation path, so the deferred `editor.focus()` lands *after* the user's focus has moved to the title. Chrome commits the paste synchronously enough that the refocus happens before the user retargets, so it isn't observed there.

### Tentative fix

A small `lexxy-focus-guard` Stimulus controller on the draft-card form wraps the `<lexxy-editor>`'s `focus()` and skips it while the title field is the intended focus target (either currently focused, or within a short guard window opened on title focus/input). Original `focus()` is restored on `disconnect`. Verified in Firefox: with the title focused, a simulated deferred `editor.focus()` no longer steals focus, and normal typing and normal editor focus (when the title isn't active) both still work. Cards controller tests, rubocop, brakeman, and importmap audit are green.

### Caveats

- Tentative — we could not reproduce the customer's exact conditions, so this is a defensive mitigation for the identified mechanism, not a confirmed end-to-end fix. Worth a targeted re-test on Windows Firefox with the customer's paste content (the report video showed pasting a table).
- The real bug is upstream: Lexxy should not call `this.editor.focus()` unconditionally after an async gap when another field may now hold focus. This app-side guard should be paired with (and later removed in favor of) a Lexxy fix.
