### PR TITLE
Fix wrong login, search, and tenancy claims in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,115 +1,34 @@
 # Fizzy
 
-This file provides guidance to AI coding agents working with this repository.
+Guidance for AI coding agents working with this repository.
 
-## What is Fizzy?
-
-Fizzy is a collaborative project management and issue tracking application built by 37signals/Basecamp. It's a kanban-style tool for teams to create and manage cards (tasks/issues) across boards, organize work into columns representing workflow stages, and collaborate via comments, mentions, and assignments.
-
-## Development Commands
-
-### Setup and Server
-```bash
-bin/setup              # Initial setup (installs gems, creates DB, loads schema)
-bin/dev                # Start development server (runs on port 3006)
-```
-
-Development URL: http://app.fizzy.localhost:3006
-Login with: david@example.com (development fixtures), password will appear in the browser console
-
-### Testing
-```bash
-bin/rails test                    # Run unit tests (fast)
-bin/rails test test/path/file_test.rb  # Run single test file
-bin/rails test:system             # Run system tests (Capybara + Selenium)
-bin/ci                            # Run full CI suite (style, security, tests)
-
-# For parallel test execution issues, use:
-PARALLEL_WORKERS=1 bin/rails test
-```
-
-CI pipeline (`bin/ci`) runs:
-1. Rubocop (style)
-2. Bundler audit (gem security)
-3. Importmap audit
-4. Brakeman (security scan)
-5. Application tests
-6. System tests
-
-### Database
-```bash
-bin/rails db:fixtures:load   # Load fixture data
-bin/rails db:migrate          # Run migrations
-bin/rails db:reset            # Drop, create, and load schema
-```
-
-### Other Utilities
-```bash
-bin/rails dev:email          # Toggle letter_opener for email preview
-bin/jobs                     # Manage Solid Queue jobs
-bin/kamal deploy             # Deploy (requires 1Password CLI for secrets)
-```
+Fizzy is a kanban-style project management and issue tracker: cards move across columns on boards, with comments, mentions, and assignments.
 
 ## Deploy
 
 Default branch: `main`
 Pre-deploy: `bin/rails saas:enable`
 Deploy: `bin/kamal deploy -d <destination>`
-Destinations: production, staging, beta, beta1, beta2, beta3, beta4
-Note: `beta` is a template requiring `BETA_NUMBER` env var; typical targets are `beta1`-`beta4`.
+Destinations: production, staging, beta, beta1
+Note: `beta` is a template requiring `BETA_NUMBER` env var; `beta1` is the only numbered target that exists.
 
 ## Architecture Overview
 
 ### Multi-Tenancy (URL-Based)
 
 Fizzy uses **URL path-based multi-tenancy**:
-- Each Account (tenant) has a unique `external_account_id` (7+ digits)
+- Accounts have a unique decimal `external_account_id` used in URL prefixes
 - URLs are prefixed: `/{account_id}/boards/...`
 - Middleware (`AccountSlug::Extractor`) extracts the account ID from the URL and sets `Current.account`
 - The slug is moved from `PATH_INFO` to `SCRIPT_NAME`, making Rails think it's "mounted" at that path
-- All models include `account_id` for data isolation
+- Tenant-scoped domain records are account-isolated; global identity, session, and authentication records are exceptions
 - Background jobs automatically serialize and restore account context
 
 **Key insight**: This architecture allows multi-tenancy without subdomains or separate databases, making local development and testing simpler.
 
 ### Authentication & Authorization
 
-**Passwordless magic link authentication**:
-- Global `Identity` (email-based) can have `Users` in multiple Accounts
-- Users belong to an Account and have roles: owner, admin, member, system
-- Sessions managed via signed cookies
-- Board-level access control via `Access` records
-
-### Core Domain Models
-
-**Account** → The tenant/organization
-- Has users, boards, cards, tags, webhooks
-- Has entropy configuration for auto-postponement
-
-**Identity** → Global user (email)
-- Can have Users in multiple Accounts
-- Session management tied to Identity
-
-**User** → Account membership
-- Belongs to Account and Identity
-- Has role (owner/admin/member/system)
-- Board access via explicit `Access` records
-
-**Board** → Primary organizational unit
-- Has columns for workflow stages
-- Can be "all access" or selective
-- Can be published publicly with shareable key
-
-**Card** → Main work item (task/issue)
-- Sequential number within each Account
-- Rich text description and attachments
-- Lifecycle: triage → columns → closed/not_now
-- Automatically postpones after inactivity ("entropy")
-
-**Event** → Records all significant actions
-- Polymorphic association to changed object
-- Drives activity timeline, notifications, webhooks
-- Has JSON `particulars` for action-specific data
+Passwordless magic link authentication. A global `Identity` (email-based) can have `Users` in multiple Accounts, so an email is not a single account membership. Users have roles: owner, admin, member, system. Board-level access control via `Access` records.
 
 ### Entropy System
 
@@ -133,17 +52,11 @@ Database-backed job queue (no Redis):
 - Jobs automatically capture/restore `Current.account`
 - Mission Control::Jobs for monitoring
 
-Key recurring tasks (via `config/recurring.yml`):
-- Deliver bundled notifications (every 30 min)
-- Auto-postpone stale cards (hourly)
-- Cleanup jobs for expired links, deliveries
+Recurring tasks are declared in `config/recurring.yml`.
 
 ### Sharded Full-Text Search
 
-16-shard MySQL full-text search instead of Elasticsearch:
-- Shards determined by account ID hash (CRC32)
-- Search records denormalized for performance
-- Models in `app/models/search/`
+Full-text search runs in the database, not Elasticsearch. On MySQL it is sharded 16 ways by CRC32 of the account ID (`Search::Record::Trilogy`); on SQLite it is a single FTS5 index (`Search::Record::SQLite`). Don't assume the sharded shape when working under SQLite. Models in `app/models/search/`.
 
 ### Imports and exports
 
@@ -152,15 +65,6 @@ Allow people to move between OSS and SAAS Fizzy instances:
 - Must be able to handle very large ZIP files (500+GB)
 - Models in `app/models/account/data_transfer/`, `app/models/zip_file`
 
-## Tools
-
-### Chrome MCP (Local Dev)
-
-URL: `http://app.fizzy.localhost:3006`
-Login: david@example.com (passwordless magic link auth - check rails console for link)
-
-Use Chrome MCP tools to interact with the running dev app for UI testing and debugging.
-
 ## Coding style
 
-@STYLE.md
+Before editing or reviewing code, read STYLE.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,12 @@ Fizzy is a kanban-style project management and issue tracker: cards move across 
 ## Deploy
 
 Default branch: `main`
-Pre-deploy: `bin/rails saas:enable`
-Deploy: `bin/kamal deploy -d <destination>`
-Destinations: production, staging, beta, beta1
-Note: `beta` is a template requiring `BETA_NUMBER` env var; `beta1` is the only numbered target that exists.
+
+Self-hosted deploys run Kamal against `config/deploy.yml` — see `docs/kamal-deployment.md`.
+
+## SaaS mode
+
+For local agent work, `tmp/saas.txt` is the checkout-level SaaS switch used by `bin/setup`. When present, read `saas/AGENTS.md` before continuing. Otherwise, do not apply its instructions.
 
 ## Architecture Overview
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,7 @@ bin/dev
 
 You'll be able to access the app in development at http://app.fizzy.localhost:3006.
 
-To login, enter `david@example.com` and grab the verification code from the browser console to sign in.
+To login, enter `david@example.com`. In development the verification code is shown on the page itself, under "Psst, here's your code" — no need to check your email.
 
 ### Web Push Notifications
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,7 @@ bin/dev
 
 You'll be able to access the app in development at http://app.fizzy.localhost:3006.
 
-To login, enter `david@example.com`. In development the verification code is shown on the page itself, under "Psst, here's your code" — no need to check your email.
+To log in, enter `david@example.com`. In development the verification code is shown on the page itself, under "Psst, here's your code" — no need to check your email.
 
 ### Web Push Notifications
 

--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -2,7 +2,7 @@
 
 37signals' hosted Fizzy: billing, our production setup, our deploy destinations. Apply this only when SaaS mode is enabled — the root `AGENTS.md` has the check.
 
-`bin/rails saas:enable` creates `tmp/saas.txt`; `saas:disable` removes it. `Fizzy.saas?` also reads `SAAS` from the environment, where anything but `false` enables and `SAAS=false` forces off even with the file present (`lib/fizzy.rb`) — that path is for the production image and `bin/ci`, not for switching a checkout. Enabling swaps the bundle to `Gemfile.saas` and the default database adapter to MySQL, so it changes what every `bin/rails` and `bin/kamal` command does.
+`bin/rails saas:enable` creates `tmp/saas.txt`; `bin/rails saas:disable` removes it. `Fizzy.saas?` also reads `SAAS` from the environment, where anything but `false` enables and `SAAS=false` forces off even with the file present (`lib/fizzy.rb`) — that path is for the production image and `bin/ci`, not for switching a checkout. Enabling swaps the bundle to `Gemfile.saas` and the default database adapter to MySQL, so it changes what every `bin/rails` and `bin/kamal` command does.
 
 `README.md` covers the environments, Stripe, push credentials, and maintenance mode. What it doesn't say:
 

--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -1,0 +1,11 @@
+# Fizzy SaaS
+
+37signals' hosted Fizzy: billing, our production setup, our deploy destinations. Apply this only when SaaS mode is enabled — the root `AGENTS.md` has the check.
+
+`bin/rails saas:enable` creates `tmp/saas.txt`; `saas:disable` removes it. `Fizzy.saas?` also reads `SAAS` from the environment, where anything but `false` enables and `SAAS=false` forces off even with the file present (`lib/fizzy.rb`) — that path is for the production image and `bin/ci`, not for switching a checkout. Enabling swaps the bundle to `Gemfile.saas` and the default database adapter to MySQL, so it changes what every `bin/rails` and `bin/kamal` command does.
+
+`README.md` covers the environments, Stripe, push credentials, and maintenance mode. What it doesn't say:
+
+`saas:enable` is a prerequisite for deploying, not just for local development. Only under that flag does `bin/kamal` pass `-c` pointing at this gem's `config/deploy.yml`. Skip it and Kamal reads the root `config/deploy.yml` instead — the self-hosting example, which knows nothing about our destinations.
+
+Destinations are production, staging, beta, and beta1, one `config/deploy.<destination>.yml` each. `beta` is a template requiring the `BETA_NUMBER` env var; `beta1` is the only numbered target that exists. The `.kamal/secrets.beta2` through `secrets.beta4` symlinks are leftovers and don't make those destinations real.


### PR DESCRIPTION
The dev login was documented wrong in three places, and three architecture claims didn't match the code.

## Login

`AGENTS.md` said the password appears in the browser console, and separately that you check the Rails console for a magic link. `docs/development.md` said browser console too. None is right: in development the view renders the code inline on the page, under "Psst, here's your code" (`app/views/sessions/magic_links/show.html.erb`).

Both `AGENTS.md` claims are deleted along with their blocks — `bin/dev` already prints the URL and login email, and the code shows up in the browser. `docs/development.md` is corrected in place, since it's the human setup guide.

## Three claims that didn't hold

- **"16-shard CRC32 search"** is MySQL-only. `Search::Record::Trilogy` shards 16 ways by CRC32 of the account id; `Search::Record::SQLite` is a single FTS5 index. Someone reasoning about shard routing under SQLite is reasoning about code that isn't there.
- **"`external_account_id` (7+ digits)"** isn't enforced anywhere. `AccountSlug::PATTERN` is `/(\d+)/` and `Account::ExternalIdSequence` seeds from `Account.maximum(:external_account_id) || 0`, so a fresh OSS install starts at 1. Seven digits is a Queenbee artifact in SaaS, not an invariant.
- **"All models include `account_id`"** is contradicted by design. `Identity` and `Session` are global; `Session` only `belongs_to :identity`. Stating the exception is the whole point, since it's what makes tenancy bugs subtle.

Deploy destinations claimed `beta1`–`beta4`; only `beta1` exists in `saas/config`.

## Kept and cut

Kept because they're non-obvious and costly to reconstruct: the `PATH_INFO` → `SCRIPT_NAME` tenancy mechanism, UUIDv7 base36 keys with fixtures deliberately "older" than runtime records, Solid Queue without Redis, entropy postponement, and the import/export invariant that both local and S3 storage must work and 500+GB ZIPs must stream.

Cut: the model-by-model catalogue. It restates `app/models/` at the cost of going stale.

166 → 70 lines.

## STYLE.md

The eager `@STYLE.md` import becomes a one-line pointer. `STYLE.md` is a public contributor guide linked from the README, Codex doesn't expand the import anyway, and it is **not** modified by this PR.
