### PR TITLE
SSRF: block NAT64 and 6to4 IPv6 encapsulation ranges

### DIFF
--- a/app/models/ssrf_protection.rb
+++ b/app/models/ssrf_protection.rb
@@ -11,7 +11,9 @@ module SsrfProtection
   DISALLOWED_IP_RANGES = [
     IPAddr.new("0.0.0.0/8"),     # "This" network (RFC1700)
     IPAddr.new("100.64.0.0/10"), # Carrier-grade NAT (RFC6598)
-    IPAddr.new("198.18.0.0/15")  # Benchmark testing (RFC2544)
+    IPAddr.new("198.18.0.0/15"), # Benchmark testing (RFC2544)
+    IPAddr.new("64:ff9b::/96"),  # NAT64 well-known prefix (RFC6052)
+    IPAddr.new("2002::/16")      # 6to4 (RFC3056)
   ].freeze
 
   def resolve_public_ip(hostname)

--- a/test/models/ssrf_protection_test.rb
+++ b/test/models/ssrf_protection_test.rb
@@ -82,4 +82,18 @@ class SsrfProtectionTest < ActiveSupport::TestCase
     stub_dns_resolution("::93.184.216.34")
     assert_nil SsrfProtection.resolve_public_ip("compat-public.example.com")
   end
+
+  # IPv6 encapsulation ranges (SSRF bypass prevention)
+
+  test "blocks NAT64 well-known prefix addresses" do
+    assert SsrfProtection.blocked_address?("64:ff9b::a00:1")
+  end
+
+  test "blocks 6to4 addresses" do
+    assert SsrfProtection.blocked_address?("2002::1")
+  end
+
+  test "allows public addresses through blocked_address?" do
+    assert_not SsrfProtection.blocked_address?("93.184.216.34")
+  end
 end


### PR DESCRIPTION
## What

`SsrfProtection`'s `DISALLOWED_IP_RANGES` covered CGNAT (`100.64.0.0/10`) and benchmark (`198.18.0.0/15`) but missed the IPv6 encapsulation ranges **NAT64 `64:ff9b::/96`** and **6to4 `2002::/16`**. These embed an IPv4 address (including private space) in an IPv6 address that `private?`/`link_local?` do not catch.

Found via weekend run #3873122 (once-campfire OpenGraph-unfurl SSRF); confirmed latent across bc3/fizzy/once-campfire.

## Fix

Add NAT64 and 6to4 to `DISALLOWED_IP_RANGES`. `blocked_address?` already applies to every resolved address; the DNS resolution path (`resolve_public_ip`, which already reads all A/AAAA records) is unchanged.

## Tests

`test/models/ssrf_protection_test.rb`: `blocked_address?` is true for `64:ff9b::a00:1` and `2002::1`, false for a public control (`93.184.216.34`).

`bin/rails test test/models/ssrf_protection_test.rb` → 19 tests, 0 failures.
