### PR TITLE
Add prek-powered git pre-commit hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env -S bin/bcenv bash
+exec prek run

--- a/.mise.toml
+++ b/.mise.toml
@@ -5,6 +5,7 @@ idiomatic_version_file_enable_tools = ["ruby"]
 
 [tools]
 gum = "0.17.0"
+prek = "0.4.11"
 
 [env]
 PROMETHEUS_EXPORTER_URL = "http://127.0.0.1:9306/metrics"

--- a/bin/bcenv
+++ b/bin/bcenv
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+# macOS doesn't launch GUI apps through a login shell, but
+# login shell profiles are how we conventionally set user-
+# specific environment variables like PATH. This can cause
+# trouble with apps like Tower that need to run git hooks.
+#
+# The `bcenv` command transparently re-execs the command
+# specified in the argument list through a login shell.
+
+if [ $# -eq 0 ]; then
+  echo "usage: bcenv command [args...]" 2>&1
+  exit 1
+fi
+
+if command -v dscl >/dev/null; then
+  read -r SHELL < <( dscl . -read "/Users/$(whoami)" UserShell )
+elif command -v getent >/dev/null; then
+  SHELL="$( getent passwd "$(whoami)" | cut -d: -f7 )"
+else
+  SHELL="/bin/sh"
+fi
+
+SHELL="${SHELL#*: }"
+
+# mise-managed tools (node, ruby, bundler) must resolve in this context even when
+# the user's profile only activates mise for interactive shells — git hooks run
+# through bcenv as non-interactive login shells. Shims are mise's recommended
+# non-interactive activation; no-op when mise isn't on the login PATH. The snippet
+# is generated for the detected login shell; unknown shells get no preamble.
+#
+# The argument vector is forwarded POSITIONALLY, never serialized into shell
+# source text: no quoting dialect survives every login shell (bash %q output
+# is not fish syntax — newline and tab arguments made fish exit 127). POSIX
+# shells receive the vector after a $0 sentinel; fish exposes it as $argv.
+#
+# Tested support surface: bash, zsh, fish (test/bcenv-matrix-test). C shells
+# were never supported — csh/tcsh reject `-l` combined with `-c` outright,
+# before any payload syntax is reached.
+# Seed the base PATH a login shell normally inherits from PAM. With PATH unset,
+# /etc/profile.d scripts run without /usr/bin, and a not-found command can send a
+# command-not-found handler recursing into a fork bomb. The login profile still
+# rebuilds the full PATH on top.
+base_path="/usr/local/bin:/usr/bin:/bin"
+
+# shellcheck disable=SC2016  # the preamble expands in the login shell, not here
+case "${SHELL##*/}" in
+  bash | zsh | sh )
+    mise_shims='command -v mise >/dev/null && eval "$(mise activate bash --shims)"; '
+    exec env PATH="$base_path" "$SHELL" -l -c "${mise_shims}exec \"\$@\"" bcenv "$@" ;;
+  fish )
+    mise_shims='command -v mise >/dev/null; and mise activate fish --shims | source; '
+    exec env PATH="$base_path" "$SHELL" -l -c "${mise_shims}exec \$argv" "$@" ;;
+  * )
+    exec env PATH="$base_path" "$SHELL" -l -c 'exec "$@"' bcenv "$@" ;;
+esac

--- a/bin/bcenv
+++ b/bin/bcenv
@@ -38,11 +38,17 @@ SHELL="${SHELL#*: }"
 # Tested support surface: bash, zsh, fish (test/bcenv-matrix-test). C shells
 # were never supported — csh/tcsh reject `-l` combined with `-c` outright,
 # before any payload syntax is reached.
-# Seed the base PATH a login shell normally inherits from PAM. With PATH unset,
-# /etc/profile.d scripts run without /usr/bin, and a not-found command can send a
-# command-not-found handler recursing into a fork bomb. The login profile still
-# rebuilds the full PATH on top.
-base_path="/usr/local/bin:/usr/bin:/bin"
+# Seed the base PATH a login shell normally inherits from PAM, plus mise's
+# standard install locations: ~/.local/bin (the mise.run installer) and
+# /opt/homebrew/bin (Apple Silicon brew; Intel brew is /usr/local/bin, package
+# managers are /usr/bin). The login shell here is non-interactive (-l -c), so
+# a profile that only activates mise in interactive rc files (.bashrc/.zshrc —
+# mise's documented setup) never adds it to PATH; the shims probe below must
+# find mise from the seed alone. With PATH unset, /etc/profile.d scripts run
+# without /usr/bin, and a not-found command can send a command-not-found
+# handler recursing into a fork bomb. The login profile still rebuilds its
+# PATH on top.
+base_path="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 # shellcheck disable=SC2016  # the preamble expands in the login shell, not here
 case "${SHELL##*/}" in

--- a/bin/setup
+++ b/bin/setup
@@ -149,6 +149,8 @@ fi
 step "Installing Ruby and tools" mise install --yes
 eval "$(mise hook-env -s bash)"
 
+step "Installing Git pre-commit hooks" git config core.hooksPath .githooks
+
 # Install gh if needed
 if ! command -v gh &>/dev/null; then
   echo

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,14 @@
+[[repos]]
+repo = "local"
+hooks = [
+  { id = "rubocop", name = "rubocop", language = "system", entry = "bin/rubocop --force-exclusion", types = ["ruby"] },
+]
+
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "check-merge-conflict" },
+  { id = "check-case-conflict" },
+  { id = "check-added-large-files" },
+  { id = "detect-private-key" },
+]


### PR DESCRIPTION
Adopts the git-hook pattern established in basecamp/bc3#12423: prek ([j178/prek](https://github.com/j178/prek), a Rust pre-commit reimplementation) installs as a sha256-verified prebuilt binary via mise's aqua backend (macOS arm64/x86_64, Arch, Ubuntu), a checked-in `.githooks/pre-commit` runs it, and `bin/setup` points `core.hooksPath` there. **This introduces local commit hooks where none ran before** — anyone who runs `bin/setup`, including outside contributors, gets blocking pre-commit linting from then on. No server-side or CI enforcement changes.

**Review boundary**: branched from `main` at `6b1b598ca0c50035ec966e78ffe9daca4cadb813`.

## What changes

- `.mise.toml [tools]`: add `prek = "0.4.11"` (nothing to remove — this repo never carried quickhook)
- `bin/bcenv`: transparently re-execs through a login shell so GUI git clients (Tower etc.) resolve mise-managed tools; generic, no internal assumptions
- `prek.toml`: rubocop (`bin/rubocop --force-exclusion`, staged files only, honors `.rubocop.yml` excludes) plus the check-merge-conflict / check-case-conflict / check-added-large-files / detect-private-key builtins. No fixers — hooks block, they don't rewrite.
- `.githooks/pre-commit`: two lines, checked in
- `bin/setup`: new `git config core.hooksPath .githooks` step after mise activation. Relative hooksPath resolves per-worktree; nothing in `.git/hooks` is consulted anymore.

File selection is `types = ["ruby"]` identify semantics (`.rb`, `.rake`, `.gemspec`, `Rakefile`, `Gemfile`, `config.ru`, ruby-shebang scripts). The whole tree already passes rubocop under that selection (`prek run rubocop --all-files`: 0 offenses), so nobody gets ambushed on their next commit.

Note: a repo-level `core.hooksPath` shadows any global `core.hooksPath` a contributor may have configured — git consults exactly one hooks dir. Accepted tradeoff; the hook stays pure prek with no global chaining.

## Verification (in a worktree of this branch)

1. `mise install --yes` → `prek 0.4.11` sourced from this repo's `.mise.toml`
2. `prek validate-config prek.toml` → valid
3. Real `git commit` attempts on a disposable branch:
   - staged `.rb` with an offense → **blocked** by rubocop
   - staged `.rake` with an offense → **blocked** (ruby-types breadth)
   - conflict markers staged during a genuine conflicted merge → **blocked** by check-merge-conflict (fires only during an actual merge/rebase, matching upstream pre-commit-hooks semantics)
   - clean staged change → commit succeeds
4. `prek run rubocop --all-files` → passes clean



---
**Update (2026-07-28):** `bin/bcenv` resynced byte-identical from bc3 after basecamp/bc3#12426 hardened the canonical copy (base-PATH seed now covers mise's standard install locations — `~/.local/bin`, `/opt/homebrew/bin` — so rc-file-only mise activation still resolves in the non-interactive login shell; verified by bc3's bcenv behavioral matrix, 22/22 with negative control). All-files rubocop rerun at the current head: exit 0, clean.