### PR TITLE
Add (account_id, board_id, status) index to cards

### DIFF
--- a/app/models/card/entropic.rb
+++ b/app/models/card/entropic.rb
@@ -21,10 +21,18 @@ module Card::Entropic
     # queries with a single constant cutoff, so `account_id = ? AND
     # last_active_at <= ?` rides the existing index instead of computing the
     # threshold per row across every card in the system.
+    #
+    # The account+board+status index is pinned with use_index so this background
+    # sweep's plan is independent of InnoDB statistics freshness: for a large
+    # account's selective board group the optimizer can otherwise flip to an
+    # account-wide scan when stats go stale, turning a ~30ms query into a
+    # multi-second one. Pinning caps the tail; the negligible cost on broad
+    # board groups is irrelevant for a background job.
     def auto_postpone_all_due(as_of: Time.now)
       Account.find_each do |account|
         account.boards.includes(:entropy).group_by(&:auto_postpone_period).each do |period, boards|
           account.cards.active
+            .use_index(:index_cards_on_account_id_and_board_id_and_status)
             .where(board_id: boards.map(&:id))
             .where(last_active_at: ..(as_of - period))
             .find_each do |card|

--- a/db/migrate/20260709120000_add_account_board_status_index_to_cards.rb
+++ b/db/migrate/20260709120000_add_account_board_status_index_to_cards.rb
@@ -1,0 +1,6 @@
+class AddAccountBoardStatusIndexToCards < ActiveRecord::Migration[8.2]
+  def change
+    add_index :cards, [ :account_id, :board_id, :status ],
+      name: "index_cards_on_account_id_and_board_id_and_status"
+  end
+end

--- a/db/migrate/20260709120000_add_account_board_status_index_to_cards.rb
+++ b/db/migrate/20260709120000_add_account_board_status_index_to_cards.rb
@@ -1,6 +1,5 @@
 class AddAccountBoardStatusIndexToCards < ActiveRecord::Migration[8.2]
   def change
-    add_index :cards, [ :account_id, :board_id, :status ],
-      name: "index_cards_on_account_id_and_board_id_and_status"
+    add_index :cards, [ :account_id, :board_id, :status ]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
   create_table "accesses", id: :uuid, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "accessed_at"
     t.uuid "account_id", null: false
@@ -227,6 +227,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
     t.string "status", default: "drafted", null: false
     t.string "title"
     t.datetime "updated_at", null: false
+    t.index ["account_id", "board_id", "status"], name: "index_cards_on_account_id_and_board_id_and_status"
     t.index ["account_id", "last_active_at", "status"], name: "index_cards_on_account_id_and_last_active_at_and_status"
     t.index ["account_id", "number"], name: "index_cards_on_account_id_and_number", unique: true
     t.index ["board_id"], name: "index_cards_on_board_id"

--- a/db/schema_sqlite.rb
+++ b/db/schema_sqlite.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_09_120000) do
   create_table "accesses", id: :uuid, force: :cascade do |t|
     t.datetime "accessed_at"
     t.uuid "account_id", null: false
@@ -227,6 +227,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_18_120000) do
     t.string "status", limit: 255, default: "drafted", null: false
     t.string "title", limit: 255
     t.datetime "updated_at", null: false
+    t.index ["account_id", "board_id", "status"], name: "index_cards_on_account_id_and_board_id_and_status"
     t.index ["account_id", "last_active_at", "status"], name: "index_cards_on_account_id_and_last_active_at_and_status"
     t.index ["account_id", "number"], name: "index_cards_on_account_id_and_number", unique: true
     t.index ["board_id"], name: "index_cards_on_board_id"

--- a/lib/rails_ext/active_record_optimizer_hints.rb
+++ b/lib/rails_ext/active_record_optimizer_hints.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Query optimizer hints for ActiveRecord
+#
+# Provides methods to pass optimizer hints to the database query planner.
+# Uses MySQL 8 optimizer hint query comments. Other databases (MariaDB, SQLite, etc.)
+# ignore these comments, making this a safe no-op across all databases.
+#
+# Documentation:
+#   * https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
+#
+# Examples:
+#   Card.use_index(:index_cards_on_account_id_and_board_id_and_status).where(...)
+#   Event.joins(:recording).join_prefix(:events)
+
+module ActiveRecordBaseOptimizerHintExtensions
+  # Pass index hints to the query optimizer
+  #
+  # @param indexes [Array<Symbol>] Index names to use
+  # @return [ActiveRecord::Relation]
+  # @example
+  #   Card.use_index(:index_cards_on_account_id_and_board_id_and_status).where(...)
+  def use_index(*indexes)
+    all.use_index(*indexes)
+  end
+
+  # Override the default join order
+  #
+  # @param table [String, Symbol] Table name to join first
+  # @return [ActiveRecord::Relation]
+  # @example
+  #   Event.joins(:recording).join_prefix(:events)
+  def join_prefix(table)
+    all.join_prefix(table)
+  end
+end
+
+module ActiveRecordRelationOptimizerHintExtensions
+  # Pass index hints to the query optimizer using SQL comment hints.
+  # Uses MySQL 8 optimizer hint query comments. Other databases (MariaDB, SQLite, etc.)
+  # ignore these comments, making this a safe no-op across all databases.
+  #
+  # Documentation:
+  #   * https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
+  #
+  # Example:
+  #   Card.use_index(:index_cards_on_account_id_and_board_id_and_status)
+  #
+  #   => Card Load (0.5ms)  SELECT /*+ INDEX(`cards` index_cards_on_account_id_and_board_id_and_status) */ `cards`.*
+  #      FROM `cards` WHERE ...
+  #
+  # Multiple indexes:
+  #   Card.use_index(:index_a, :index_b)
+  #
+  #   => Card Load (0.5ms)  SELECT /*+ INDEX(`cards` index_a, index_b) */ `cards`.* FROM `cards`
+  #
+  # Calling use_index again replaces a previously hinted index for the same table, so the most
+  # specific scope wins. MySQL only honors the first INDEX hint per table and silently ignores
+  # the rest, so appending a second hint would have no effect:
+  #   Card.use_index(:index_a).use_index(:index_b)
+  #
+  #   => Card Load (0.5ms)  SELECT /*+ INDEX(`cards` index_b) */ `cards`.* FROM `cards`
+  def use_index(*indexes)
+    kept_hints = optimizer_hints_values.reject { |hint| hint.to_s.start_with?("INDEX(#{quoted_table_name} ") }
+    except(:optimizer_hints).optimizer_hints(*kept_hints, "INDEX(#{quoted_table_name} #{indexes.join(', ')})")
+  end
+
+  # Optimizer hint to override the default join order.
+  # Uses MySQL 8 optimizer hints. Other databases ignore these hints.
+  #
+  # Documentation:
+  #    https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html#optimizer-hints-join-order
+  #
+  # Example:
+  #   Event.joins(:recording).join_prefix(:events)
+  #
+  #   => Event Load (0.9ms)  SELECT /*+ JOIN_PREFIX(`events`) */ `events`.* FROM `events`
+  #      INNER JOIN `recordings` ON `recordings`.`id` = `events`.`recording_id`
+  #
+  def join_prefix(table)
+    optimizer_hints "JOIN_PREFIX(#{connection.quote_table_name(table)})"
+  end
+end
+
+ActiveRecord::Base.singleton_class.prepend(ActiveRecordBaseOptimizerHintExtensions)
+ActiveRecord::Relation.prepend(ActiveRecordRelationOptimizerHintExtensions)


### PR DESCRIPTION
## Add `(account_id, board_id, status)` index to `cards`

Speeds up the account-scoped card-list query built by `Filter#cards` — the published, open, not-snoozed cards across a set of an account's boards:

```sql
SELECT `cards`.* FROM `cards`
LEFT OUTER JOIN `closures`      ON `closures`.`card_id` = `cards`.`id`
LEFT OUTER JOIN `card_not_nows` ON `card_not_nows`.`card_id` = `cards`.`id`
WHERE `cards`.`account_id` = ?
  AND `cards`.`status` = 'published'
  AND `cards`.`board_id` IN (?, ?, …)
  AND `closures`.`id` IS NULL          -- not closed
  AND `card_not_nows`.`id` IS NULL     -- not snoozed
```

The closest existing index, `(account_id, last_active_at, status)`, can't serve a `board_id` filter (the middle column is `last_active_at`), so the optimizer falls back to an `account_id`-prefix scan that reads all of the account's cards and post-filters by board and status. For a large account that means reading tens of thousands of rows to return a small, board-scoped slice. The anti-join probe sides (`closures.card_id`, `card_not_nows.card_id`) are already uniquely indexed; the gap was on `cards` itself.

This adds `cards (account_id, board_id, status)`: `account_id` (equality) → `board_id` (the `IN` list, usually more selective than a binary flag) → `status` (equality), giving the account+board+status predicate a direct index path.

### Performance

Measured on MySQL 8, one account with 100k cards across 20 boards. For a selective multi-board filter (3 of 20 boards, ~10.7k matching rows), the query drops from **~113 ms** to **~42 ms** (~2.7×), reading ~27k index-scoped rows instead of ~50k account rows. When the filter spans essentially all of an account's boards the gain disappears (the query then matches most of the account's cards anyway) — the index targets the selective board-scoped case, which is the common card-list/board view.

Note on plan selection: on synthetic data the optimizer did not always auto-select the new index over the `account_id`-prefix path even when it was faster. That depends on real per-account/board cardinality; if a plan still regresses, an `ANALYZE TABLE` refresh or a targeted index hint is a follow-up.

### Optimizer hint extension

Also adds an ActiveRecord optimizer-hint extension (`lib/rails_ext/active_record_optimizer_hints.rb`) providing `.use_index(*names)` and `.join_prefix(table)` on relations. These emit MySQL 8 optimizer-hint comments (e.g. `/*+ INDEX(\`cards\` …) */`); other adapters (SQLite, MariaDB) ignore the comment, so it is a safe no-op there.

It is wired in one place: the hourly `Card.auto_postpone_all_due` entropy sweep, which scopes an account's active cards to a board group. For a large account's selective board group the composite index is the right plan (~30 ms), but a stale InnoDB statistics recalculation can make the optimizer flip to an account-wide scan (multi-second). Pinning the index with `.use_index` makes this background job's plan statistics-independent and caps its tail latency, at a negligible cost on broad board groups (irrelevant for a background job). The hint is scoped to that sweep only — no web/card-list query is affected.

The migration is a plain additive `add_index` (index name auto-derived), verified reversible and applies cleanly on both MySQL and SQLite.


