### PR TITLE
Speed up the card list for large accounts

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -27,7 +27,7 @@ class Filter < ApplicationRecord
       result = result.unassigned if assignment_status.unassigned?
       result = result.assigned_to(assignees.ids) if assignees.present?
       result = result.where(creator_id: creators.ids) if creators.present?
-      result = result.where(board: boards.ids) if boards.present?
+      result = filter_boards(result) if boards.present?
       result = result.tagged_with(tags.ids) if tags.present?
       result = result.where(cards: { created_at: creation_window }) if creation_window
       result = result.closed_at_window(closure_window) if closure_window
@@ -66,6 +66,20 @@ class Filter < ApplicationRecord
   end
 
   private
+    def filter_boards(relation)
+      relation = relation.where(cards: { account_id: creator.account_id }).where(board: boards.ids)
+      return relation if fans_out?
+      # Pin the (account_id, last_active_at, status) index so the ordered page is served by a reverse scan, not a filesort.
+      relation.use_index(:index_cards_on_account_id_and_last_active_at_and_status)
+    end
+
+    # Assignee, tag, and term filters add a has-many join that fans a card into
+    # several rows; the ordered reverse scan loses to a different plan then, so
+    # the pin only applies without them.
+    def fans_out?
+      assignees.present? || tags.present? || terms.present?
+    end
+
     def include_closed_cards?
       only_closed? || card_ids.present?
     end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -68,9 +68,12 @@ class Filter < ApplicationRecord
   private
     def filter_boards(relation)
       relation = relation.where(cards: { account_id: creator.account_id }).where(board: boards.ids)
-      return relation if fans_out?
-      # Pin the (account_id, last_active_at, status) index so the ordered page is served by a reverse scan, not a filesort.
-      relation.use_index(:index_cards_on_account_id_and_last_active_at_and_status)
+      if fans_out?
+        relation
+      else
+        # Pin the (account_id, last_active_at, status) index so the ordered page is served by a reverse scan, not a filesort.
+        relation.use_index(:index_cards_on_account_id_and_last_active_at_and_status)
+      end
     end
 
     # Assignee, tag, and term filters add a has-many join that fans a card into

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -68,7 +68,7 @@ class Filter < ApplicationRecord
   private
     def filter_boards(relation)
       relation = relation.where(cards: { account_id: creator.account_id }).where(board: boards.ids)
-      if fans_out?
+      if filters_by_association?
         relation
       else
         # Pin the (account_id, last_active_at, status) index so the ordered page is served by a reverse scan, not a filesort.
@@ -79,7 +79,7 @@ class Filter < ApplicationRecord
     # Assignee, tag, and term filters add a has-many join that fans a card into
     # several rows; the ordered reverse scan loses to a different plan then, so
     # the pin only applies without them.
-    def fans_out?
+    def filters_by_association?
       assignees.present? || tags.present? || terms.present?
     end
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -68,7 +68,7 @@ class Filter < ApplicationRecord
   private
     def filter_boards(relation)
       relation = relation.where(cards: { account_id: creator.account_id }).where(board: boards.ids)
-      if filters_by_association?
+      if joins_has_many?
         relation
       else
         # Pin the (account_id, last_active_at, status) index so the ordered page is served by a reverse scan, not a filesort.
@@ -79,7 +79,7 @@ class Filter < ApplicationRecord
     # Assignee, tag, and term filters add a has-many join that fans a card into
     # several rows; the ordered reverse scan loses to a different plan then, so
     # the pin only applies without them.
-    def filters_by_association?
+    def joins_has_many?
       assignees.present? || tags.present? || terms.present?
     end
 

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -48,6 +48,15 @@ class FilterTest < ActiveSupport::TestCase
     assert_empty users(:david).filters.new(board_ids: [ boards(:writebook).id ]).boards
   end
 
+  test "board-scoped cards never leak cards from an inaccessible board in the same account" do
+    inaccessible_card = boards(:private).cards.create!(status: "published", creator: users(:kevin))
+
+    filter = users(:david).filters.new(board_ids: [ boards(:private).id, boards(:writebook).id ])
+
+    assert_not_includes filter.cards, inaccessible_card
+    filter.cards.each { |card| assert_includes users(:david).boards, card.board }
+  end
+
   test "remembering equivalent filters" do
     assert_difference "Filter.count", +1 do
       filter = users(:david).filters.remember(sorted_by: "latest", assignment_status: "unassigned", tag_ids: [ tags(:mobile).id ])


### PR DESCRIPTION
## What this fixes
`CardsController#index` (`/<acct>/cards?board_ids[]=…`) runs hundreds of ms to seconds of DB time on large accounts — the account's card list with the `Card.active` anti-joins, a `board_id IN (…)` filter, and the default `ORDER BY last_active_at DESC, id DESC`.

## Why it was slow
Filtering by board goes through `creator.accessible_cards` (an `accesses` INNER JOIN) and anchors the plan on `index_cards_on_board_id` — a range scan over every published card on the boards — then a filesort by `last_active_at` to return one page.

## The fix
- **Keep `creator.accessible_cards`.** The `accesses` INNER JOIN stays, so authorization is enforced by the query and never depends on the board list being pre-filtered.
- **Add a redundant `account_id` predicate + conditional index pin.** `accessible_cards` scopes by `accesses.user_id`, not `cards.account_id`, so `(account_id, last_active_at, status)` isn't eligible. Every selected board belongs to the creator's account, so `where(cards: { account_id: … })` makes that index usable, and pinning it holds the plan on its reverse scan — serving the ordering directly and stopping at the page limit, no filesort. Applied only when boards are filtered and no fan-out join (assignee/tag/term) is present.

### Why pin, not just the predicate
With the predicate alone the optimizer's choice depends on how many boards are in the `IN` list: for a handful of boards it still picks `index_cards_on_board_id` and filesorts, only switching to the fast index for larger lists — and even there the two plans cost within a few percent, so statistics drift can flip it back. The conditional pin holds the fast plan across every board count.

## Before / after
MySQL 8, 40k-active-card account filtered to 15 boards, identical result sets (**20,005 == 20,005** ids; `accesses` join present in both):
- **Before:** ~42.7 ms — `index_cards_on_board_id`, filesort.
- **After:** ~0.9 ms — `(account_id, last_active_at, status)` reverse scan, no filesort.

## Notes
- No new index — reuses the existing `(account_id, last_active_at, status)` index.
- The `use_index` hint is an optimizer-hint comment; SQLite/MariaDB ignore it (safe no-op).
