### PR TITLE
Reset .card-columns vertical scroll on drag end (#2964)

### DIFF
--- a/app/javascript/controllers/drag_and_drop_controller.js
+++ b/app/javascript/controllers/drag_and_drop_controller.js
@@ -60,6 +60,8 @@ export default class extends Controller {
       this.#restoreOriginalDraggedItemCssVariable()
     }
 
+    this.element.scrollTop = 0 // .card-columns is overflow-y: hidden; reset any browser-internal vertical scroll so empty drop zones don't peek out (#2964)
+
     this.sourceContainer = null
     this.dragItem = null
     this.wasDropped = false


### PR DESCRIPTION
## Problem

After dragging a card, empty columns' "Drag cards here" drop zones can peek out at the bottom and push the column headings up, leaving the board stuck until a full page refresh (#2964).

## Root cause

`.card-columns` is `overflow-y: hidden` but still a scroll container. Empty columns' blank-slate placeholders hang past its bottom edge (clipped by the hidden overflow), and browser-internal scrolling (e.g. drag auto-scroll on some Chrome/Edge builds) can offset `scrollTop`, which is never reset.

## Fix

Reset `scrollTop` to `0` in `dragEnd`. There is never a legitimate vertical scroll, so this is always safe.

## Testing

Verified on the dev board: after a drag, `document.querySelector(".card-columns").scrollTop` is `0`. Forcing the stuck state (`scrollTop = 9999`) then dragging any card snaps it back and unsticks the board.

Closes #2964.

https://github.com/user-attachments/assets/92b5b544-df21-4b9e-a308-23352decb32f