### PR TITLE
Give the SaaS deploy block its machine-parsed Destinations line

### DIFF
--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -8,4 +8,11 @@
 
 `saas:enable` is a prerequisite for deploying, not just for local development. Only under that flag does `bin/kamal` pass `-c` pointing at this gem's `config/deploy.yml`. Skip it and Kamal reads the root `config/deploy.yml` instead — the self-hosting example, which knows nothing about our destinations.
 
-Destinations are production, staging, beta, and beta1, one `config/deploy.<destination>.yml` each. `beta` is a template requiring the `BETA_NUMBER` env var; `beta1` is the only numbered target that exists. The `.kamal/secrets.beta2` through `secrets.beta4` symlinks are leftovers and don't make those destinations real.
+## Deploy
+
+Deploy: `bin/kamal deploy -d <destination>`
+Destinations: production, staging, beta, beta1
+
+One `config/deploy.<destination>.yml` each. `beta` is a template requiring the `BETA_NUMBER` env var; `beta1` is the only numbered target that exists. The `.kamal/secrets.beta2` through `secrets.beta4` symlinks are leftovers and don't make those destinations real.
+
+The default branch stays in the root `AGENTS.md` — it describes the repository, not the hosted deployment.

--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -13,6 +13,6 @@
 Deploy: `bin/kamal deploy -d <destination>`
 Destinations: production, staging, beta, beta1
 
-One `config/deploy.<destination>.yml` each. `beta` is a template requiring the `BETA_NUMBER` env var; `beta1` is the only numbered target that exists. The `.kamal/secrets.beta2` through `secrets.beta4` symlinks are leftovers and don't make those destinations real.
+One `saas/config/deploy.<destination>.yml` each — paths here are given from the repository root, because that's where you're working from, and `config/deploy.yml` at the root is the self-hosting example rather than ours. `beta` is a template requiring the `BETA_NUMBER` env var; `beta1` is the only numbered target that exists. The `saas/.kamal/secrets.beta2` through `saas/.kamal/secrets.beta4` symlinks are leftovers and don't make those destinations real.
 
 The default branch stays in the root `AGENTS.md` — it describes the repository, not the hosted deployment.


### PR DESCRIPTION
Our registry drift gate parses `Destinations:` by exact prefix. Moving the hosted deploy details out of the public root left the list as prose in `saas/AGENTS.md`, so the gate found no destinations for Fizzy and failed the fleet run.

`saas/AGENTS.md` now carries a real Deploy block:

```
Deploy: `bin/kamal deploy -d <destination>`
Destinations: production, staging, beta, beta1
```

Those four match the four `saas/config/deploy.*.yml` files exactly. The default branch stays in the root `AGENTS.md` — it describes the repository, not the hosted deployment — so branch and destinations are read from different files by design.