### PR TITLE
fix double-escaping in Slack webhook payloads

### DIFF
--- a/app/models/webhook/delivery.rb
+++ b/app/models/webhook/delivery.rb
@@ -172,8 +172,11 @@ class Webhook::Delivery < ApplicationRecord
       document.text
     end
 
+    # https://docs.slack.dev/messaging/formatting-message-text/#escaping
+    SLACK_ESCAPE = { "&" => "&amp;", "<" => "&lt;", ">" => "&gt;" }.freeze
+
     def slack_payload
-      text = event.description_for(nil).to_plain_text
+      text = CGI.unescapeHTML(event.description_for(nil).to_plain_text).gsub(/[&<>]/, SLACK_ESCAPE)
       url = polymorphic_url(event.eventable, base_url_options.merge(script_name: account.slug))
 
       { text: "#{text} <#{url}|Open in Fizzy>" }.to_json

--- a/test/models/webhook/delivery_test.rb
+++ b/test/models/webhook/delivery_test.rb
@@ -310,7 +310,7 @@ class Webhook::DeliveryTest < ActiveSupport::TestCase
     assert_equal expected, content
   end
 
-  test "slack webhook payload html-escapes special characters" do
+  test "slack webhook payload escapes slack control characters but preserves quotes" do
     cards(:logo).update_column(:title, %(Tom & Jerry's <Great> "Adventure"))
 
     webhook = Webhook.create!(
@@ -330,7 +330,32 @@ class Webhook::DeliveryTest < ActiveSupport::TestCase
     text = JSON.parse(captured_body)["text"]
 
     expected = <<~TEXT.strip
-      David added &quot;Tom &amp; Jerry&#39;s &lt;Great&gt; &quot;Adventure&quot;&quot; <http://example.com/897362094/cards/1|Open in Fizzy>
+      David added "Tom &amp; Jerry's &lt;Great&gt; "Adventure"" <http://example.com/897362094/cards/1|Open in Fizzy>
+    TEXT
+    assert_equal expected, text
+  end
+
+  test "slack webhook payload preserves literal html entities in titles" do
+    cards(:logo).update_column(:title, %(Literal &quot;entity&quot; text))
+
+    webhook = Webhook.create!(
+      board: boards(:writebook),
+      name: "Slack",
+      url: "https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx" # gitleaks:allow
+    )
+    delivery = Webhook::Delivery.create!(webhook: webhook, event: events(:logo_published))
+
+    captured_body = nil
+    stub_request(:post, webhook.url)
+      .with { |request| captured_body = request.body; true }
+      .to_return(status: 200)
+
+    delivery.deliver
+
+    text = JSON.parse(captured_body)["text"]
+
+    expected = <<~TEXT.strip
+      David added "Literal &amp;quot;entity&amp;quot; text" <http://example.com/897362094/cards/1|Open in Fizzy>
     TEXT
     assert_equal expected, text
   end


### PR DESCRIPTION
## What

`Event::Description#to_plain_text` HTML-escapes its output, so Slack notifications showed literal entities like `&quot;` and `&#39;`. Slack renders plain text rather than HTML and only wants `&`, `<`, and `>` converted to entities:

https://docs.slack.dev/messaging/formatting-message-text/#escaping

Undo the HTML escaping with `CGI.unescapeHTML`, then escape just the three Slack control characters.

<img width="1064" height="116" alt="image" src="https://github.com/user-attachments/assets/3a6c6f78-bc4b-4cec-8f0f-6b32e806e70f" />