### PR TITLE
Disable native push where credentials aren't provisioned

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -30,8 +30,8 @@ if [ "$USE_PUSH" = "1" ]; then
     echo "Error: failed to load push credentials. Are you signed into 1Password?" >&2
     exit 1
   fi
-  if [ -z "$APNS_ENCRYPTION_KEY_B64" ] || [ -z "$APNS_KEY_ID" ]; then
-    echo "Error: Push credentials not set. Missing APNS_ENCRYPTION_KEY_B64 or APNS_KEY_ID." >&2
+  if [ -z "$APNS_ENCRYPTION_KEY_B64" ] || [ -z "$APNS_KEY_ID" ] || [ -z "$FCM_ENCRYPTION_KEY_B64" ]; then
+    echo "Error: Push credentials not set. Missing APNS_ENCRYPTION_KEY_B64, APNS_KEY_ID, or FCM_ENCRYPTION_KEY_B64." >&2
     exit 1
   fi
 fi

--- a/saas/app/models/application_push_notification.rb
+++ b/saas/app/models/application_push_notification.rb
@@ -1,4 +1,26 @@
 class ApplicationPushNotification < ActionPushNative::Notification
   queue_as :default
-  self.enabled = Fizzy.saas? && (!Rails.env.local? || ENV["ENABLE_NATIVE_PUSH"] == "true")
+
+  class << self
+    # Native push runs only where APNs/FCM credentials are provisioned: production
+    # and beta. Staging is deliberately unprovisioned, so it enqueues no-op jobs.
+    # ENABLE_NATIVE_PUSH=true is the escape hatch for development (via exe/push-dev)
+    # or any environment that gets credentials later.
+    def enable?
+      Fizzy.saas? && (Rails.env.production? || Rails.env.beta? || ENV["ENABLE_NATIVE_PUSH"] == "true")
+    end
+
+    def verify_credentials!
+      config = ActionPushNative.config
+
+      { "APNS_KEY_ID" => config.dig(:apple, :key_id),
+        "APNS_ENCRYPTION_KEY_B64" => config.dig(:apple, :encryption_key),
+        "FCM_ENCRYPTION_KEY_B64" => config.dig(:google, :encryption_key) }.each do |env_var, value|
+        raise "Native push is enabled but #{env_var} is not set" if value.blank?
+      end
+    end
+  end
+
+  self.enabled = enable?
+  verify_credentials! if enabled
 end

--- a/saas/app/models/application_push_notification.rb
+++ b/saas/app/models/application_push_notification.rb
@@ -7,7 +7,7 @@ class ApplicationPushNotification < ActionPushNative::Notification
     # ENABLE_NATIVE_PUSH=true is the escape hatch for development (via exe/push-dev)
     # or any environment that gets credentials later.
     def enable?
-      Fizzy.saas? && (Rails.env.production? || Rails.env.beta? || ENV["ENABLE_NATIVE_PUSH"] == "true")
+      Rails.env.production? || Rails.env.beta? || ENV["ENABLE_NATIVE_PUSH"] == "true"
     end
 
     def verify_credentials!

--- a/saas/exe/push-dev
+++ b/saas/exe/push-dev
@@ -17,19 +17,13 @@ apns_key_id = op_read("APNS_KEY_ID")
 apns_encryption_key_b64 = op_read("APNS_ENCRYPTION_KEY_B64")
 fcm_encryption_key_b64 = op_read("FCM_ENCRYPTION_KEY_B64")
 
-if apns_key_id.empty? || apns_encryption_key_b64.empty?
-  warn "Error: Could not fetch APNs credentials from 1Password"
+if apns_key_id.empty? || apns_encryption_key_b64.empty? || fcm_encryption_key_b64.empty?
+  warn "Error: Could not fetch push credentials from 1Password"
   warn "Make sure you're signed in: op signin --account #{OP_ACCOUNT}"
   exit 1
 end
 
-if fcm_encryption_key_b64.empty?
-  warn "Warning: Could not fetch FCM credentials from 1Password"
-  warn "Android push notifications will not work"
-end
-
 puts %Q(export APNS_KEY_ID="#{apns_key_id}")
-puts %Q(export APNS_TEAM_ID="#{apns_team_id}")
 puts %Q(export APNS_ENCRYPTION_KEY_B64="#{apns_encryption_key_b64}")
 puts %Q(export FCM_ENCRYPTION_KEY_B64="#{fcm_encryption_key_b64}")
 puts %Q(export ENABLE_NATIVE_PUSH="true")
@@ -37,6 +31,6 @@ puts %Q(export ENABLE_NATIVE_PUSH="true")
 warn ""
 warn "Push notification credentials loaded for development"
 warn "  APNs Key ID: #{apns_key_id}"
-warn "  APNs: #{apns_encryption_key_b64.empty? ? "not configured" : "configured"}"
-warn "  FCM: #{fcm_encryption_key_b64.empty? ? "not configured" : "configured"}"
+warn "  APNs: configured"
+warn "  FCM: configured"
 warn "  Native push: enabled"

--- a/saas/test/models/application_push_notification_test.rb
+++ b/saas/test/models/application_push_notification_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class ApplicationPushNotificationTest < ActiveSupport::TestCase
+  CONFIGURED = {
+    apple: { key_id: "ABC123DEF4", encryption_key: "p8-key-material" },
+    google: { encryption_key: "{\"type\":\"service_account\"}" }
+  }.freeze
+
+  setup do
+    # Autoload the class under the real test env before any test stubs
+    # Rails.env, or the class body's boot-time guard fires mid-stub.
+    ApplicationPushNotification
+  end
+
+  test "disabled in test" do
+    assert_not ApplicationPushNotification.enabled
+  end
+
+  test "disabled on staging, where push credentials are deliberately unprovisioned" do
+    with_rails_env "staging" do
+      assert_not ApplicationPushNotification.enable?
+    end
+  end
+
+  test "disabled in development by default" do
+    with_rails_env "development" do
+      assert_not ApplicationPushNotification.enable?
+    end
+  end
+
+  test "enabled on production" do
+    with_rails_env "production" do
+      assert ApplicationPushNotification.enable?
+    end
+  end
+
+  test "enabled on beta" do
+    with_rails_env "beta" do
+      assert ApplicationPushNotification.enable?
+    end
+  end
+
+  test "ENABLE_NATIVE_PUSH=true enables push in otherwise-disabled environments" do
+    with_env "ENABLE_NATIVE_PUSH" => "true" do
+      with_rails_env "staging" do
+        assert ApplicationPushNotification.enable?
+      end
+    end
+  end
+
+  test "verify_credentials! passes when all credentials are present" do
+    ActionPushNative.stubs(:config).returns(CONFIGURED)
+
+    assert_nothing_raised do
+      ApplicationPushNotification.verify_credentials!
+    end
+  end
+
+  test "verify_credentials! names each missing credential" do
+    { "APNS_KEY_ID" => [ :apple, :key_id ],
+      "APNS_ENCRYPTION_KEY_B64" => [ :apple, :encryption_key ],
+      "FCM_ENCRYPTION_KEY_B64" => [ :google, :encryption_key ] }.each do |env_var, (platform, key)|
+      config = { apple: CONFIGURED[:apple].dup, google: CONFIGURED[:google].dup }
+      config[platform][key] = ""
+      ActionPushNative.stubs(:config).returns(config)
+
+      error = assert_raises RuntimeError do
+        ApplicationPushNotification.verify_credentials!
+      end
+      assert_equal "Native push is enabled but #{env_var} is not set", error.message
+    end
+  end
+
+  private
+    def with_rails_env(env)
+      Rails.stubs(:env).returns(ActiveSupport::EnvironmentInquirer.new(env))
+      yield
+    ensure
+      Rails.unstub(:env)
+    end
+
+    def with_env(vars)
+      originals = vars.keys.index_with { |key| ENV[key] }
+      vars.each { |key, value| ENV[key] = value }
+      yield
+    ensure
+      originals.each { |key, value| ENV[key] = value }
+    end
+end


### PR DESCRIPTION
Environments without APNs/FCM secrets provisioned still enabled native push, so every `ApplicationPushNotificationJob` there failed at delivery time with the cryptic errors that come from parsing empty keys: OpenSSL `invalid curve name` (APNs) and a googleauth failure (FCM).

## Changes

- **Enable push by allowlist**: `production` and `beta` — the environments that actually have credentials — with `ENABLE_NATIVE_PUSH=true` as the escape hatch for development or a later-provisioned environment. Unprovisioned environments (e.g. staging) now enqueue jobs that no-op via the gem's `enabled` gate, so already-failed jobs succeed on retry after deploy.
- **Fail fast at boot**: when push is enabled, verify all three credentials (`APNS_KEY_ID`, `APNS_ENCRYPTION_KEY_B64`, `FCM_ENCRYPTION_KEY_B64`) at class load, raising a named error per missing variable instead of failing per-job with the curve error.
- **Consistent all-or-nothing credential contract** (matching the gem's single `enabled` flag): `saas/exe/push-dev` treats missing FCM as fatal instead of a warning, and `bin/dev --push` checks FCM alongside the APNs vars.
- **Fix `saas/exe/push-dev` NameError**: drop the `apns_team_id` reference orphaned by 9c165e1e8 — it killed the whole script before it printed anything. `push.yml` already defaults `team_id`.
- **Regression tests** for the policy (disabled in test/staging/dev, enabled in production/beta, override) and the guard (passes on full config, named error per missing credential). The tests force the class to autoload under the real test env before stubbing `Rails.env`, since the boot guard runs in the class body.

## Verification

- `SAAS=1 bin/rails test saas/test/models/application_push_notification_test.rb saas/test/models/notification/push_target/native_test.rb` — 29 tests green, stable across seeds.
- `SAAS=1 bin/rails runner 'puts ApplicationPushNotification.enabled'` → `false`; with `ENABLE_NATIVE_PUSH=true` and no credentials → raises `Native push is enabled but APNS_KEY_ID is not set` at boot.
- `RAILS_ENV=production SAAS=1` asset precompile (the `saas/Dockerfile` seam, which runs without push secrets) still completes: the guard runs at class load and `rake_eager_load` is false, so precompile never loads app models.