### PR TITLE
Drop the index hint from the auto-postpone sweep

### DIFF
--- a/app/models/card/entropic.rb
+++ b/app/models/card/entropic.rb
@@ -21,18 +21,10 @@ module Card::Entropic
     # queries with a single constant cutoff, so `account_id = ? AND
     # last_active_at <= ?` rides the existing index instead of computing the
     # threshold per row across every card in the system.
-    #
-    # The account+board+status index is pinned with use_index so this background
-    # sweep's plan is independent of InnoDB statistics freshness: for a large
-    # account's selective board group the optimizer can otherwise flip to an
-    # account-wide scan when stats go stale, turning a ~30ms query into a
-    # multi-second one. Pinning caps the tail; the negligible cost on broad
-    # board groups is irrelevant for a background job.
     def auto_postpone_all_due(as_of: Time.now)
       Account.find_each do |account|
         account.boards.includes(:entropy).group_by(&:auto_postpone_period).each do |period, boards|
           account.cards.active
-            .use_index(:index_cards_on_account_id_and_board_id_and_status)
             .where(board_id: boards.map(&:id))
             .where(last_active_at: ..(as_of - period))
             .find_each do |card|


### PR DESCRIPTION
Removes the `use_index` pin from `Card::Entropic.auto_postpone_all_due`, keeping the `(account_id, board_id, status)` index added in #2970.

Once MySQL collected statistics on the new index, the planner started choosing it for the sweep on its own. The forced pin is no longer needed and is better left to the planner, which can adapt per-account as data shifts — a background sweep doesn't warrant a hardcoded plan.

The index stays; only the hint is removed.
