### PR TITLE
Set client-side DB connection timeouts

### DIFF
--- a/saas/config/database.yml
+++ b/saas/config/database.yml
@@ -21,6 +21,11 @@ default: &default
   port: <%= ENV.fetch "FIZZY_DB_PORT", 3306 %>
   pool: 50
   timeout: 5000
+  <% unless ENV["MIGRATE"].present? %>
+  connect_timeout: 5
+  read_timeout: 15
+  write_timeout: 15
+  <% end %>
   variables:
     transaction_isolation: READ-COMMITTED
     max_execution_time: <%= max_execution_time_ms %>
@@ -112,6 +117,11 @@ production: &production
     username: <%= mysql_app_user %>
     password: <%= mysql_app_password %>
     migrations_paths: db/cache_migrate
+    <% unless ENV["MIGRATE"].present? %>
+    connect_timeout: 1
+    read_timeout: 1
+    write_timeout: 1
+    <% end %>
   saas:
     <<: *default
     database: fizzy_saas_production


### PR DESCRIPTION
## Why

The df-iad latency RCA (card 9920846083) found our trilogy connections run with **no wire timeouts at all** — no `connect_timeout`, no `read_timeout`/`write_timeout`; `TCPSocket.new` receives `connect_timeout: nil`. A stalled connect or read hangs the client indefinitely. During the thread-pool starvation episodes this surfaced as multi-second request hangs and 17s CLI waits instead of fast failures + clean retries.

## What (sibling-app convention: bc3, haystack)

| Tier | connect | read | write | Rationale |
|---|---|---|---|---|
| primary/replica/cable/queue/saas | 5s | 15s | 15s | app user runs `max_execution_time=5000` server-side, so 15s has ample margin — trips only on a genuinely wedged connection |
| cache (Solid Cache) | 1s | 1s | 1s | matches bc3/haystack cache tier: fail fast, degrade to a cache miss |
| `MIGRATE=1` | — | — | — | untimed, mirroring haystack's migration exemption (alter user, unlimited `max_execution_time`, DDL legitimately blocks the wire) |

## Verification

Rendered the ERB in both modes: timeouts present across production/beta/staging normally (primary 5/15/15, cache 1/1/1), absent under `MIGRATE=1`. Trilogy supports all three options natively (verified in the C ext).