### PR TITLE
Declare docker-dev in a SaaS-only mise overlay

### DIFF
--- a/mise.saas.toml
+++ b/mise.saas.toml
@@ -1,0 +1,10 @@
+# SaaS-only mise overlay, loaded when MISE_ENV=saas (mise environment
+# configs: mise.saas.toml loads above .mise.toml in the same directory).
+#
+# Private Basecamp infrastructure is declared ONLY here — the OSS root
+# .mise.toml must never reference it. Consumed by saas/bin/setup, which runs
+# the repos phase under MISE_ENV=saas after proving https git auth.
+min_version = "2026.7.5"
+
+[bootstrap.repos]
+"~/Work/basecamp/docker-dev" = { url = "https://github.com/basecamp/docker-dev.git", ref = "master" }

--- a/saas/bin/setup
+++ b/saas/bin/setup
@@ -4,9 +4,46 @@ set -eo pipefail
 # SaaS-specific setup tasks
 # This script is called from the main Fizzy bin/setup when SAAS is enabled
 
+# docker-dev is declared in mise.saas.toml — the SaaS-only overlay, loaded via
+# MISE_ENV=saas — and converged declaratively through mise's repos phase. The
+# OSS root .mise.toml never references it; OSS setups never reach this file.
+step "Trusting SaaS mise overlay" mise trust --yes "$app_root/mise.saas.toml"
+
+# shipyard-block: docker-dev-origin v1
+# mise syncs docker-dev from the declared https URL: its repos preflight doesn't
+# equate ssh with https origins, and fresh clones use the URL as-is. docker-dev is
+# private and gh being installed does not imply its git credential helper is
+# configured (gh auth setup-git is a separate step), so prove https auth with a
+# noninteractive probe wherever mise is about to need it: before a fresh clone, and
+# before rewriting the canonical ssh origin of an existing checkout. On failure,
+# stop with guidance and leave any working ssh remote untouched. Forks, mirrors,
+# and dirty checkouts are left for mise to flag.
+docker_dev="$HOME/Work/basecamp/docker-dev"
+docker_dev_url="https://github.com/basecamp/docker-dev.git"
+docker_dev_https_ok() {
+  GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=true git ls-remote "$docker_dev_url" HEAD > /dev/null 2>&1
+}
+docker_dev_auth_required() {
+  echo "docker-dev syncs from $docker_dev_url, but https git auth isn't set up." >&2
+  echo "Run: gh auth setup-git — then rerun bin/setup." >&2
+  exit 1
+}
+if [ ! -e "$docker_dev/.git" ]; then
+  docker_dev_https_ok || docker_dev_auth_required
+else
+  case "$(git -C "$docker_dev" config --get remote.origin.url || true)" in
+    git@github.com:basecamp/docker-dev|git@github.com:basecamp/docker-dev.git|ssh://git@github.com/basecamp/docker-dev|ssh://git@github.com/basecamp/docker-dev.git)
+      docker_dev_https_ok || docker_dev_auth_required
+      git -C "$docker_dev" remote set-url origin "$docker_dev_url";;
+  esac
+fi
+# shipyard-block-end: docker-dev-origin
+
+step "Syncing docker-dev" env MISE_ENV=saas mise bootstrap --only repos --yes
+
 if [ -e tmp/minio-dev.txt ]; then
-  step "Starting Docker services" bash -c "[ -d ~/Work/basecamp/docker-dev ] && git -C ~/Work/basecamp/docker-dev pull || gh repo clone basecamp/docker-dev ~/Work/basecamp/docker-dev && ~/Work/basecamp/docker-dev/setup minio"
+  step "Starting Docker services" ~/Work/basecamp/docker-dev/setup minio
   step "Configuring MinIO" bin/minio-setup
 fi
 
-step "Starting mysql" bash -c "[ -d ~/Work/basecamp/docker-dev ] && git -C ~/Work/basecamp/docker-dev pull || gh repo clone basecamp/docker-dev ~/Work/basecamp/docker-dev && ~/Work/basecamp/docker-dev/setup mysql80"
+step "Starting mysql" ~/Work/basecamp/docker-dev/setup mysql80


### PR DESCRIPTION
Wave 4 / C3: fizzy's SaaS docker-dev goes declarative, without moving the OSS/SaaS boundary an inch.

### Design

- **`mise.saas.toml`** (new): a mise environment overlay — loaded above `.mise.toml` only when `MISE_ENV=saas` (validated against mise v2026.7.5's `env_config_patterns`: `mise.{env}.toml` is a first-class overlay name). It carries `[bootstrap.repos]` docker-dev and nothing else. **Private Basecamp references live only here; the OSS root `.mise.toml` never names them** — and since `MISE_ENV=saas` is set only for the one bootstrap invocation inside `saas/bin/setup`, OSS users' mise never even parses the overlay.
- **`saas/bin/setup`**: replaces the imperative `gh repo clone`/`git pull` with: trust the overlay → the fleet's fenced docker-dev origin block (`shipyard-block: docker-dev-origin v1`, byte-identical to Shipyard's canonical copy — https-auth probe before fresh clones and canonical-ssh rewrites, guided `gh auth setup-git` stop, forks/mirrors/dirty left for mise to flag) → `env MISE_ENV=saas mise bootstrap --only repos --yes` → start services as before. SaaS stays macOS/Omarchy-only.

### Verification

- **Fixture matrix (17/17)**: block extracted verbatim and byte-compared to the canonical copy; origin cases against sandbox HOMEs with a sandbox-level credential helper — missing dir with working/broken https auth, canonical https untouched, canonical ssh converts once then no-ops, broken-auth hard stop leaves ssh origin untouched, foreign origin untouched; overlay semantics against a local upstream — `MISE_ENV` unset sees **zero** repos (OSS boundary), `saas` declares and clones docker-dev, dirty and foreign checkouts still fail mise's preflight with the stock reasons.
- **OSS run** (converged Mac, no `SAAS`): `./bin/setup` exit 0 in 23s; the log contains zero docker-dev/SaaS/overlay references; root `.mise.toml` greps clean of private references.
- **SaaS run** (converged Mac, `SAAS=1`): exit 0 in 21s — overlay trusted, `mise bootstrap: repos → 1 repo(s) already current`, mysql started via docker-dev as before.
