### PR TITLE
Tag all pushes to main as 'latest' in Docker

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -152,7 +152,7 @@ jobs:
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
           flavor: |
             latest=false
           labels: |
@@ -171,8 +171,12 @@ jobs:
             [ -z "$tag" ] && continue
             echo "Creating manifest for $tag"
             src_tag="$tag"
-            if [[ "$tag" == *:latest && "${GITHUB_REF}" == refs/tags/* ]]; then
-              ref="${GITHUB_REF#refs/tags/}"
+            if [[ "$tag" == *:latest ]]; then
+              if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+                ref="${GITHUB_REF#refs/tags/}"
+              else
+                ref="${GITHUB_REF#refs/heads/}"
+              fi
               src_tag="${tag%:latest}:$ref"
             fi
             if [ -n "${IMAGE_DESCRIPTION:-}" ]; then


### PR DESCRIPTION
We never make tagged releases here, so there isn't a 'latest' image which is unusual. We treat 'main' as 'latest' and keep it stable, so it is effectively 'latest', this just codifies it.