### PR TITLE
Name the pre-deploy step beside the command it governs

### DIFF
--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -10,6 +10,7 @@
 
 ## Deploy
 
+Pre-deploy: `bin/rails saas:enable`
 Deploy: `bin/kamal deploy -d <destination>`
 Destinations: production, staging, beta, beta1
 


### PR DESCRIPTION
One line.

```diff
+Pre-deploy: `bin/rails saas:enable`
 Deploy: `bin/kamal deploy -d <destination>`
 Destinations: production, staging, beta, beta1
```

`bin/kamal deploy` does nothing useful until `saas:enable` has run — that flag is what makes `bin/kamal` pass `-c` pointing at this gem's `config/deploy.yml` instead of the self-hosting example at the repository root. The prose above the block already said so; the block itself did not, so anything reading the block got a command without its prerequisite.