### PR TITLE
Raise the mise floor to 2026.7.10

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-min_version = "2026.7.5"
+min_version = "2026.7.10"
 
 [settings]
 idiomatic_version_file_enable_tools = ["ruby"]

--- a/bin/setup
+++ b/bin/setup
@@ -39,7 +39,7 @@ step() {
   return $exit_code
 }
 
-mise_min_version="2026.7.5" # keep in lockstep with min_version in .mise.toml
+mise_min_version="2026.7.10" # keep in lockstep with min_version in .mise.toml
 
 mise_too_old() {
   local current="$(mise --version 2>/dev/null | awk '{ print $1; exit }')"


### PR DESCRIPTION
Track B, Train 1 (fleet mise floor raise, lockstep with https://github.com/basecamp/shipyard/pull/149): this repo's vendored floor pair — `min_version` in `.mise.toml` and `mise_min_version` in `bin/setup` — bumped 2026.7.5 → 2026.7.10, a mise containing jdx/mise#11034 (transport-agnostic repo-origin comparison), which Train 2's docker-dev-origin v2 block relies on.

> [!IMPORTANT]
> **Floor resolved: `2026.7.10`** — upstream tagged but never published v2026.7.8–v2026.7.10 (v2026.7.11 is the first published release since 7.7). GitHub releases and brew now carry 2026.7.14, but Arch's `extra/mise` — the Omarchy suite's only install channel — was built from the unpublished v2026.7.10 tag, so 2026.7.10 is the highest floor every channel satisfies today (ancestry: `compare v2026.7.10...95ca0a7b` = `behind`; raise again once Arch catches up). The 7.8→7.14 release/source audit is **complete** (2026-07-27, tracked in the shipyard PR): no task-output or origin-comparison surface changes; the committed audits now bind to 2026.7.10, and the 2026.8.0 unconditional-precompiled-ruby flip remains ahead of the floor. **Gate 3 PASSED 2026-07-27** — installability proven by installation on all four channels (macOS curl one-shot self-updated to 2026.7.15, brew bottle 2026.7.14, Arch pacman `extra/mise` 2026.7.10-1 = exactly the floor, Ubuntu dpkg→mise.run curl 2026.7.15; evidence in shipyard `TRACK_B_DRAFT_EVIDENCE/gate3-*-2026-07-27.log`). Merge remains gated on the fleet announcement + train GO, and this PR merges only after the shipyard PR lands.

### Operations

Blast radius is **pull-time**: once this lands, machines below the floor error on every mise invocation in this checkout (shell hook-env, quickhook hooks, editor integration) until upgraded — `bin/setup` converges them, or one upgrade command per platform. **Announce before landing; merge early in a workday.**

### Evidence

- `test/mise-floor-test --ref ×5` (all five app branches): **61/61** — floor declared correctly here, and the vendored floor/upgrade logic remains byte-identical across the fleet at this head.
- `bin/audit-fleet-setup --ref ×5`: **fleet clean** (this PR does not touch the vendored docker-dev-origin block).
- CI/container audit: no mise pins or installs in this repo's workflows/Dockerfiles — nothing breaks at merge.

### Precompiled-ruby spike (binding evidence, 2026-07-27)

Run with the durable harness (`test/ruby-precompiled-spike`, shipyard PR) from a clean detached worktree at THIS PR's head, against the **published** `v2026.7.14` macos-arm64 release binary (≥ the 2026.7.10 floor; the floor tag itself has no published binary, and the ruby/bootstrap surface is audit-verified unchanged across 7.8→7.14):

```
ok: raise-mise-floor: worktree clean before
ok: raise-mise-floor: credential preflight reaches https://github.com/basecamp/useragent
ok: raise-mise-floor: hostile inherited askpass never invoked
ok: raise-mise-floor: toolset installed with no compile activity
ok: raise-mise-floor: pinned ruby 3.4.8 active
ok: raise-mise-floor: ABI dir lib/ruby/3.4.0 present
ok: raise-mise-floor: extensions dir is 3.4.0-static (precompiled provenance)
ok: raise-mise-floor: bundle install completes frozen
ok: raise-mise-floor: native gems (sqlite3 nokogiri) load from the built bundle
ok: raise-mise-floor: worktree clean after
ALL 26 SPIKE ASSERTIONS PASSED  (full run: both apps + 6 posture assertions)
record: candidate mise: 2026.7.14 (/private/tmp/claude-501/-Users-jeremy-Worktrees-basecamp-shipyard-mise-bootstrap/a4d9d33d-563b-49af-a7f4-6db1fbe545e2/scratchpad/bin/mise-2026.7.14)
record: candidate mise sha256: 082262daa1cd73e22f71272c574afda560c4fcf39852bc18884eae9e13cd5f2c
record: shipyard: e28e0e5dd72fc0dcb4839308461275ec9015a150
record: harness blob: 1cdbb1ef41b049bc7db72c719415b5d930c5a7a9
record: fragment blob: 2b5bf85ae0e137dfe8fe809a0c904339d8d35ed6
record: raise-mise-floor head: e00437b5ac10c4a12aef8c31173279fe63b48aff
record: raise-mise-floor tree: 50794e58d344db80a92ca02a3f42e2422af9eab8
record: raise-mise-floor base: origin/main 9ae6b3b9fdefdf34140b996383175aa8ef2dab61
```

