### PR TITLE
Fix BC-10091759496: stop leaking event listeners across Stimulus connect/disconnect

### DIFF
--- a/app/javascript/controllers/dialog_manager_controller.js
+++ b/app/javascript/controllers/dialog_manager_controller.js
@@ -2,11 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    this.element.addEventListener("dialog:show", this.handleDialogShow.bind(this))
+    this.boundHandleDialogShow = this.handleDialogShow.bind(this)
+    this.element.addEventListener("dialog:show", this.boundHandleDialogShow)
   }
 
   disconnect() {
-    this.element.removeEventListener("dialog:show", this.handleDialogShow.bind(this))
+    this.element.removeEventListener("dialog:show", this.boundHandleDialogShow)
   }
 
   handleDialogShow(event) {

--- a/app/javascript/controllers/drag_and_strum_controller.js
+++ b/app/javascript/controllers/drag_and_strum_controller.js
@@ -49,11 +49,12 @@ export default class extends Controller {
   connect() {
     this.instrumentIndex = 0
     this.preloadedAudioFiles = []
-    document.addEventListener("keydown", this.handleKeyDown.bind(this));
+    this.boundHandleKeyDown = this.handleKeyDown.bind(this)
+    document.addEventListener("keydown", this.boundHandleKeyDown);
   }
 
   disconnect() {
-    document.removeEventListener("keydown", this.handleKeyDown.bind(this));
+    document.removeEventListener("keydown", this.boundHandleKeyDown);
   }
 
   handleKeyDown(event) {

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -5,13 +5,15 @@ export default class extends Controller {
   static targets = [ "tooltip" ]
 
   connect() {
-    this.element.addEventListener("mouseenter", this.mouseEnter.bind(this))
-    this.element.addEventListener("mouseout", this.mouseOut.bind(this))
+    this.boundMouseEnter = this.mouseEnter.bind(this)
+    this.boundMouseOut = this.mouseOut.bind(this)
+    this.element.addEventListener("mouseenter", this.boundMouseEnter)
+    this.element.addEventListener("mouseout", this.boundMouseOut)
   }
 
   disconnect() {
-    this.element.removeEventListener("mouseenter", this.mouseEnter.bind(this))
-    this.element.removeEventListener("mouseout", this.mouseOut.bind(this))
+    this.element.removeEventListener("mouseenter", this.boundMouseEnter)
+    this.element.removeEventListener("mouseout", this.boundMouseOut)
   }
 
   mouseEnter(event) {


### PR DESCRIPTION
## Summary
Fixes [BC-10091759496](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10091759496) — typing in a card editor progressively freezes Safari (worst in "Add to Dock" PWA mode), getting worse the longer the session runs.

## Problem
`drag_and_strum_controller` attaches a `document`-level `keydown` listener on `connect()`. Under Turbo Drive, every board visit connects the controller again — and `disconnect()` never actually removes the previous listener. They accumulate for the life of the tab. Each leaked listener fires on any Shift-modified keystroke (capitals, punctuation while typing) and rebuilds 6 `Audio` objects, so per-keystroke cost grows with every board you've visited. Long-lived Safari/PWA sessions (which never full-reload) accumulate unbounded listeners → the reported progressive freeze.

## Solution
Store the bound handler once in `connect()` and remove *that same reference* in `disconnect()`.

```js
// connect()
this.boundHandleKeyDown = this.handleKeyDown.bind(this)
document.addEventListener("keydown", this.boundHandleKeyDown)
// disconnect()
document.removeEventListener("keydown", this.boundHandleKeyDown)
```

## Root Cause
`disconnect()` called `document.removeEventListener("keydown", this.handleKeyDown.bind(this))`. `Function.prototype.bind()` returns a **new** function object every call, so the reference passed to `removeEventListener` never equalled the one `addEventListener` registered — the removal was a silent no-op.

## Origin
Introduced in 88ef14ccd "Preload various instruments" (Andy Smith, 2025-09-26) — the `connect`/`disconnect` pair used a fresh `.bind(this)` on both sides from the start. Not a regression; born broken.

## Verification (real Safari engine — no regression test)
Reproduced in **WebKit** (Playwright's WebKit 26.5 = Safari's engine) by driving the real Stimulus connect/disconnect lifecycle across 10 simulated board visits and counting live `document` `keydown` listeners by function identity:

```
board visit #:       1  2  3  4  5  6  7  8  9  10
BEFORE (current):    1  2  3  4  5  6  7  8  9  10   <- leaked listeners
AFTER  (this fix):   0  0  0  0  0  0  0  0  0  0
```

Current code leaks exactly one listener per visit (matching "gets worse the longer the session runs"); with this fix the count stays flat. No unit test added — this is a one-time lifecycle correctness fix with no realistic regression path, and a listener-count test would be permanent scar tissue.

## Related / not covered here
- Cross-links [fizzy#2926](https://github.com/basecamp/fizzy/issues/2926), which independently profiled this controller's `new Audio()` storm during typing but did not diagnose the listener leak. #2926 also flags a **separate** GPU-compositing cost during editor mutation that this fix does not address — worth a follow-up.
- A `handleKeyDown` guard (early-return when focus is in a typing context, or only preload during an active drag) would further cut per-fire cost, but is a behavior change and is left out of this focused fix.

## Bug Card
https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10091759496