### PR TITLE
Update Lexxy to 0.9.23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "geared_pagination", "~> 1.2"
 gem "rqrcode"
 gem "rouge"
 gem "jbuilder"
-gem "lexxy", "0.9.14.beta"
+gem "lexxy", "0.9.23"
 gem "image_processing", "~> 1.14"
 gem "platform_agent"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.9.14.beta)
+    lexxy (0.9.23)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -534,7 +534,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  lexxy (= 0.9.14.beta)
+  lexxy (= 0.9.23)
   minitest-reporters
   mission_control-jobs
   mittens

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -377,7 +377,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.9.14.beta)
+    lexxy (0.9.23)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -739,7 +739,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  lexxy (= 0.9.14.beta)
+  lexxy (= 0.9.23)
   minitest-reporters
   mission_control-jobs
   mittens


### PR DESCRIPTION
## Summary

Updates `lexxy` from **0.9.14.beta** to **0.9.23** (latest on RubyGems, published 2026-07-07). Both `Gemfile.lock` and `Gemfile.saas.lock` are bumped in lockstep; no other gems change (Lexxy's only gem dependency is still `rails >= 8.0.2`).

143 upstream commits land in this range, including a large amount of editor paste/selection/caret rework.

## Tests

- `bin/rails test` — 1513 tests, 0 failures.
- `bin/rails test:system` — 12 tests, 0 failures (includes the Lexxy `markdown_paste` system test).
- `bin/bundle-drift check`, `bin/bundler-audit`, `bin/importmap audit` — all clean.

## Does this fix the Firefox title-focus bug?

Context: the [card 10036823881](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10036823881) bug — card title loses focus per keystroke after pasting into the description, Firefox-only. Root cause identified earlier: Lexxy's `clipboard.js` `#preservingScrollPosition` calls `this.editor.focus()` unconditionally one animation frame after a file/image paste.

- That specific method is **unchanged** between 0.9.14.beta and 0.9.23 — it still calls `editor.focus()` unconditionally after `await nextFrame()`.
- However, the paste path around it saw significant rework in this range. Candidate commits that could shift the Firefox paste/focus timing: `206e0b6e` (fire paste nodes command on insertHtml/insertDOM during paste), `327b15a7` (modify selection programmatically for Playwright Firefox), `1980901b` (handle node selections when inserting dropped/pasted files), plus several plain-text/blockquote/list paste fixes.
- **Verdict: uncertain.** The exact refocus call that causes the bug is still present, so a durable fix likely still belongs upstream in Lexxy. This upgrade is worth taking on its own merits (Jorge's call — many fixes landed) and may or may not incidentally resolve the report. We could not reproduce the customer's Windows-Firefox conditions locally (Linux Firefox 151, before or after the upgrade), so this needs a targeted re-test on Windows Firefox with the customer's paste content.

## Notes

- No breaking API changes affecting Fizzy's usage (`form.rich_textarea`, `lexxy:change` / `lexxy:insert-markdown` events, `lexxy-prompt` @mention / #card references, the `<lexxy-editor>` element) were observed in tests.
