### PR TITLE
Bump trilogy to 2.12.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "solid_cache", "~> 1.0"
 gem "solid_queue", github: "rails/solid_queue"
 gem "sqlite3", ">= 2.0"
 gem "thruster", require: false
-gem "trilogy", "~> 2.11"
+gem "trilogy", "~> 2.12"
 
 # Features
 gem "bcrypt", "~> 3.1.22"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,7 @@ GEM
     thruster (0.1.21-x86_64-darwin)
     thruster (0.1.21-x86_64-linux)
     timeout (0.6.1)
-    trilogy (2.11.1)
+    trilogy (2.12.6)
       bigdecimal
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -561,7 +561,7 @@ DEPENDENCIES
   stackprof
   stimulus-rails
   thruster
-  trilogy (~> 2.11)
+  trilogy (~> 2.12)
   turbo-rails!
   useragent!
   vcr

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -653,7 +653,7 @@ GEM
     thruster (0.1.21-x86_64-darwin)
     thruster (0.1.21-x86_64-linux)
     timeout (0.6.1)
-    trilogy (2.11.1)
+    trilogy (2.12.6)
       bigdecimal
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -771,7 +771,7 @@ DEPENDENCIES
   stackprof
   stimulus-rails
   thruster
-  trilogy (~> 2.11)
+  trilogy (~> 2.12)
   turbo-rails!
   useragent!
   vcr


### PR DESCRIPTION
Bumps the `trilogy` gem from 2.11.1 to 2.12.6 (`~> 2.11` → `~> 2.12`).

Updated both `Gemfile.lock` and `Gemfile.saas.lock`.

## Testing
`bin/rails test` (MySQL/SaaS mode) — 1630 tests, 0 failures, 0 errors.

Tested fine on beta1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)