### PR TITLE
Remove redundant ActiveModel::Validations include from Signup

### DIFF
--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -1,7 +1,6 @@
 class Signup
   include ActiveModel::Model
   include ActiveModel::Attributes
-  include ActiveModel::Validations
 
   attr_accessor :full_name, :email_address, :identity, :skip_account_seeding
   attr_reader :account, :user


### PR DESCRIPTION
   ActiveModel::Model already includes ActiveModel::API, which brings in
   ActiveModel::Validations.