### PR TITLE
Restore toolchain resolution in nested shells

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -97,6 +97,19 @@ EOF
   exit 1
 }
 
+# `mise exec` does not prepend its tool directories unconditionally: when the shims
+# directory is already on PATH it substitutes the install dirs at that entry's position.
+# A login profile puts shims ahead of /usr/bin; an agent session's PATH does not, and the
+# hook then lints against /usr/bin/ruby while reporting plausible paths. Declaring the
+# shims directory here makes resolution independent of inherited ordering.
+#
+# Precedence mirrors mise's own, so a customised store is still honoured. bin/bcenv covered
+# this by sourcing a login profile; this replaces that, and is why the hook no longer
+# depends on what the caller's PATH happened to look like.
+mise_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
+PATH="$mise_shims:$PATH"
+export PATH
+
 # `mise exec` rather than bare `prek`: shims alone resolve the toolchain but do
 # not export the project's [env] table, which is what bcenv silently lost.
 exec "$mise" exec -- prek run

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -297,6 +297,14 @@ assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_p
 # leave `mise which ruby` unresolved, or the probe is proving nothing. mise also
 # distinguishes "Setting [x] is not set" (known, unset) from "Unknown setting:
 # x"; only the second means mise does not read it.
+#
+# The honest limit of this list: it is bounded by measurement, not enumerated
+# from mise. `mise settings --all` does not report the path settings at all --
+# not data_dir, not installs_dir, not shared_install_dirs -- so there is no
+# authoritative set to copy, and a variable nobody thought to probe would be
+# missed the same way. A miss shows up as this scenario failing a working hook
+# under a store override, never as a false pass: the assertion compares the
+# hook's resolution against mise's own, so the two disagreeing is the symptom.
 echo "agent session (shims ordered below /usr/bin):"
 agent_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
 agent_path="/usr/bin:/bin:$agent_shims:/usr/sbin:/sbin"

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -13,23 +13,24 @@
 # the file -- so the "test harness interpreter" section re-runs line 1 against
 # both.
 #
-# Git runs that hook two ways: from a terminal, where a login profile has
-# already built PATH, and from a GUI client (Tower, Fork, GitHub Desktop) with
-# a bare launchd/systemd environment and no profile. Both must resolve this
-# project's mise-managed toolchain and export its [env].
+# Git runs that hook three ways: from a terminal, where a login profile has
+# already built PATH; from a GUI client (Tower, Fork, GitHub Desktop) with a
+# bare launchd/systemd environment and no profile; and from an agent session --
+# Claude Code, Codex and opencode are provisioned fleet-wide -- whose PATH
+# orders mise's shims BELOW /usr/bin. All three must resolve this project's
+# mise-managed toolchain and export its [env].
+#
+# That third one is why the hook declares the shims directory itself. `mise
+# exec` substitutes its install dirs at the shims entry's position, so shims
+# ordered below /usr/bin silently resolve /usr/bin/ruby. An earlier revision of
+# this file recorded the opposite -- that shipyard "already orders ~/.local/bin
+# and mise's shims above /usr/bin, so `mise exec` resolves the toolchain
+# unaided" -- and dropped the shims handling as unnecessary. A login shell does
+# order them that way; an agent session does not, and on that premise the hook
+# shipped resolving the wrong ruby. The third scenario below is what now holds
+# the premise to account.
 #
 # Run it directly:  ./test/prek-hook-test
-#
-# Git also runs it from an agent session -- Claude Code, Codex and opencode are
-# provisioned fleet-wide -- whose PATH orders mise's shims BELOW /usr/bin.
-# `mise exec` substitutes its install dirs at the shims entry's position, so
-# that ordering silently resolves /usr/bin/ruby. An earlier revision of this
-# file recorded the opposite, that shipyard "already orders ~/.local/bin and
-# mise's shims above /usr/bin, so `mise exec` resolves the toolchain unaided",
-# and dropped the shims handling as unnecessary. A login shell does order them
-# that way; an agent session does not, and it was on that premise that the hook
-# shipped resolving the wrong ruby. The hook now declares the shims directory
-# itself, and the third scenario below is what holds that premise to account.
 #
 # Deliberately small, but not empty. A GUI launch runs no login profile, so
 # nothing orders coexisting mise installations for it -- the hook picks by

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -230,7 +230,7 @@ echo "terminal launch (login profile applied):"
 # and rebuilding bcenv's multi-shell matrix to read four variables is not worth
 # it -- fish and anything else fall back to the environment this process
 # inherited, which is itself a terminal's.
-_mise_dirs='MISE_SHIMS_DIR MISE_INSTALLS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
+_mise_dirs='MISE_SHIMS_DIR MISE_INSTALLS_DIR MISE_SHARED_INSTALL_DIRS MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
 login_shell=$(dscl . -read "/Users/$(id -un)" UserShell 2>/dev/null | sed 's/^UserShell: *//')
 [ -n "$login_shell" ] || login_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)
 [ -n "$login_shell" ] || login_shell=${SHELL:-}
@@ -282,12 +282,21 @@ assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_p
 #
 # The same $_mise_dirs the terminal scenario harvests, deliberately not a second
 # list: the two exist for one reason -- name the mise configuration the expected
-# values were derived from -- and a copy drifts. MISE_INSTALLS_DIR is in it
-# because this scenario asserts the resolved path, which is an INSTALL path.
-# Measured against `mise which ruby`, exactly two variables relocate the install
-# tree: MISE_INSTALLS_DIR and MISE_DATA_DIR (XDG_DATA_HOME only through the
-# latter's default). Omitting the first resolved the default tree here while
-# expected_ruby_path named the custom one, failing a working hook.
+# values were derived from -- and a copy drifts.
+#
+# The install-tree variables matter here specifically, because this scenario
+# asserts the resolved path and that is an INSTALL path. Three relocate it:
+# MISE_INSTALLS_DIR, MISE_SHARED_INSTALL_DIRS, and MISE_DATA_DIR (XDG_DATA_HOME
+# only through the latter's default). Omitting one resolves the default tree
+# here while expected_ruby_path names the custom one, failing a working hook.
+#
+# Establish that against an EMPTY local store, or the finding hides: a populated
+# local store satisfies the lookup first and masks every fallback behind it.
+# MISE_SHARED_INSTALL_DIRS was missed exactly that way. The check that keeps the
+# method honest is a made-up variable name -- MISE_TOTALLY_MADE_UP_DIRS must
+# leave `mise which ruby` unresolved, or the probe is proving nothing. mise also
+# distinguishes "Setting [x] is not set" (known, unset) from "Unknown setting:
+# x"; only the second means mise does not read it.
 echo "agent session (shims ordered below /usr/bin):"
 agent_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
 agent_path="/usr/bin:/bin:$agent_shims:/usr/sbin:/sbin"

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -212,7 +212,7 @@ echo "terminal launch (login profile applied):"
 # and rebuilding bcenv's multi-shell matrix to read four variables is not worth
 # it -- fish and anything else fall back to the environment this process
 # inherited, which is itself a terminal's.
-_mise_dirs='MISE_SHIMS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
+_mise_dirs='MISE_SHIMS_DIR MISE_INSTALLS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
 login_shell=$(dscl . -read "/Users/$(id -un)" UserShell 2>/dev/null | sed 's/^UserShell: *//')
 [ -n "$login_shell" ] || login_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)
 [ -n "$login_shell" ] || login_shell=${SHELL:-}
@@ -261,11 +261,19 @@ assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_p
 # The store variables are forwarded, not re-derived: this models an agent
 # session, so the hook must resolve the same store the PATH below was built
 # from. __MISE_ORIG_PATH is what a real agent session carries.
+#
+# MISE_INSTALLS_DIR is forwarded because this scenario asserts the resolved
+# path, which is an INSTALL path -- and run_hook rebuilds the environment with
+# `env -i`. Measured against `mise which ruby`, exactly two variables relocate
+# the install tree: MISE_INSTALLS_DIR and MISE_DATA_DIR (XDG_DATA_HOME only
+# through the latter's default). Leaving the first out would resolve the
+# default tree here while expected_ruby_path named the custom one, failing a
+# working hook -- the same defect already fixed for the terminal scenario.
 echo "agent session (shims ordered below /usr/bin):"
 agent_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
 agent_path="/usr/bin:/bin:$agent_shims:/usr/sbin:/sbin"
 agent_env=()
-for _var in MISE_SHIMS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME; do
+for _var in MISE_SHIMS_DIR MISE_INSTALLS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME; do
   eval "_value=\${$_var-}"
   [ -n "$_value" ] && agent_env+=("$_var=$_value")
 done

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -120,6 +120,7 @@ probe="$workdir/probe"
 cat > "$probe" <<'PROBE'
 #!/bin/sh
 printf 'ruby=%s\n' "$(ruby -e 'print RUBY_VERSION' 2>/dev/null || echo NONE)"
+printf 'ruby_path=%s\n' "$(command -v ruby || echo NONE)"
 printf 'MISE_PICK=%s\n' "${MISE_PICK-<UNSET>}"
 for k in $PROBE_ENV_KEYS; do
   eval "printf '%s=%s\n' \"\$k\" \"\${$k-<UNSET>}\""
@@ -151,6 +152,8 @@ run_hook() {
 
 expected_ruby=$(mise exec -- ruby -e 'print RUBY_VERSION' 2>/dev/null)
 [ -n "$expected_ruby" ] || die "could not determine the project's ruby via mise"
+expected_ruby_path=$(mise which ruby 2>/dev/null)
+[ -n "$expected_ruby_path" ] || die "could not determine the project's ruby path via mise"
 
 assert_run() {
   local label=$1 out=$2 k want got
@@ -159,6 +162,26 @@ assert_run() {
     ok "$label: ruby is the project's $expected_ruby"
   else
     no "$label: ruby is the project's $expected_ruby" "got: ${got:-<empty>}"
+  fi
+  # The resolved path, for the agent scenario only. A version comparison cannot
+  # see the ordering bug on Arch, where /usr/bin/ruby is also 3.4.10 -- a broken
+  # hook passes. The path distinguishes them on both platforms.
+  #
+  # Scoped rather than global: expected_ruby_path is derived in the invoking
+  # environment, so it names the invoking environment's store. The GUI scenario
+  # deliberately receives no store variables and therefore resolves the DEFAULT
+  # store, so asserting this everywhere would contradict the GUI model and fail
+  # a working hook whenever the two stores differ. The agent scenario is exempt
+  # because it forwards those variables, so the two agree by construction.
+  # Neither of the others can reach the ordering bug anyway: one has no shims
+  # entry at all, the other harvests an already-ordered PATH.
+  if [ "$label" = agent ]; then
+    got=$(field "$out" ruby_path)
+    if [ "$got" = "$expected_ruby_path" ]; then
+      ok "$label: ruby resolves to $expected_ruby_path"
+    else
+      no "$label: ruby resolves to $expected_ruby_path" "got: ${got:-<empty>}"
+    fi
   fi
   for k in $env_keys; do
     want=$(printf '%s\n' "$env_section" | grep -E "^${k}[[:space:]]*=" | head -1 \
@@ -189,7 +212,7 @@ echo "terminal launch (login profile applied):"
 # and rebuilding bcenv's multi-shell matrix to read four variables is not worth
 # it -- fish and anything else fall back to the environment this process
 # inherited, which is itself a terminal's.
-_mise_dirs='MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
+_mise_dirs='MISE_SHIMS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
 login_shell=$(dscl . -read "/Users/$(id -un)" UserShell 2>/dev/null | sed 's/^UserShell: *//')
 [ -n "$login_shell" ] || login_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)
 [ -n "$login_shell" ] || login_shell=${SHELL:-}
@@ -227,6 +250,28 @@ unset _var _value _line _mise_dirs
 # array under `set -u` is an error.
 assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_probe login)" \
   ${login_store[@]+"${login_store[@]}"})"
+
+# --- an agent session's environment ------------------------------------------
+# Claude Code, Codex and opencode are provisioned fleet-wide, and their PATH
+# orders mise's shims below /usr/bin. `mise exec` substitutes install dirs at
+# the shims entry's position, so inherited ordering -- not the hook -- decided
+# the toolchain. Neither scenario above can catch that: one has no shims entry
+# at all, the other harvests an already-correct order from the login profile.
+#
+# The store variables are forwarded, not re-derived: this models an agent
+# session, so the hook must resolve the same store the PATH below was built
+# from. __MISE_ORIG_PATH is what a real agent session carries.
+echo "agent session (shims ordered below /usr/bin):"
+agent_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
+agent_path="/usr/bin:/bin:$agent_shims:/usr/sbin:/sbin"
+agent_env=()
+for _var in MISE_SHIMS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME; do
+  eval "_value=\${$_var-}"
+  [ -n "$_value" ] && agent_env+=("$_var=$_value")
+done
+unset _var _value
+assert_run agent "$(run_hook "$agent_path" "$(hook_with_probe agent)" \
+  "__MISE_ORIG_PATH=$agent_path" ${agent_env[@]+"${agent_env[@]}"})"
 
 # --- coexisting installations ------------------------------------------------
 # bin/setup upgrades whichever mise it resolved and leaves the rest installed,

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -20,14 +20,21 @@
 #
 # Run it directly:  ./test/prek-hook-test
 #
-# Deliberately small, but not empty. Shims-path canonicalisation and trailing-
-# slash handling were dropped once the real environment was measured: shipyard
-# already orders ~/.local/bin and mise's shims above /usr/bin, so `mise exec`
-# resolves the toolchain unaided. What stayed is the part measurement justified.
-# A GUI launch runs no login profile, so nothing orders coexisting mise
-# installations for it -- the hook picks by version floor instead, and refuses
-# to let a prerelease satisfy the stable floor it precedes. Both are exercised
-# below.
+# Git also runs it from an agent session -- Claude Code, Codex and opencode are
+# provisioned fleet-wide -- whose PATH orders mise's shims BELOW /usr/bin.
+# `mise exec` substitutes its install dirs at the shims entry's position, so
+# that ordering silently resolves /usr/bin/ruby. An earlier revision of this
+# file recorded the opposite, that shipyard "already orders ~/.local/bin and
+# mise's shims above /usr/bin, so `mise exec` resolves the toolchain unaided",
+# and dropped the shims handling as unnecessary. A login shell does order them
+# that way; an agent session does not, and it was on that premise that the hook
+# shipped resolving the wrong ruby. The hook now declares the shims directory
+# itself, and the third scenario below is what holds that premise to account.
+#
+# Deliberately small, but not empty. A GUI launch runs no login profile, so
+# nothing orders coexisting mise installations for it -- the hook picks by
+# version floor instead, and refuses to let a prerelease satisfy the stable
+# floor it precedes. Both are exercised below.
 
 set -uo pipefail
 
@@ -245,7 +252,7 @@ else
   _from="inherited environment (login shell ${login_shell:-unknown} not reconstructable)"
 fi
 echo "  environment from: $_from"
-unset _var _value _line _mise_dirs
+unset _var _value _line
 # ${login_store[@]+...} because macOS ships bash 3.2, where expanding an empty
 # array under `set -u` is an error.
 assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_probe login)" \
@@ -262,22 +269,23 @@ assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_p
 # session, so the hook must resolve the same store the PATH below was built
 # from. __MISE_ORIG_PATH is what a real agent session carries.
 #
-# MISE_INSTALLS_DIR is forwarded because this scenario asserts the resolved
-# path, which is an INSTALL path -- and run_hook rebuilds the environment with
-# `env -i`. Measured against `mise which ruby`, exactly two variables relocate
-# the install tree: MISE_INSTALLS_DIR and MISE_DATA_DIR (XDG_DATA_HOME only
-# through the latter's default). Leaving the first out would resolve the
-# default tree here while expected_ruby_path named the custom one, failing a
-# working hook -- the same defect already fixed for the terminal scenario.
+# The same $_mise_dirs the terminal scenario harvests, deliberately not a second
+# list: the two exist for one reason -- name the mise configuration the expected
+# values were derived from -- and a copy drifts. MISE_INSTALLS_DIR is in it
+# because this scenario asserts the resolved path, which is an INSTALL path.
+# Measured against `mise which ruby`, exactly two variables relocate the install
+# tree: MISE_INSTALLS_DIR and MISE_DATA_DIR (XDG_DATA_HOME only through the
+# latter's default). Omitting the first resolved the default tree here while
+# expected_ruby_path named the custom one, failing a working hook.
 echo "agent session (shims ordered below /usr/bin):"
 agent_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
 agent_path="/usr/bin:/bin:$agent_shims:/usr/sbin:/sbin"
 agent_env=()
-for _var in MISE_SHIMS_DIR MISE_INSTALLS_DIR MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME; do
+for _var in $_mise_dirs; do
   eval "_value=\${$_var-}"
   [ -n "$_value" ] && agent_env+=("$_var=$_value")
 done
-unset _var _value
+unset _var _value _mise_dirs
 assert_run agent "$(run_hook "$agent_path" "$(hook_with_probe agent)" \
   "__MISE_ORIG_PATH=$agent_path" ${agent_env[@]+"${agent_env[@]}"})"
 

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -158,6 +158,16 @@ run_hook() {
     ${1+"$@"} PATH="$path" "$hook" 2>&1
 }
 
+# Ground truth, and it cannot be poisoned by the ordering these scenarios test,
+# which is worth saying because it looks like it could be: this runs in the
+# invoking environment, and that may itself be an agent shell with shims below
+# /usr/bin. The distinction is what mise is asked to resolve. `mise exec -- ruby`
+# and `mise which ruby` name a TOOL, which mise resolves from its own registry;
+# both return the project's ruby even with a decoy ruby ahead of the shims entry
+# on PATH. `mise exec -- <script>` -- what the hook does, and how prek reaches
+# bin/rubocop's `#!/usr/bin/env ruby` -- only hands the script a PATH, and that
+# PATH is where the substitution bites. Measured both ways against a fake ruby
+# placed first: the tool form returned 3.4.10, the script form ran the fake.
 expected_ruby=$(mise exec -- ruby -e 'print RUBY_VERSION' 2>/dev/null)
 [ -n "$expected_ruby" ] || die "could not determine the project's ruby via mise"
 expected_ruby_path=$(mise which ruby 2>/dev/null)


### PR DESCRIPTION
`git commit` from an agent session resolves the wrong ruby. The hook lints against
system ruby 2.6.10 instead of the project's 3.4.10, and says nothing — it reports
plausible paths throughout. Live on all five default branches since bcenv was retired,
and what drove the `-n` bypass on bc3 master (`d0edc1283b`). Reproduced independently in
both Claude Code and Codex sessions.

**Independently hit again during this review**, by an unrelated agent session working in a
different bc3 worktree — reported as "prek rubocop hook is broken repo-wide, pre-existing",
surfacing as `You must use Bundler 4 or greater with this lockfile` (system Ruby 2.6's
bundled Bundler, rather than the traceback seen elsewhere), and worked around with
`--no-verify` after running `bin/rubocop` by hand. Reproduced in *that* worktree: the
current hook fails there with exactly that message, and this branch's hook reports
`rubocop … Passed`. Their observation that `mise exec -- ruby -v` prints 3.4.10 in the same
shell where the hook still fails is the tool-vs-script distinction described below.

## Mechanism

`mise exec` does not prepend its tool directories unconditionally. When the shims
directory is already on the inherited PATH it substitutes the install dirs **at that
entry's position**, so inherited ordering — not the hook — decides the toolchain:

| PATH handed to `mise exec` | installs land | result |
|---|---|---|
| shims ahead of `/usr/bin` | ahead | project ruby ✓ |
| `/usr/bin` ahead of shims | behind | **system ruby** ✗ |
| shims absent entirely | prepended | project ruby ✓ |

A shipyard login shell puts shims first. An agent harness PATH puts `/usr/bin` at ~#12
and shims at ~#25. All five `bin/rubocop` are `#!/usr/bin/env ruby`, so the nested PATH
picks the interpreter directly. `bin/bcenv` was immune because it re-derived PATH from
the login profile rather than inheriting it; retiring it removed that protection.

Arch is not affected — shims #1, `/usr/bin` #4 in both login and non-login shells — so
this is macOS-agent-shell exposure today. The fix is ordering-independence, which is the
property worth having everywhere.

**This is not a new idea, and that matters.** Pre-merge revisions carried exactly this
fix and it was retired as *unnecessary*, on the finding that the broken ordering was "an
artifact of a nested agent shell rather than a fleet condition". That premise is now
false: shipyard provisions Claude Code, Codex and opencode on every machine, so the
nested agent shell **is** the fleet condition.

## Prepend rather than drop — decided on evidence

The retired code *removed* the shims entry. That works, but needs canonical path
comparison: a trailing-slash spelling defeats an exact-string filter and mise then
behaves as if nothing was removed (measured: `/usr/bin:$shims/:/bin` → `/usr/bin/ruby`).
That comparison was a ~20-line `physical()` helper, itself refined twice for its own
bugs. Prepending needs no equality logic and fixes every case that defeats dropping —
trailing slash, exact-but-late, shims absent, shims already first. The precedence chain
mirrors mise's own, so a customised store is still honoured; checked against
`mise doctor` for default storage, `MISE_DATA_DIR`, `XDG_DATA_HOME`, `MISE_SHIMS_DIR`,
and overlapping overrides.

## Why the suite passed 14/14 against a broken hook

Neither existing scenario can reach the bug: the GUI one builds a shims-free PATH, and
the terminal one harvests an already-ordered PATH from the login profile. So a third
scenario models an agent session, ordering shims below `/usr/bin`. It forwards its own
store variables rather than re-deriving them, because `run_hook` rebuilds the environment
with `env -i` — the same defect already found and fixed for the terminal scenario — and
carries `__MISE_ORIG_PATH` as a real agent session does. `MISE_SHIMS_DIR` joins the
terminal harvest, since hook behaviour now depends on it.

That scenario also asserts the **resolved path**, not just the version. A version
comparison cannot detect this bug on Arch at all, where `/usr/bin/ruby` is *also* 3.4.10
and a broken hook passes:

| | resolved ruby | version |
|---|---|---|
| Arch, broken ordering | `/usr/bin/ruby` | 3.4.10 |
| Arch, fixed | `…/mise/installs/ruby/3.4.10/bin/ruby` | 3.4.10 |
| macOS, broken ordering | `/usr/bin/ruby` | 2.6.10 |

The assertion is scoped to the agent scenario deliberately, not for tidiness. The
expected path is derived in the invoking environment, so it names the invoking
environment's store, while the GUI scenario deliberately receives no store variables and
resolves the *default* one. Applying it globally would contradict the GUI model and fail
a working hook.

## Verification

1. `shellcheck .githooks/pre-commit test/prek-hook-test` clean in all five.
2. Suite green on macOS **and** Arch at this exact head. `sha256` of both files identical
   across all five repos: hook `f7ed8a4b…`, test `2f22d3e5…`.
3. **Negative control on both platforms.** Stripping only the two prepend lines fails the
   agent scenario — on macOS by version *and* path (`2.6.10`, `/usr/bin/ruby`), on Arch by
   **path alone** (`/usr/bin/ruby` vs `mise which ruby`, both 3.4.10). The Arch run is the
   evidence that a version-only assertion would have been decorative there.
4. End-to-end in a real agent shell (`/usr/bin` #22, shims #35), final `exec` swapped for
   a probe: before, `2.6.10` at `/usr/bin/ruby`; after, `3.4.10` at
   `~/.local/share/mise/installs/ruby/3.4.10/bin/ruby`, matching `mise which ruby`.
   Then the unmodified hook, with a real Ruby file staged so `rubocop` actually runs —
   the pre-fix hook dies inside
   `/System/Library/Frameworks/Ruby.framework/Versions/2.6/.../bundler.rb` and exits 1;
   this one reports `rubocop … Passed` and exits 0. That is the failure the `-n` bypass
   was working around.
5. Inert where behaviour was already correct — clean login shell and bare GUI environment
   byte-identical before and after, on both platforms; plus Arch's native shims-first
   ordering.
6. Whole suite run with `MISE_DATA_DIR` pointed at an **empty store**: 17/17, with the
   agent scenario resolving out of that empty store and GUI/terminal out of the default
   one — confirming the path assertion did not leak past the agent scenario.

Assertion count goes 14 → 17 here (20 in launchpad, which has a second `[env]` key).

## From review

Four Codex rounds. Two real bugs, both in the test harness, both with the same shape:
the agent scenario asserts an **install** path, and `run_hook` rebuilds the environment
with `env -i`, so any store variable it fails to forward makes the harness name one store
while the hook derives another — failing a *working* hook.

- **`MISE_INSTALLS_DIR`** was not forwarded. Fixed, with its own negative control against
  a populated custom tree: 16/17 without, 17/17 with.
- **`MISE_SHARED_INSTALL_DIRS`** was not forwarded either. Fixed. Codex raised this, I
  rebutted it wrongly, and it re-raised it with the flaw in my method named exactly —
  I had measured against a *populated* local store, which satisfies the lookup first and
  masks every fallback behind it. I also misread mise's own signal: it distinguishes
  `Setting [x] is not set` (known, unset) from `Unknown setting: x`, and I read the first
  as the second, inverting the one probe that pointed the right way.

Re-bounded properly — empty local store, plus a made-up variable name as a control that
must *fail* to resolve — **three** variables relocate the install tree:
`MISE_INSTALLS_DIR`, `MISE_SHARED_INSTALL_DIRS`, `MISE_DATA_DIR` (`XDG_DATA_HOME` only via
the latter's default). `MISE_SHIMS_DIR`, `MISE_STATE_DIR`, `XDG_STATE_HOME`,
`MISE_CACHE_DIR`, `MISE_CONFIG_DIR`, `MISE_DOWNLOADS_DIR` do not. All three are forwarded,
and the method — including that a populated local store hides the result — is recorded in
the file, because the comment that stood there asserted "exactly two".

Control for the second fix, in a shared-store-only configuration: without the forward the
agent scenario fails 16/17, expecting the shared binary and getting a locally
auto-installed one; with it, 17/17 resolving the shared path. The passing run must start
from a pristine store, or it passes off the copy the failing run created — the same
masking again. Confirmed honoured on both platforms and both fleet mise versions.

One round was a genuine rebuttal: whether `expected_ruby` could itself pick up the system
ruby, since it is derived in the invoking environment. It cannot — `mise exec -- ruby` and
`mise which ruby` name a **tool**, which mise resolves from its own registry, while
`mise exec -- <script>` only hands the script a PATH. The second form is the hook's,
because prek reaches `bin/rubocop`, which is `#!/usr/bin/env ruby`; that *is* the
mechanism. Measured with a decoy `ruby` placed ahead of everything: tool form `3.4.10`,
script form ran the decoy. The finding does not hold, but nothing in the file said why, so
the distinction now sits beside the ground-truth lines.
