### PR TITLE
Express bin/setup's post-prelude phases as a mise task graph

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -25,3 +25,55 @@ PROMETHEUS_EXPORTER_URL = "http://127.0.0.1:9306/metrics"
 "pacman:rav1e" = "latest"
 "pacman:svt-av1" = "latest"
 "pacman:gitleaks" = "latest"
+
+# bin/setup's post-prelude phases, individually runnable from a bare shell at
+# the repo root (`mise run db:prepare`) — they depend on nothing bin/setup
+# exports; bin/rails selects the SaaS gemfile itself when tmp/saas.txt exists.
+# bin/setup remains the orchestrator and drives these with --skip-deps so its
+# explicit ordering isn't double-run by the dependency graph. SaaS-only tasks
+# live in mise.saas.toml. Behavior is pinned by test/setup-phases-test.
+
+[tasks."db:prepare"]
+description = "Create or migrate the development and test databases"
+quiet = true
+run = "bin/rails db:prepare"
+
+[tasks."db:reset"]
+description = "Drop, recreate, and reseed the databases"
+quiet = true
+run = "bin/rails db:reset"
+
+[tasks."db:seed"]
+description = "Seed development data (prepares the database first when run standalone)"
+quiet = true
+depends = ["db:prepare"]
+run = "bin/rails db:seed"
+
+[tasks."setup:mysql-start"]
+description = "Start the existing fizzy-mysql Docker container"
+quiet = true
+run = "docker start fizzy-mysql"
+
+[tasks."setup:mysql-create"]
+description = "Create and start the fizzy-mysql Docker container"
+quiet = true
+# The inner bash -c is bin/setup's original block verbatim — deliberately NOT
+# flattened into this task's own shell: mise runs tasks under `sh -c` with
+# errexit/pipefail, and a failed `docker pull` here must keep falling through
+# to `docker run` exactly as it always has (the image may already be local).
+run = '''
+bash -c '
+  docker pull mysql:8.4
+  docker run -d \
+    --name fizzy-mysql \
+    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+    -p 3306:3306 \
+    mysql:8.4
+  echo "MySQL is starting… (it may take a few seconds)"
+'
+'''
+
+[tasks."setup:cleanup"]
+description = "Clear logs and tempfiles"
+quiet = true
+run = "bin/rails log:clear tmp:clear"

--- a/bin/setup
+++ b/bin/setup
@@ -100,20 +100,17 @@ needs_seeding() {
   fi
 }
 
+# Phase bodies live in .mise.toml [tasks] (SaaS ones in mise.saas.toml) so
+# they're individually runnable: `mise run db:prepare`. bin/setup remains the
+# orchestrator — all guards and conditionals stay here in bash, and every
+# dispatch uses --skip-deps so this explicit ordering isn't double-run by the
+# task graph's depends (which serve standalone runs).
 oss_mysql_setup() {
   if ! nc -z localhost 3306 2>/dev/null; then
     if docker ps -aq -f name=fizzy-mysql | grep -q .; then
-      step "Starting MySQL" docker start fizzy-mysql
+      step "Starting MySQL" mise run --skip-deps setup:mysql-start
     else
-      step "Setting up MySQL" bash -c '
-        docker pull mysql:8.4
-        docker run -d \
-          --name fizzy-mysql \
-          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-          -p 3306:3306 \
-          mysql:8.4
-        echo "MySQL is starting… (it may take a few seconds)"
-      '
+      step "Setting up MySQL" mise run --skip-deps setup:mysql-create
     fi
   fi
 }
@@ -181,15 +178,15 @@ else
 fi
 
 if [[ $* == *--reset* ]]; then
-  step "Resetting the database" rails db:reset
+  step "Resetting the database" mise run --skip-deps db:reset
 else
-  step "Preparing the database" rails db:prepare
+  step "Preparing the database" mise run --skip-deps db:prepare
 
   if needs_seeding; then
-    step "Seeding the database" rails db:seed
+    step "Seeding the database" mise run --skip-deps db:seed
   fi
 fi
 
-step "Cleaning up logs and tempfiles" rails log:clear tmp:clear
+step "Cleaning up logs and tempfiles" mise run --skip-deps setup:cleanup
 
 gum style --foreground 46 "✓ Done (${SECONDS} sec)"

--- a/bin/tasks/db/prepare
+++ b/bin/tasks/db/prepare
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mise run db:prepare "$@"

--- a/bin/tasks/db/reset
+++ b/bin/tasks/db/reset
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mise run db:reset "$@"

--- a/bin/tasks/db/seed
+++ b/bin/tasks/db/seed
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mise run db:seed "$@"

--- a/bin/tasks/setup/cleanup
+++ b/bin/tasks/setup/cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mise run setup:cleanup "$@"

--- a/bin/tasks/setup/mysql-create
+++ b/bin/tasks/setup/mysql-create
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mise run setup:mysql-create "$@"

--- a/bin/tasks/setup/mysql-start
+++ b/bin/tasks/setup/mysql-start
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mise run setup:mysql-start "$@"

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -17,6 +17,8 @@ CI.run do
   step "Security: Brakeman audit", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
   step "Security: Gitleaks audit", "bin/gitleaks-audit"
 
+  step "Tests: Setup phases", "test/setup-phases-test"
+
   if Fizzy.saas?
     step "Tests: SaaS",          "#{SAAS_ENV} bin/rails test"
     step "Tests: SaaS System",   "#{SAAS_ENV} #{SYSTEM_TEST_ENV} bin/rails test:system"

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,25 @@ You'll be able to access the app in development at http://app.fizzy.localhost:30
 
 To login, enter `david@example.com` and grab the verification code from the browser console to sign in.
 
+### Running setup phases individually
+
+`bin/setup`'s post-prelude phases are defined as mise tasks, so each one is also runnable on its own from the repo root:
+
+```sh
+mise tasks ls        # list them
+mise run db:prepare  # create or migrate the databases
+mise run db:seed     # seed development data (prepares the database first)
+bin/tasks/db/seed    # generated stubs — same thing, tab-completable
+```
+
+SaaS-only tasks live in the `mise.saas.toml` overlay and need it loaded explicitly:
+
+```sh
+env MISE_ENV=saas mise run saas:mysql
+```
+
+Standalone runs follow each task's declared dependencies (`saas:mysql` syncs docker-dev first, `db:seed` prepares the database first). `bin/setup` remains the orchestrator: it drives the same tasks with `--skip-deps` under its own ordering, guards, and conditionals.
+
 ### Web Push Notifications
 
 Fizzy uses VAPID (Voluntary Application Server Identification) keys to send browser push notifications. For notifications to work in development you'll need to generate a key pair and set these environment variables:

--- a/mise.saas.toml
+++ b/mise.saas.toml
@@ -8,3 +8,38 @@ min_version = "2026.7.5"
 
 [bootstrap.repos]
 "~/Work/basecamp/docker-dev" = { url = "https://github.com/basecamp/docker-dev.git", ref = "master" }
+
+# SaaS setup phases, individually runnable from a bare shell at the repo root
+# with the overlay loaded: `env MISE_ENV=saas mise run saas:mysql`. Deliberately
+# several tasks rather than one umbrella: mise runs a task's dependencies in
+# parallel (--jobs), and these docker operations must keep today's strict
+# ordering. saas/bin/setup drives them one at a time with --skip-deps; the
+# depends chains serve standalone runs. Behavior is pinned by
+# test/setup-phases-test.
+
+[tasks."saas:repos"]
+description = "Sync private repos (docker-dev) declared in this overlay"
+quiet = true
+run = "mise bootstrap --only repos --yes"
+
+[tasks."saas:minio"]
+description = "Start the MinIO docker-dev service"
+quiet = true
+depends = ["saas:repos"]
+run = "~/Work/basecamp/docker-dev/setup minio"
+
+[tasks."saas:minio-config"]
+description = "Create the development MinIO bucket"
+quiet = true
+depends = ["saas:minio"]
+# bin/minio-setup boots config/environment directly — config/boot.rb picks the
+# OSS Gemfile before Fizzy.configure_bundle could intervene — so standalone
+# runs need the SaaS gemfile selected explicitly here.
+env = { SAAS = "1", BUNDLE_GEMFILE = "Gemfile.saas" }
+run = "bin/minio-setup"
+
+[tasks."saas:mysql"]
+description = "Start the MySQL 8.0 docker-dev service"
+quiet = true
+depends = ["saas:repos"]
+run = "~/Work/basecamp/docker-dev/setup mysql80"

--- a/saas/bin/setup
+++ b/saas/bin/setup
@@ -99,11 +99,17 @@ elif docker_dev_is_repo \
 fi
 # shipyard-block-end: docker-dev-origin
 
-step "Syncing docker-dev" env MISE_ENV=saas mise bootstrap --only repos --yes
+# Phase bodies live in mise.saas.toml [tasks], individually runnable with the
+# overlay loaded: `env MISE_ENV=saas mise run saas:mysql`. The env-var form
+# matters twice over — it makes the overlay's tasks visible to `mise run`, and
+# the child processes (saas:repos runs `mise bootstrap` itself) inherit it.
+# --skip-deps keeps this script's explicit ordering from double-running the
+# depends chains, which serve standalone runs.
+step "Syncing docker-dev" env MISE_ENV=saas mise run --skip-deps saas:repos
 
 if [ -e tmp/minio-dev.txt ]; then
-  step "Starting Docker services" ~/Work/basecamp/docker-dev/setup minio
-  step "Configuring MinIO" bin/minio-setup
+  step "Starting Docker services" env MISE_ENV=saas mise run --skip-deps saas:minio
+  step "Configuring MinIO" env MISE_ENV=saas mise run --skip-deps saas:minio-config
 fi
 
-step "Starting mysql" ~/Work/basecamp/docker-dev/setup mysql80
+step "Starting mysql" env MISE_ENV=saas mise run --skip-deps saas:mysql

--- a/test/fixtures/setup_phases/ci-sim/commands.txt
+++ b/test/fixtures/setup_phases/ci-sim/commands.txt
@@ -1,0 +1,6 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+rails db:prepare
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/ci-sim/output.txt
+++ b/test/fixtures/setup_phases/ci-sim/output.txt
@@ -1,0 +1,27 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+[2mmise[0m trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/ci-sim/output.txt
+++ b/test/fixtures/setup_phases/ci-sim/output.txt
@@ -3,7 +3,7 @@ ensure_correct_mise_install
 
 ▸ Trusting mise config
 mise trust --yes $APP/.mise.toml
-[2mmise[0m trusted $APP
+mise trusted $APP
 
 ▸ Installing system packages
 brew bundle --file=$APP/Brewfile

--- a/test/fixtures/setup_phases/ci-sim/output.txt
+++ b/test/fixtures/setup_phases/ci-sim/output.txt
@@ -19,9 +19,9 @@ mise install --yes
 bundle install
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/fail-db-prepare/commands.txt
+++ b/test/fixtures/setup_phases/fail-db-prepare/commands.txt
@@ -1,0 +1,5 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+rails db:prepare
+exit: 9

--- a/test/fixtures/setup_phases/fail-db-prepare/output.txt
+++ b/test/fixtures/setup_phases/fail-db-prepare/output.txt
@@ -1,0 +1,23 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Preparing the database
+rails db:prepare
+stub-fail: rails db:prepare

--- a/test/fixtures/setup_phases/fail-db-prepare/output.txt
+++ b/test/fixtures/setup_phases/fail-db-prepare/output.txt
@@ -19,5 +19,6 @@ mise install --yes
 bundle install
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 stub-fail: rails db:prepare
+[db:prepare] ERROR task failed

--- a/test/fixtures/setup_phases/fail-mysql-pull/commands.txt
+++ b/test/fixtures/setup_phases/fail-mysql-pull/commands.txt
@@ -1,0 +1,11 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+nc -z localhost 3306
+docker ps -aq -f name=fizzy-mysql
+docker pull mysql:8.4
+docker run -d --name fizzy-mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mysql:8.4
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/fail-mysql-pull/output.txt
+++ b/test/fixtures/setup_phases/fail-mysql-pull/output.txt
@@ -1,0 +1,40 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Setting up MySQL
+bash -c 
+        docker pull mysql:8.4
+        docker run -d \
+          --name fizzy-mysql \
+          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+          -p 3306:3306 \
+          mysql:8.4
+        echo "MySQL is starting… (it may take a few seconds)"
+      
+stub-fail: docker pull mysql:8.4
+MySQL is starting… (it may take a few seconds)
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/fail-mysql-pull/output.txt
+++ b/test/fixtures/setup_phases/fail-mysql-pull/output.txt
@@ -19,22 +19,14 @@ mise install --yes
 bundle install
 
 ▸ Setting up MySQL
-bash -c 
-        docker pull mysql:8.4
-        docker run -d \
-          --name fizzy-mysql \
-          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-          -p 3306:3306 \
-          mysql:8.4
-        echo "MySQL is starting… (it may take a few seconds)"
-      
+mise run --skip-deps setup:mysql-create
 stub-fail: docker pull mysql:8.4
 MySQL is starting… (it may take a few seconds)
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/fail-saas-minio-config/commands.txt
+++ b/test/fixtures/setup_phases/fail-saas-minio-config/commands.txt
@@ -1,0 +1,6 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+docker-dev/setup minio
+minio-setup [SAAS=1 BUNDLE_GEMFILE=Gemfile.saas]
+exit: 9

--- a/test/fixtures/setup_phases/fail-saas-minio-config/output.txt
+++ b/test/fixtures/setup_phases/fail-saas-minio-config/output.txt
@@ -1,0 +1,33 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Trusting SaaS mise overlay
+mise trust --yes $APP/mise.saas.toml
+mise trusted $APP
+
+▸ Syncing docker-dev
+env MISE_ENV=saas mise bootstrap --only repos --yes
+
+▸ Starting Docker services
+$HOME/Work/basecamp/docker-dev/setup minio
+
+▸ Configuring MinIO
+bin/minio-setup
+stub-fail: minio-setup [SAAS=1 BUNDLE_GEMFILE=Gemfile.saas]

--- a/test/fixtures/setup_phases/fail-saas-minio-config/output.txt
+++ b/test/fixtures/setup_phases/fail-saas-minio-config/output.txt
@@ -23,11 +23,12 @@ mise trust --yes $APP/mise.saas.toml
 mise trusted $APP
 
 ▸ Syncing docker-dev
-env MISE_ENV=saas mise bootstrap --only repos --yes
+env MISE_ENV=saas mise run --skip-deps saas:repos
 
 ▸ Starting Docker services
-$HOME/Work/basecamp/docker-dev/setup minio
+env MISE_ENV=saas mise run --skip-deps saas:minio
 
 ▸ Configuring MinIO
-bin/minio-setup
+env MISE_ENV=saas mise run --skip-deps saas:minio-config
 stub-fail: minio-setup [SAAS=1 BUNDLE_GEMFILE=Gemfile.saas]
+[saas:minio-config] ERROR task failed

--- a/test/fixtures/setup_phases/fail-seed/commands.txt
+++ b/test/fixtures/setup_phases/fail-seed/commands.txt
@@ -1,0 +1,7 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+rails db:prepare
+rails runner pp Account.all.any?
+rails db:seed
+exit: 9

--- a/test/fixtures/setup_phases/fail-seed/output.txt
+++ b/test/fixtures/setup_phases/fail-seed/output.txt
@@ -1,0 +1,26 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Seeding the database
+rails db:seed
+stub-fail: rails db:seed

--- a/test/fixtures/setup_phases/fail-seed/output.txt
+++ b/test/fixtures/setup_phases/fail-seed/output.txt
@@ -19,8 +19,9 @@ mise install --yes
 bundle install
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Seeding the database
-rails db:seed
+mise run --skip-deps db:seed
 stub-fail: rails db:seed
+[db:seed] ERROR task failed

--- a/test/fixtures/setup_phases/oss-mysql-container/commands.txt
+++ b/test/fixtures/setup_phases/oss-mysql-container/commands.txt
@@ -1,0 +1,10 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+nc -z localhost 3306
+docker ps -aq -f name=fizzy-mysql
+docker start fizzy-mysql
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/oss-mysql-container/output.txt
+++ b/test/fixtures/setup_phases/oss-mysql-container/output.txt
@@ -1,0 +1,30 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Starting MySQL
+docker start fizzy-mysql
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-mysql-container/output.txt
+++ b/test/fixtures/setup_phases/oss-mysql-container/output.txt
@@ -19,12 +19,12 @@ mise install --yes
 bundle install
 
 ▸ Starting MySQL
-docker start fizzy-mysql
+mise run --skip-deps setup:mysql-start
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-mysql-fresh/commands.txt
+++ b/test/fixtures/setup_phases/oss-mysql-fresh/commands.txt
@@ -1,0 +1,11 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+nc -z localhost 3306
+docker ps -aq -f name=fizzy-mysql
+docker pull mysql:8.4
+docker run -d --name fizzy-mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mysql:8.4
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/oss-mysql-fresh/output.txt
+++ b/test/fixtures/setup_phases/oss-mysql-fresh/output.txt
@@ -1,0 +1,39 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Setting up MySQL
+bash -c 
+        docker pull mysql:8.4
+        docker run -d \
+          --name fizzy-mysql \
+          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+          -p 3306:3306 \
+          mysql:8.4
+        echo "MySQL is starting… (it may take a few seconds)"
+      
+MySQL is starting… (it may take a few seconds)
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-mysql-fresh/output.txt
+++ b/test/fixtures/setup_phases/oss-mysql-fresh/output.txt
@@ -19,21 +19,13 @@ mise install --yes
 bundle install
 
 ▸ Setting up MySQL
-bash -c 
-        docker pull mysql:8.4
-        docker run -d \
-          --name fizzy-mysql \
-          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-          -p 3306:3306 \
-          mysql:8.4
-        echo "MySQL is starting… (it may take a few seconds)"
-      
+mise run --skip-deps setup:mysql-create
 MySQL is starting… (it may take a few seconds)
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-mysql-running/commands.txt
+++ b/test/fixtures/setup_phases/oss-mysql-running/commands.txt
@@ -1,0 +1,8 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+nc -z localhost 3306
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/oss-mysql-running/output.txt
+++ b/test/fixtures/setup_phases/oss-mysql-running/output.txt
@@ -1,0 +1,27 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-mysql-running/output.txt
+++ b/test/fixtures/setup_phases/oss-mysql-running/output.txt
@@ -19,9 +19,9 @@ mise install --yes
 bundle install
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-reset/commands.txt
+++ b/test/fixtures/setup_phases/oss-reset/commands.txt
@@ -1,0 +1,6 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+rails db:reset
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/oss-reset/output.txt
+++ b/test/fixtures/setup_phases/oss-reset/output.txt
@@ -1,0 +1,27 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Resetting the database
+rails db:reset
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-reset/output.txt
+++ b/test/fixtures/setup_phases/oss-reset/output.txt
@@ -19,9 +19,9 @@ mise install --yes
 bundle install
 
 ▸ Resetting the database
-rails db:reset
+mise run --skip-deps db:reset
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-sqlite-seeded/commands.txt
+++ b/test/fixtures/setup_phases/oss-sqlite-seeded/commands.txt
@@ -1,0 +1,8 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+rails db:prepare
+rails runner pp Account.all.any?
+rails db:seed
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/oss-sqlite-seeded/output.txt
+++ b/test/fixtures/setup_phases/oss-sqlite-seeded/output.txt
@@ -1,0 +1,30 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Seeding the database
+rails db:seed
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-sqlite-seeded/output.txt
+++ b/test/fixtures/setup_phases/oss-sqlite-seeded/output.txt
@@ -19,12 +19,12 @@ mise install --yes
 bundle install
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Seeding the database
-rails db:seed
+mise run --skip-deps db:seed
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-sqlite/commands.txt
+++ b/test/fixtures/setup_phases/oss-sqlite/commands.txt
@@ -1,0 +1,7 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/oss-sqlite/output.txt
+++ b/test/fixtures/setup_phases/oss-sqlite/output.txt
@@ -1,0 +1,27 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/oss-sqlite/output.txt
+++ b/test/fixtures/setup_phases/oss-sqlite/output.txt
@@ -19,9 +19,9 @@ mise install --yes
 bundle install
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/saas-minio/commands.txt
+++ b/test/fixtures/setup_phases/saas-minio/commands.txt
@@ -1,0 +1,10 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+docker-dev/setup minio
+minio-setup [SAAS=1 BUNDLE_GEMFILE=Gemfile.saas]
+docker-dev/setup mysql80
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/saas-minio/output.txt
+++ b/test/fixtures/setup_phases/saas-minio/output.txt
@@ -1,0 +1,43 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Trusting SaaS mise overlay
+mise trust --yes $APP/mise.saas.toml
+mise trusted $APP
+
+▸ Syncing docker-dev
+env MISE_ENV=saas mise bootstrap --only repos --yes
+
+▸ Starting Docker services
+$HOME/Work/basecamp/docker-dev/setup minio
+
+▸ Configuring MinIO
+bin/minio-setup
+
+▸ Starting mysql
+$HOME/Work/basecamp/docker-dev/setup mysql80
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/fixtures/setup_phases/saas-minio/output.txt
+++ b/test/fixtures/setup_phases/saas-minio/output.txt
@@ -23,21 +23,21 @@ mise trust --yes $APP/mise.saas.toml
 mise trusted $APP
 
 ▸ Syncing docker-dev
-env MISE_ENV=saas mise bootstrap --only repos --yes
+env MISE_ENV=saas mise run --skip-deps saas:repos
 
 ▸ Starting Docker services
-$HOME/Work/basecamp/docker-dev/setup minio
+env MISE_ENV=saas mise run --skip-deps saas:minio
 
 ▸ Configuring MinIO
-bin/minio-setup
+env MISE_ENV=saas mise run --skip-deps saas:minio-config
 
 ▸ Starting mysql
-$HOME/Work/basecamp/docker-dev/setup mysql80
+env MISE_ENV=saas mise run --skip-deps saas:mysql
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/saas-no-minio/commands.txt
+++ b/test/fixtures/setup_phases/saas-no-minio/commands.txt
@@ -1,0 +1,8 @@
+brew bundle --file=$APP/Brewfile
+bundle config set --local auto_install true
+bundle install
+docker-dev/setup mysql80
+rails db:prepare
+rails runner pp Account.all.any?
+rails log:clear tmp:clear
+exit: 0

--- a/test/fixtures/setup_phases/saas-no-minio/output.txt
+++ b/test/fixtures/setup_phases/saas-no-minio/output.txt
@@ -23,15 +23,15 @@ mise trust --yes $APP/mise.saas.toml
 mise trusted $APP
 
 ▸ Syncing docker-dev
-env MISE_ENV=saas mise bootstrap --only repos --yes
+env MISE_ENV=saas mise run --skip-deps saas:repos
 
 ▸ Starting mysql
-$HOME/Work/basecamp/docker-dev/setup mysql80
+env MISE_ENV=saas mise run --skip-deps saas:mysql
 
 ▸ Preparing the database
-rails db:prepare
+mise run --skip-deps db:prepare
 
 ▸ Cleaning up logs and tempfiles
-rails log:clear tmp:clear
+mise run --skip-deps setup:cleanup
 
 ✓ Done (N sec)

--- a/test/fixtures/setup_phases/saas-no-minio/output.txt
+++ b/test/fixtures/setup_phases/saas-no-minio/output.txt
@@ -1,0 +1,37 @@
+▸ Ensuring mise install
+ensure_correct_mise_install
+
+▸ Trusting mise config
+mise trust --yes $APP/.mise.toml
+mise trusted $APP
+
+▸ Installing system packages
+brew bundle --file=$APP/Brewfile
+
+▸ Installing Ruby and tools
+mise install --yes
+
+
+   ˚ ∘             ∘ ˚   
+  ∘˚˳°∘°  𝒻𝒾𝓏𝓏𝓎  °∘°˳˚∘  
+
+▸ Installing RubyGems
+bundle install
+
+▸ Trusting SaaS mise overlay
+mise trust --yes $APP/mise.saas.toml
+mise trusted $APP
+
+▸ Syncing docker-dev
+env MISE_ENV=saas mise bootstrap --only repos --yes
+
+▸ Starting mysql
+$HOME/Work/basecamp/docker-dev/setup mysql80
+
+▸ Preparing the database
+rails db:prepare
+
+▸ Cleaning up logs and tempfiles
+rails log:clear tmp:clear
+
+✓ Done (N sec)

--- a/test/setup-phases-test
+++ b/test/setup-phases-test
@@ -113,6 +113,16 @@ rec "\$label"; die_if_fail "\$label"
 EOF
   done
 
+  # Pin the sandbox to the macOS/brew branch on every host: the bracket
+  # asserts ONE platform's command sequence, and bin/setup's own platform
+  # probes (`uname -s` + command -v) would otherwise route Arch hosts down
+  # the pacman branch and diverge from the goldens. Platform branching is
+  # bin/setup's behavior under test elsewhere, not this bracket's concern.
+  cat > "$sb/stubbin/uname" <<'EOF'
+#!/usr/bin/env bash
+echo Darwin
+EOF
+
   # Not a recorder: gum is presentation. --version fails so step() takes its
   # deterministic plain-echo fallback; direct `gum style` calls print their
   # text arguments.
@@ -147,7 +157,7 @@ EOF
 
   chmod +x "$sb/bin/rails" "$sb/bin/minio-setup" "$sb/home/Work/basecamp/docker-dev/setup" \
            "$sb/stubbin/docker" "$sb/stubbin/nc" "$sb/stubbin/brew" "$sb/stubbin/bundle" \
-           "$sb/stubbin/gh" "$sb/stubbin/gum" "$sb/stubbin/mise"
+           "$sb/stubbin/gh" "$sb/stubbin/gum" "$sb/stubbin/mise" "$sb/stubbin/uname"
 }
 
 run_scenario() { # run_scenario <name> <args> [VAR=value|SAAS_FILE=1|MINIO_FILE=1]...

--- a/test/setup-phases-test
+++ b/test/setup-phases-test
@@ -184,7 +184,12 @@ run_scenario() { # run_scenario <name> <args> [VAR=value|SAAS_FILE=1|MINIO_FILE=
   local rc=0
   ( cd "$sb" && env -i "${envs[@]}" bin/setup $args ) > "$sb/output.raw" 2>&1 || rc=$?
   printf 'exit: %s\n' "$rc" >> "$sb/commands.txt"
-  sed -e "s|$sb/home|\$HOME|g" -e "s|$sb|\$APP|g" \
+  # ANSI escapes (mise colors some lines even under TERM=dumb, and coloring
+  # varies by version/environment) are styling, not behavior — strip them so
+  # the goldens stay stable.
+  local esc; esc="$(printf '\033')"
+  sed -e "s/${esc}\[[0-9;]*[A-Za-z]//g" \
+      -e "s|$sb/home|\$HOME|g" -e "s|$sb|\$APP|g" \
       -e 's/([0-9][0-9]* sec)/(N sec)/' "$sb/output.raw" > "$sb/output.txt"
 
   if [ "${REGEN:-}" = 1 ]; then

--- a/test/setup-phases-test
+++ b/test/setup-phases-test
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Snapshot bracket for bin/setup's post-prelude phases: run bin/setup in a
+# hermetic sandbox where every effectful command is a recorder stub, and
+# compare the ordered command sequence and step output against goldens in
+# test/fixtures/setup_phases/. The commands goldens are the contract — any
+# refactor of how bin/setup dispatches its phases must leave them
+# byte-identical, including the exit trailer. Output goldens pin the step
+# labels; only the dim command-echo lines may change across a dispatch
+# refactor.
+#
+# The sandbox stubs bin/rails, bin/minio-setup, docker, nc, brew, bundle, gh,
+# gum, and ~/Work/basecamp/docker-dev/setup (under a fake HOME). mise is a
+# dispatcher: run/tasks/trust exec the REAL mise against the sandbox's own
+# TOML (whose task leaves are the recorders), with --skip-tools injected so
+# nothing downloads; install/bootstrap/self-update no-op. Requires a real
+# mise >= the repo floor on PATH — the same thing bin/setup's prelude
+# guarantees on any dev machine.
+#
+# Invocation (from anywhere):
+#
+#   test/setup-phases-test            # compare against goldens
+#   REGEN=1 test/setup-phases-test    # regenerate goldens
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES="$ROOT/test/fixtures/setup_phases"
+REAL_MISE="$(command -v mise)" || { echo "error: setup-phases-test needs mise on PATH" >&2; exit 1; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/setup-phases.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+# Physical path: bin/setup canonicalizes app_root with pwd, and recorded
+# paths must match it for $APP normalization (macOS /var -> /private/var).
+WORK="$(cd "$WORK" && pwd -P)"
+
+pass=0 fail=0
+ok()  { pass=$((pass+1)); echo "  ok: $1"; }
+bad() { fail=$((fail+1)); echo "  FAIL: $1"; }
+
+build_sandbox() { # build_sandbox <dir>
+  local sb="$1" stub
+  mkdir -p "$sb/bin" "$sb/saas/bin" "$sb/tmp" "$sb/tmpdir" "$sb/stubbin" \
+           "$sb/home/Work/basecamp/docker-dev" "$sb/home/.config" \
+           "$sb/home/.local/share" "$sb/home/.local/state" "$sb/home/.cache"
+  cp "$ROOT/bin/setup" "$sb/bin/setup"
+  cp "$ROOT/saas/bin/setup" "$sb/saas/bin/setup"
+  cp "$ROOT/.mise.toml" "$sb/.mise.toml"
+  cp "$ROOT/mise.saas.toml" "$sb/mise.saas.toml"
+  cp "$ROOT/Brewfile" "$sb/Brewfile"
+  : > "$sb/home/global-mise.toml"
+
+  # Recorders append one normalized line per invocation. STUB_FAIL names a
+  # recorded-command prefix that should exit 9 AFTER recording, so the stop
+  # point stays visible in commands.txt.
+  cat > "$sb/stubbin/_stublib" <<'EOF'
+rec() {
+  local line="$1"
+  line="${line//$STUB_SANDBOX\/home/\$HOME}"
+  line="${line//$STUB_SANDBOX/\$APP}"
+  printf '%s\n' "$line" >> "$STUB_RECORD"
+}
+die_if_fail() {
+  case "$1" in "${STUB_FAIL:-__none__}"*) echo "stub-fail: $1" >&2; exit 9;; esac
+}
+EOF
+
+  cat > "$sb/bin/rails" <<'EOF'
+#!/usr/bin/env bash
+source "$STUB_LIB"
+label="rails $*"
+rec "$label"; die_if_fail "$label"
+if [ "${1:-}" = runner ]; then echo "${STUB_HAS_DATA:-false}"; fi
+EOF
+
+  # Env markers prove the SaaS gemfile selection survives however this
+  # command is dispatched: bin/minio-setup boots config/environment directly,
+  # so it lives or dies by BUNDLE_GEMFILE.
+  cat > "$sb/bin/minio-setup" <<'EOF'
+#!/usr/bin/env bash
+source "$STUB_LIB"
+label="minio-setup${*:+ $*} [SAAS=${SAAS:-unset} BUNDLE_GEMFILE=${BUNDLE_GEMFILE:-unset}]"
+rec "$label"; die_if_fail "$label"
+EOF
+
+  cat > "$sb/home/Work/basecamp/docker-dev/setup" <<'EOF'
+#!/usr/bin/env bash
+source "$STUB_LIB"
+label="docker-dev/setup $*"
+rec "$label"; die_if_fail "$label"
+EOF
+
+  cat > "$sb/stubbin/docker" <<'EOF'
+#!/usr/bin/env bash
+source "$STUB_LIB"
+label="docker $*"
+rec "$label"; die_if_fail "$label"
+if [ "${1:-}" = ps ] && [ "${STUB_MYSQL_CONTAINER:-0}" = 1 ]; then echo "3fa85f64c001"; fi
+EOF
+
+  cat > "$sb/stubbin/nc" <<'EOF'
+#!/usr/bin/env bash
+source "$STUB_LIB"
+label="nc $*"
+rec "$label"; die_if_fail "$label"
+if [ "${STUB_MYSQL_RUNNING:-0}" = 1 ]; then exit 0; else exit 1; fi
+EOF
+
+  for stub in brew bundle gh; do
+    cat > "$sb/stubbin/$stub" <<EOF
+#!/usr/bin/env bash
+source "\$STUB_LIB"
+label="$stub \$*"
+rec "\$label"; die_if_fail "\$label"
+EOF
+  done
+
+  # Not a recorder: gum is presentation. --version fails so step() takes its
+  # deterministic plain-echo fallback; direct `gum style` calls print their
+  # text arguments.
+  cat > "$sb/stubbin/gum" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) exit 1 ;;
+  style)
+    shift
+    while [ $# -gt 0 ] && [ "${1#--}" != "$1" ]; do
+      case "$1" in --foreground) shift 2 ;; *) shift ;; esac
+    done
+    printf '%s\n' "$*"
+    ;;
+esac
+EOF
+
+  # Orchestration, not an effect: never recorded. run/tasks/trust exec the
+  # real mise against the sandbox's TOML; --skip-tools keeps the harness
+  # offline (installing tools is the prelude's job, outside this bracket).
+  cat > "$sb/stubbin/mise" <<'EOF'
+#!/usr/bin/env bash
+label="mise $*"
+case "$label" in "${STUB_FAIL:-__none__}"*) echo "stub-fail: $label" >&2; exit 9;; esac
+case "${1:-}" in
+  run) shift; exec "$STUB_REAL_MISE" run --skip-tools "$@" ;;
+  tasks|trust) exec "$STUB_REAL_MISE" "$@" ;;
+  --version) exec "$STUB_REAL_MISE" --version ;;
+  *) exit 0 ;;
+esac
+EOF
+
+  chmod +x "$sb/bin/rails" "$sb/bin/minio-setup" "$sb/home/Work/basecamp/docker-dev/setup" \
+           "$sb/stubbin/docker" "$sb/stubbin/nc" "$sb/stubbin/brew" "$sb/stubbin/bundle" \
+           "$sb/stubbin/gh" "$sb/stubbin/gum" "$sb/stubbin/mise"
+}
+
+run_scenario() { # run_scenario <name> <args> [VAR=value|SAAS_FILE=1|MINIO_FILE=1]...
+  local name="$1" args="$2"; shift 2
+  local sb="$WORK/$name"
+  build_sandbox "$sb"
+
+  local envs=(
+    PATH="$sb/stubbin:/usr/bin:/bin:/usr/sbin:/sbin"
+    HOME="$sb/home"
+    TMPDIR="$sb/tmpdir"
+    TERM=dumb
+    STUB_SANDBOX="$sb"
+    STUB_RECORD="$sb/commands.txt"
+    STUB_LIB="$sb/stubbin/_stublib"
+    STUB_REAL_MISE="$REAL_MISE"
+    XDG_CONFIG_HOME="$sb/home/.config"
+    XDG_DATA_HOME="$sb/home/.local/share"
+    XDG_STATE_HOME="$sb/home/.local/state"
+    XDG_CACHE_HOME="$sb/home/.cache"
+    MISE_TRUSTED_CONFIG_PATHS="$sb"
+    MISE_GLOBAL_CONFIG_FILE="$sb/home/global-mise.toml"
+  )
+  local kv
+  for kv in "$@"; do
+    case "$kv" in
+      SAAS_FILE=1)  touch "$sb/tmp/saas.txt" ;;
+      MINIO_FILE=1) touch "$sb/tmp/minio-dev.txt" ;;
+      *) envs+=("$kv") ;;
+    esac
+  done
+
+  : > "$sb/commands.txt"
+  local rc=0
+  ( cd "$sb" && env -i "${envs[@]}" bin/setup $args ) > "$sb/output.raw" 2>&1 || rc=$?
+  printf 'exit: %s\n' "$rc" >> "$sb/commands.txt"
+  sed -e "s|$sb/home|\$HOME|g" -e "s|$sb|\$APP|g" \
+      -e 's/([0-9][0-9]* sec)/(N sec)/' "$sb/output.raw" > "$sb/output.txt"
+
+  if [ "${REGEN:-}" = 1 ]; then
+    mkdir -p "$FIXTURES/$name"
+    cp "$sb/commands.txt" "$FIXTURES/$name/commands.txt"
+    cp "$sb/output.txt" "$FIXTURES/$name/output.txt"
+    echo "regenerated: $name (exit: $rc)"
+  else
+    echo "=== $name"
+    if diff -u "$FIXTURES/$name/commands.txt" "$sb/commands.txt" > "$sb/commands.diff" 2>&1; then
+      ok "commands match golden"
+    else
+      bad "commands diverge from golden"; sed 's/^/    /' "$sb/commands.diff"
+    fi
+    if diff -u "$FIXTURES/$name/output.txt" "$sb/output.txt" > "$sb/output.diff" 2>&1; then
+      ok "output matches golden"
+    else
+      bad "output diverges from golden"; sed 's/^/    /' "$sb/output.diff"
+    fi
+  fi
+}
+
+# State scenarios: every post-prelude branch of bin/setup.
+run_scenario oss-sqlite          ""        STUB_HAS_DATA=true
+run_scenario oss-sqlite-seeded   ""        STUB_HAS_DATA=false
+run_scenario oss-reset           "--reset" STUB_HAS_DATA=true
+run_scenario oss-mysql-fresh     ""        STUB_HAS_DATA=true DATABASE_ADAPTER=mysql
+run_scenario oss-mysql-container ""        STUB_HAS_DATA=true DATABASE_ADAPTER=mysql STUB_MYSQL_CONTAINER=1
+run_scenario oss-mysql-running   ""        STUB_HAS_DATA=true DATABASE_ADAPTER=mysql STUB_MYSQL_RUNNING=1
+run_scenario saas-minio          ""        STUB_HAS_DATA=true SAAS_FILE=1 MINIO_FILE=1
+run_scenario saas-no-minio       ""        STUB_HAS_DATA=true SAAS_FILE=1
+run_scenario ci-sim              ""        STUB_HAS_DATA=false CI=true
+
+# Failure-injection scenarios: exit status and stop point are part of the
+# contract. fail-mysql-pull pins the deliberate non-errexit interior of the
+# MySQL creation block — a failed pull falls through to `docker run` and the
+# phase still succeeds, exactly as bin/setup has always behaved.
+run_scenario fail-db-prepare        ""  STUB_HAS_DATA=false "STUB_FAIL=rails db:prepare"
+run_scenario fail-seed              ""  STUB_HAS_DATA=false "STUB_FAIL=rails db:seed"
+run_scenario fail-mysql-pull        ""  STUB_HAS_DATA=true DATABASE_ADAPTER=mysql "STUB_FAIL=docker pull mysql:8.4"
+run_scenario fail-saas-minio-config ""  STUB_HAS_DATA=true SAAS_FILE=1 MINIO_FILE=1 "STUB_FAIL=minio-setup"
+
+echo
+if [ "${REGEN:-}" = 1 ]; then
+  echo "goldens regenerated in $FIXTURES"
+elif [ "$fail" = 0 ]; then
+  echo "ALL $pass ASSERTIONS PASSED"
+else
+  echo "$fail FAILED, $pass passed"
+  exit 1
+fi


### PR DESCRIPTION
Pilot for expressing `bin/setup`'s post-prelude phases as a mise `[tasks]` graph. Success criteria: `bin/setup` behavior unchanged, each phase individually runnable. Branched from main at 6b1b598c.

## Scope

Post-prelude phases only. The mise prelude (ensure/trust/packages/tools + hook-env) and the fenced `docker-dev-origin` block stay verbatim. All guards and conditionals stay in bash: the `--reset` branch, `needs_seeding()` (including its CI guard), the `DATABASE_ADAPTER`/SAAS branch, the `nc`/`docker ps` guards, `tmp/minio-dev.txt`.

## Design

- **`.mise.toml` (OSS)**: `db:prepare`, `db:reset`, `db:seed` (depends `db:prepare`), `setup:mysql-start`, `setup:mysql-create`, `setup:cleanup` — one task per step body, `quiet = true`. Colon-namespaced names can't collide with the 18 existing `bin/` files.
- **`mise.saas.toml` (SaaS overlay)**: `saas:repos`, `saas:minio` (depends repos), `saas:minio-config` (depends minio), `saas:mysql` (depends repos). Private infra stays out of the OSS root structurally. Deliberately several tasks, not one umbrella: mise parallelizes a task's depends (`--jobs`), and these docker ops must keep today's strict ordering.
- **`bin/setup` rewiring**: each phase becomes `step "<same label>" mise run --skip-deps <task>` — `--skip-deps` so bin/setup's explicit ordering isn't double-run by the graph; standalone users omit it and get the depends chains. `saas/bin/setup` uses `env MISE_ENV=saas mise run --skip-deps saas:…` — the env-var form makes the overlay visible *and* lets the child `mise bootstrap` inherit it.
- **Shell-boundary preservation**: `setup:mysql-create` wraps the original `bash -c` block verbatim. mise runs tasks under `sh -c` with errexit/pipefail; flattening the block would have changed failure behavior — a failed `docker pull` must keep falling through to `docker run` (the image may already be local). Pinned by the `fail-mysql-pull` scenario.
- **SaaS gemfile correctness**: `saas:minio-config` carries explicit `env = { SAAS = "1", BUNDLE_GEMFILE = "Gemfile.saas" }`. `bin/rails` self-detects SaaS via `Fizzy.configure_bundle`, but `bin/minio-setup` boots `config/environment` directly and `config/boot.rb` picks the OSS Gemfile before anything could intervene — standalone runs need the selection made here.
- **Stubs**: `mise generate task-stubs --dir bin/tasks` (fresh dir, zero collision; OSS tasks only). Namespaces land as `bin/tasks/db/prepare` etc. Stubs run *without* `--skip-deps` — standalone semantics.

## Contract

Tasks are runnable from a bare shell at the repo root and depend on nothing `bin/setup` exports. Not changed: step labels/sequence, effectful commands, exit behavior, the prelude, the fenced block. Changed: the dim command-echo lines (now naming the task dispatch), mise's `[task] ERROR task failed` stderr diagnostic on failing tasks, new files.

## Snapshot bracket (the proof)

`test/setup-phases-test` + goldens in `test/fixtures/setup_phases/`: full stubbed execution of `bin/setup` in a hermetic sandbox — recorder stubs for `bin/rails`, `bin/minio-setup`, `docker`, `nc`, `brew`, `bundle`, `gh`, `gum`, and `docker-dev/setup` under a fake HOME; `mise` is a dispatcher that execs the real mise for `run`/`tasks`/`trust` (with `--skip-tools`, so the harness stays offline) and no-ops `install`/`bootstrap`/`self-update`.

Thirteen scenarios: oss-sqlite, oss-sqlite-seeded, oss-reset, oss-mysql-fresh/-container/-running, saas-minio, saas-no-minio, ci-sim, plus failure injection pinning exit status and stop point (fail-db-prepare, fail-seed, fail-saas-minio-config exit 9; fail-mysql-pull exits 0 with `docker run` still recorded after the failed pull). The minio-setup recorder stamps `SAAS`/`BUNDLE_GEMFILE`, asserting gemfile selection through the dispatch boundary.

The commit sequence makes the bracket self-proving: (1) harness + goldens against untouched `bin/setup`, (2) TOML + rewiring — **all 13 `commands.txt` goldens (ordered effectful commands + exit trailer) are untouched by the rewiring commit, byte-identical**; only `output.txt` goldens regenerate, (3) stubs + docs.

## Verification

- Harness: 26/26, deterministic across back-to-back runs, at both commit 1 and commit 2.
- `mise tasks ls` / `MISE_ENV=saas mise tasks ls` (overlay scoping correct); `mise tasks deps db:seed` and `saas:minio-config` show the chains; plain `mise run saas:mysql` fails "no task found" — expected, overlay not loaded.
- Real runs on this machine, each green end-to-end through the task dispatches: OSS `bin/setup`, `bin/setup --reset`, `DATABASE_ADAPTER=mysql bin/setup` (3306 already bound by docker-dev mysql80 → running-branch), SaaS `touch tmp/saas.txt && bin/setup` (overlay trust, repos sync, mysql80, SaaS test DBs created).
- Standalone from bare shells: `mise run db:prepare`; `mise run db:seed` (ran its `db:prepare` dep first); `env MISE_ENV=saas mise run saas:mysql` (synced docker-dev first via depends).
- CI simulation via the ci-sim scenario (`CI=true` → no probe, no seed).
- `bin/ci` end-to-end on the branch: running at PR-open time; result will be posted here.

## Caveat found during verification

`mise run` builds the task env by restoring the pre-activation base PATH and adding tool paths — with dedup. In a shell whose *base* PATH already contains mise install dirs positioned after `/usr/bin` (e.g. an agent session with a baked, stale PATH), dedup keeps the wrong position and tasks resolve `/usr/bin/ruby`. Normal dev shells (dynamic `mise activate`) and clean environments resolve correctly — verified both. Not introduced by this PR; noting it because task-dispatched phases now traverse that env rebuild.
