### PR TITLE
Migrate bin/setup to mise's declarative bootstrap pipeline

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,27 @@
+min_version = "2026.7.5"
+
 [settings]
 idiomatic_version_file_enable_tools = ["ruby"]
 
+[tools]
+gum = "0.17.0"
+
 [env]
 PROMETHEUS_EXPORTER_URL = "http://127.0.0.1:9306/metrics"
+
+[bootstrap.packages]
+# Arch
+"pacman:imagemagick" = "latest"
+"pacman:mariadb-libs" = "latest"
+"pacman:openslide" = "latest"
+"pacman:libvips" = "latest"
+"pacman:libheif" = "latest"
+"pacman:libwebp" = "latest"
+"pacman:libjxl" = "latest"
+"pacman:libraw" = "latest"
+"pacman:poppler-glib" = "latest"
+"pacman:libcgif" = "latest"
+"pacman:ffmpeg" = "latest"
+"pacman:rav1e" = "latest"
+"pacman:svt-av1" = "latest"
+"pacman:gitleaks" = "latest"

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,4 @@
+brew "imagemagick"
+brew "openslide"
+brew "vips"
+brew "gitleaks"

--- a/bin/setup
+++ b/bin/setup
@@ -44,22 +44,31 @@ mise_too_old() {
 }
 
 ensure_correct_mise_install() {
-  if ! command -v mise &>/dev/null; then
-    if command -v brew &>/dev/null; then
+  if ! command -v mise &> /dev/null; then
+    if command -v brew &> /dev/null; then
       brew install mise
-    elif command -v pacman &>/dev/null; then
+    elif command -v pacman &> /dev/null; then
       sudo pacman -S --noconfirm --needed mise
     else
-      echo "Please install mise: https://mise.jdx.dev/installing-mise.html#installation-methods"
+      echo "Please install mise: https://mise.jdx.dev/"
       exit 1
     fi
   fi
 
   if mise_too_old; then
-    if command -v brew &>/dev/null && brew list --versions mise &>/dev/null; then
+    if command -v brew &> /dev/null && brew list --versions mise &> /dev/null; then
       brew upgrade mise || true
-    elif command -v pacman &>/dev/null && pacman -Q mise &>/dev/null; then
-      sudo pacman -Sy --noconfirm --needed mise || true
+    elif command -v pacman &> /dev/null && pacman -Q mise &> /dev/null; then
+      sudo pacman -Syu --noconfirm mise || true
+    elif command -v dpkg &> /dev/null && dpkg -S "$(readlink -f "$(command -v mise)")" &> /dev/null; then
+      # apt can't reach the floor: there's no mise apt repo on our fleet, and mise
+      # disables self-update for package-manager installs. Deliberate ownership
+      # change, matching Shipyard's ensure-mise: install via mise.run, shadowing
+      # the apt package.
+      echo "Replacing your apt-installed mise with a mise.run install (apt has no upgrade path)."
+      curl -fsSL https://mise.run | sh || true
+      export PATH="$HOME/.local/bin:$PATH"
+      hash -r
     else
       mise self-update --yes --no-plugins || true
     fi

--- a/bin/setup
+++ b/bin/setup
@@ -127,7 +127,14 @@ fi
 if [ "$manager" = "brew" ]; then
   step "Installing system packages" brew bundle --file="$app_root/Brewfile"
 else
-  step "Installing system packages" mise bootstrap packages apply --manager "$manager" --yes --update
+  # apt refreshes package lists with --update; pacman must NOT — mise maps it to a
+  # forced `pacman -Sy` before a targeted -S, Arch's unsupported partial upgrade.
+  # Install against the existing synchronized database instead.
+  if [ "$manager" = pacman ]; then
+    step "Installing system packages" mise bootstrap packages apply --manager "$manager" --yes
+  else
+    step "Installing system packages" mise bootstrap packages apply --manager "$manager" --yes --update
+  fi
 fi
 
 step "Installing Ruby and tools" mise install --yes

--- a/bin/setup
+++ b/bin/setup
@@ -21,9 +21,10 @@ step() {
   local step_name="$1"
   shift
 
-  # gum may resolve to a mise shim before this config is trusted or mise meets the
-  # floor; invoking it would abort setup right here, so treat shims as unavailable.
-  if command -v gum &> /dev/null && [[ "$(command -v gum)" != */mise/shims/* ]]; then
+  # gum may resolve to a mise shim that aborts before this config is trusted or
+  # mise meets the floor — and the shim dir is configurable, so probe by running
+  # gum rather than matching paths. Any failure falls back to plain echo.
+  if gum --version &> /dev/null; then
     gum style --foreground 135 --bold "▸ $step_name"
     gum style --foreground 240 "$*"
   else
@@ -107,12 +108,14 @@ oss_mysql_setup() {
 step "Ensuring mise install" ensure_correct_mise_install
 step "Trusting mise config" mise trust --yes "$app_root/.mise.toml"
 
-if command -v brew &>/dev/null; then
+# Manager by OS, not PATH: a Linux machine with Homebrew installed must still
+# converge its declared pacman packages, not the macOS Brewfile.
+if [ "$(uname -s)" = Darwin ] && command -v brew &> /dev/null; then
   manager=brew
-elif command -v pacman &>/dev/null; then
+elif [ "$(uname -s)" = Linux ] && command -v pacman &> /dev/null; then
   manager=pacman
 else
-  echo "Unsupported platform: bin/setup needs Homebrew or pacman."
+  echo "Unsupported platform: bin/setup needs Homebrew (macOS) or pacman."
   exit 1
 fi
 

--- a/bin/setup
+++ b/bin/setup
@@ -21,7 +21,9 @@ step() {
   local step_name="$1"
   shift
 
-  if command -v gum &>/dev/null; then
+  # gum may resolve to a mise shim before this config is trusted or mise meets the
+  # floor; invoking it would abort setup right here, so treat shims as unavailable.
+  if command -v gum &> /dev/null && [[ "$(command -v gum)" != */mise/shims/* ]]; then
     gum style --foreground 135 --bold "▸ $step_name"
     gum style --foreground 240 "$*"
   else
@@ -60,15 +62,6 @@ ensure_correct_mise_install() {
       brew upgrade mise || true
     elif command -v pacman &> /dev/null && pacman -Q mise &> /dev/null; then
       sudo pacman -Syu --noconfirm mise || true
-    elif command -v dpkg &> /dev/null && dpkg -S "$(readlink -f "$(command -v mise)")" &> /dev/null; then
-      # apt can't reach the floor: there's no mise apt repo on our fleet, and mise
-      # disables self-update for package-manager installs. Deliberate ownership
-      # change, matching Shipyard's ensure-mise: install via mise.run, shadowing
-      # the apt package.
-      echo "Replacing your apt-installed mise with a mise.run install (apt has no upgrade path)."
-      curl -fsSL https://mise.run | sh || true
-      export PATH="$HOME/.local/bin:$PATH"
-      hash -r
     else
       mise self-update --yes --no-plugins || true
     fi

--- a/bin/setup
+++ b/bin/setup
@@ -16,63 +16,59 @@ if [ -n "$SAAS" ]; then
   export BUNDLE_GEMFILE="Gemfile.saas"
 fi
 
-# Install gum if needed
-if ! command -v gum &>/dev/null; then
-  echo
-  echo "▸ Installing gum"
-  if command -v pacman &>/dev/null; then
-    sudo pacman -S --noconfirm gum
-  elif command -v brew &>/dev/null; then
-    brew install gum
-  else
-    echo "Please install gum: https://github.com/charmbracelet/gum"
-    exit 1
-  fi
-  echo
-fi
-
-# Install mise if needed
-if ! command -v mise &>/dev/null; then
-  echo
-  echo "▸ Installing mise"
-  if command -v pacman &>/dev/null; then
-    sudo pacman -S --noconfirm mise
-  elif command -v brew &>/dev/null; then
-    brew install mise
-  else
-    echo "Please install mise: https://mise.jdx.dev/installing-mise.html#installation-methods"
-    exit 1
-  fi
-  echo
-fi
-
-# Install gh if needed
-if ! command -v gh &>/dev/null; then
-  echo
-  echo "▸ Installing GitHub CLI"
-  if command -v pacman &>/dev/null; then
-    sudo pacman -S --noconfirm github-cli
-  elif command -v brew &>/dev/null; then
-    brew install gh
-  else
-    echo "Please install GitHub CLI: https://github.com/cli/cli#installation"
-    exit 1
-  fi
-  echo
-fi
-
+# gum is a mise-managed tool, so it isn't installed yet on a fresh machine.
 step() {
   local step_name="$1"
   shift
 
-  gum style --foreground 135 --bold "▸ $step_name"
-  gum style --foreground 240 "$*"
+  if command -v gum &>/dev/null; then
+    gum style --foreground 135 --bold "▸ $step_name"
+    gum style --foreground 240 "$*"
+  else
+    echo "▸ $step_name"
+    echo "$*"
+  fi
 
   "$@"
 
   local exit_code=$?
   echo
   return $exit_code
+}
+
+mise_min_version="2026.7.5" # keep in lockstep with min_version in .mise.toml
+
+mise_too_old() {
+  local current="$(mise --version 2>/dev/null | awk '{ print $1; exit }')"
+  [ "$(printf '%s\n' "$mise_min_version" "$current" | sort -V | head -1)" != "$mise_min_version" ]
+}
+
+ensure_correct_mise_install() {
+  if ! command -v mise &>/dev/null; then
+    if command -v brew &>/dev/null; then
+      brew install mise
+    elif command -v pacman &>/dev/null; then
+      sudo pacman -S --noconfirm --needed mise
+    else
+      echo "Please install mise: https://mise.jdx.dev/installing-mise.html#installation-methods"
+      exit 1
+    fi
+  fi
+
+  if mise_too_old; then
+    if command -v brew &>/dev/null && brew list --versions mise &>/dev/null; then
+      brew upgrade mise || true
+    elif command -v pacman &>/dev/null && pacman -Q mise &>/dev/null; then
+      sudo pacman -Sy --noconfirm --needed mise || true
+    else
+      mise self-update --yes --no-plugins || true
+    fi
+  fi
+
+  if mise_too_old; then
+    echo "mise $mise_min_version or newer is required. Please upgrade mise and rerun bin/setup."
+    exit 1
+  fi
 }
 
 needs_seeding() {
@@ -106,31 +102,47 @@ oss_mysql_setup() {
   fi
 }
 
+step "Ensuring mise install" ensure_correct_mise_install
+step "Trusting mise config" mise trust --yes "$app_root/.mise.toml"
+
+if command -v brew &>/dev/null; then
+  manager=brew
+elif command -v pacman &>/dev/null; then
+  manager=pacman
+else
+  echo "Unsupported platform: bin/setup needs Homebrew or pacman."
+  exit 1
+fi
+
+# Native packages before tools: Bundler builds native extensions against them.
+if [ "$manager" = "brew" ]; then
+  step "Installing system packages" brew bundle --file="$app_root/Brewfile"
+else
+  step "Installing system packages" mise bootstrap packages apply --manager "$manager" --yes --update
+fi
+
+step "Installing Ruby and tools" mise install --yes
+eval "$(mise hook-env -s bash)"
+
+# Install gh if needed
+if ! command -v gh &>/dev/null; then
+  echo
+  echo "▸ Installing GitHub CLI"
+  if command -v pacman &>/dev/null; then
+    sudo pacman -S --noconfirm github-cli
+  elif command -v brew &>/dev/null; then
+    brew install gh
+  else
+    echo "Please install GitHub CLI: https://github.com/cli/cli#installation"
+    exit 1
+  fi
+  echo
+fi
+
 echo
 gum style --foreground 153 "   ˚ ∘             ∘ ˚   "
 gum style --foreground 111 --bold "  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  "
 echo
-
-step "Installing Ruby" mise install --yes
-eval "$(mise hook-env -s bash)"
-
-if which pacman >/dev/null 2>&1; then
-  packages=(imagemagick mariadb-libs openslide libvips libheif libwebp libjxl libraw poppler-glib libcgif ffmpeg rav1e svt-av1 gitleaks)
-  if ! pacman -Q "${packages[@]}" >/dev/null 2>&1; then
-    step "Installing packages" sudo pacman -S --noconfirm --needed "${packages[@]}"
-  fi
-elif which brew >/dev/null 2>&1; then
-  packages=(imagemagick openslide vips gitleaks)
-  missing_packages=()
-  for pkg in "${packages[@]}"; do
-    if ! brew list "$pkg" &>/dev/null; then
-      missing_packages+=("$pkg")
-    fi
-  done
-  if [ ${#missing_packages[@]} -gt 0 ]; then
-    step "Installing packages" brew install "${missing_packages[@]}"
-  fi
-fi
 
 bundle config set --local auto_install true
 step "Installing RubyGems" bundle install

--- a/bin/setup
+++ b/bin/setup
@@ -49,6 +49,9 @@ mise_too_old() {
 ensure_correct_mise_install() {
   if ! command -v mise &> /dev/null; then
     if command -v brew &> /dev/null; then
+      # refresh the formula index first: a stale one (fresh VM images, long-idle
+      # machines) resolves an old mise and the version floor is unreachable
+      brew update --quiet || true
       brew install mise
     elif command -v pacman &> /dev/null; then
       sudo pacman -S --noconfirm --needed mise
@@ -60,6 +63,10 @@ ensure_correct_mise_install() {
 
   if mise_too_old; then
     if command -v brew &> /dev/null && brew list --versions mise &> /dev/null; then
+      # refresh the formula index first: with a stale one (fresh VM images,
+      # long-idle machines) brew considers an old mise current and this upgrade
+      # is a no-op — found live on the fresh-macOS signoff VM
+      brew update --quiet || true
       brew upgrade mise || true
     elif command -v pacman &> /dev/null && pacman -Q mise &> /dev/null; then
       sudo pacman -Syu --noconfirm mise || true

--- a/bin/setup
+++ b/bin/setup
@@ -48,7 +48,9 @@ mise_too_old() {
 
 ensure_correct_mise_install() {
   if ! command -v mise &> /dev/null; then
-    if command -v brew &> /dev/null; then
+    # brew installs are a macOS decision — a Linuxbrew host must not gain a
+    # brew-owned mise moments before the manager gate rejects or ignores it
+    if [ "$(uname -s)" = Darwin ] && command -v brew &> /dev/null; then
       # refresh the formula index first: a stale one (fresh VM images, long-idle
       # machines) resolves an old mise and the version floor is unreachable
       brew update --quiet || true

--- a/bin/setup
+++ b/bin/setup
@@ -62,13 +62,17 @@ ensure_correct_mise_install() {
   fi
 
   if mise_too_old; then
-    if command -v brew &> /dev/null && brew list --versions mise &> /dev/null; then
+    # Upgrade the ACTIVE mise, classified by the resolved binary's owner — a brew
+    # keg can coexist with the pacman/dpkg/mise.run install PATH actually
+    # resolves, and upgrading an inactive copy would leave the floor unmet.
+    mise_path="$(readlink -f "$(command -v mise)")"
+    if command -v brew &> /dev/null && [[ "$mise_path" = "$(brew --prefix)"/* ]]; then
       # refresh the formula index first: with a stale one (fresh VM images,
       # long-idle machines) brew considers an old mise current and this upgrade
       # is a no-op — found live on the fresh-macOS signoff VM
       brew update --quiet || true
       brew upgrade mise || true
-    elif command -v pacman &> /dev/null && pacman -Q mise &> /dev/null; then
+    elif command -v pacman &> /dev/null && pacman -Qo "$mise_path" &> /dev/null; then
       sudo pacman -Syu --noconfirm mise || true
     else
       mise self-update --yes --no-plugins || true


### PR DESCRIPTION
Migrates fizzy's `bin/setup` to mise's declarative bootstrap pipeline, following the pattern proven in bc3#12250 and shipyard#135. Fizzy stays fully self-sufficient without Shipyard.

## What moved and why

- **`.mise.toml`**: the ~14-package inline pacman array from `bin/setup` becomes `[bootstrap.packages]` (`"pacman:*"` entries), installed via `mise bootstrap packages apply`. Adds `min_version = "2026.7.5"` and `gum = "0.17.0"` under `[tools]` (the bc3-proven pin). Keeps `idiomatic_version_file_enable_tools = ["ruby"]`, so ruby still comes from `.ruby-version`.
- **`Brewfile`** (new): fizzy had no Brewfile — macOS packages (`imagemagick openslide vips gitleaks`) were an inline `brew install` loop. They now live in a real Brewfile installed via `brew bundle`. macOS packages are **never** routed through mise: mise's brew path self-pours dependency closures that collide with brew-linked kegs and is arm64-only.
- **`bin/setup`**: gum/mise preinstall blocks replaced by the mise-managed flow below. The gh install block, SaaS sourcing, MySQL/database/seed steps are preserved as-is.
- **`saas/bin/setup`**: untouched. docker-dev stays SaaS-only (minio/mysql), so no `[bootstrap.repos]` in the root config.

## The ordering fix

Fresh-machine prelude now runs in dependency order — native packages **before** language tools, since Bundler native extensions (sqlite3, trilogy, ruby-vips/image processing) need system libraries present regardless of how ruby was built:

1. `step()` tolerates missing gum (plain-echo fallback) — gum is now a mise tool and doesn't exist yet on a fresh machine
2. Install mise if missing (brew/pacman) + enforce the `2026.7.5` floor with self-escalation (`brew upgrade mise` / full `pacman -Syu` / `mise self-update`), then hard fail with guidance
3. `mise trust --yes .mise.toml`
4. Detect the platform manager: brew or pacman; hard error otherwise (fizzy has no apt support today, and none was added)
5. Native packages first: macOS → `brew bundle`; Arch → `mise bootstrap packages apply --manager pacman --yes` (no `--update` — that flag would force a bare `pacman -Sy` metadata refresh before the targeted install, Arch's unsupported partial-upgrade shape; installs run `pacman -S --noconfirm --needed` against the existing sync DB)
6. `mise install --yes` (ruby + gum)
7. `eval "$(mise hook-env)"`
8. Only then: gh install, banner, bundle install, and all app work

## Boundary rules honored

- No `"brew:"` entries under `[bootstrap.packages]` — macOS stays Brewfile/`brew bundle` (grep-proven)
- `min_version` floor matches the `mise_min_version` probe in `bin/setup` (lockstep comment included)
- fizzy has no otool/openssl relink block and no `build.mysql2` bundler config (it uses trilogy) — nothing to preserve or drop
- No quickhook (fizzy has no consumer), no SaaS mise config created

## Verification (static — no app code run)

- `bash -n bin/setup` and `bash -n saas/bin/setup` pass
- `MISE_TRUSTED_CONFIG_PATHS=<worktree> mise ls -C <worktree>` exits 0 and resolves gum 0.17.0 from `.mise.toml` + ruby 3.4.8 from `.ruby-version`
- `grep '"brew:' .mise.toml` — no matches
- Full diff re-reviewed against every boundary rule

## Pending signoff

- [x] macOS (Apple Silicon): fresh `bin/setup` — Brewfile via `brew bundle`, mise floor escalation via brew
- [x] macOS (Apple Silicon): second `bin/setup` run — state-based no-op (brew/mise state snapshots byte-identical; documented imperative reassertions may print)
- [x] Arch/pacman (Omarchy): fresh `bin/setup` — `[bootstrap.packages]` via `mise bootstrap packages apply --manager pacman`
- [x] Arch/pacman (Omarchy): second `bin/setup` run — state-based no-op (pacman/mise state snapshots byte-identical)
- [x] Standalone OSS run on a machine with **no Shipyard present** — proves `mise trust` works without shipyard's fragment pre-trusting `~/Work/basecamp`
- [x] SaaS-mode run (`tmp/saas.txt` present): docker-dev path via `saas/bin/setup` (minio/mysql80)





