### PR TITLE
Let the agent hook scenario inherit its environment; write down what mise does

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -97,8 +97,23 @@ EOF
   exit 1
 }
 
-# `mise exec` does not prepend its tool directories unconditionally: when the shims
-# directory is already on PATH it substitutes the install dirs at that entry's position.
+# `mise exec` does not prepend its tool directories unconditionally. It strips the
+# install directories it recognises out of the inherited PATH, then inserts the
+# resolved ones immediately BEFORE the shims entry -- keeping that entry -- or
+# prepends them when there is no shims entry at all. Ask it directly, rather than
+# inferring it from which binary won, and the rewrite is plain (measured on 2026.7.10,
+# the floor above, and on 2026.7.16):
+#
+#   in   /usr/bin:$shims:/bin                  out  /usr/bin:<installs>:$shims:/bin
+#   in   $installs/ruby/4/bin:/usr/bin:$shims  out  /usr/bin:<installs>:$shims
+#   in   /usr/bin:/bin                         out  <installs>:/usr/bin:/bin
+#   in   $decoy:/usr/bin:$shims                out  $decoy:/usr/bin:<installs>:$shims
+#
+# Row 2 is the counterintuitive one, and it is why a globally activated
+# installs/ruby/4/bin can sit nine places ahead of /usr/bin and still lose to it: mise
+# strips that entry, then re-lands the toolchain at the shims position, which is behind
+# /usr/bin. Foreign entries -- row 4 -- are never touched.
+#
 # A login profile puts shims ahead of /usr/bin; an agent session's PATH does not, and the
 # hook then lints against /usr/bin/ruby while reporting plausible paths. Declaring the
 # shims directory here makes resolution independent of inherited ordering.

--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -21,8 +21,13 @@
 # mise-managed toolchain and export its [env].
 #
 # That third one is why the hook declares the shims directory itself. `mise
-# exec` substitutes its install dirs at the shims entry's position, so shims
-# ordered below /usr/bin silently resolve /usr/bin/ruby. An earlier revision of
+# exec` strips the install directories it recognises out of the inherited PATH,
+# then inserts the resolved ones immediately BEFORE the shims entry, keeping
+# that entry -- or prepends them when there is no shims entry at all. So shims
+# ordered below /usr/bin silently resolve /usr/bin/ruby, and a globally
+# activated installs/ruby/4/bin nine places AHEAD of /usr/bin loses to it too,
+# because mise strips that entry and re-lands the toolchain at the shims
+# position. Foreign entries are never touched. An earlier revision of
 # this file recorded the opposite -- that shipyard "already orders ~/.local/bin
 # and mise's shims above /usr/bin, so `mise exec` resolves the toolchain
 # unaided" -- and dropped the shims handling as unnecessary. A login shell does
@@ -158,6 +163,66 @@ run_hook() {
     ${1+"$@"} PATH="$path" "$hook" 2>&1
 }
 
+# The agent scenario inherits the invoking environment rather than rebuilding it.
+# An agent session does inherit the developer's environment, so this models one
+# directly -- and it is why no store variables are forwarded: expected_ruby_path
+# is derived in this same environment, so the two agree by construction, under
+# any store configuration. The forwarded list this replaces had to name every
+# variable that can relocate mise's install tree, and twice did not.
+#
+# It could not have been completed even in principle, which is the real argument
+# for deleting it rather than extending it a third time. shared_install_dirs is
+# a genuine mise SETTING, so a config FILE relocates the install tree just as an
+# environment variable does -- and the list named no config-dir variable at all.
+# Measured: with MISE_CONFIG_DIR pointing at a config declaring
+# shared_install_dirs, the old harness failed a working hook and this one
+# passes. (data_dir, shims_dir and installs_dir are environment-only by
+# contrast: `mise settings get` calls them "Unknown setting", not merely unset,
+# and a config file setting them is ignored with a warning.)
+#
+# Three overrides and two removals. PATH is the thing under test.
+# __MISE_ORIG_PATH is what a real agent session carries, and must describe the
+# PATH we are supplying, not the one we inherited -- so __MISE_DIFF, which
+# describes the inherited PATH, is dropped as incoherent with it.
+#
+# The [env] keys are unset because this environment may already carry them: a
+# mise-activated project shell exports PROMETHEUS_EXPORTER_URL, and running the
+# suite that way is normal. Inheriting them would let the [env] assertions pass
+# on ambient state instead of on what the hook exported -- decorative exactly
+# the way two assertions in this file already once shipped decorative. The list
+# is $env_keys, read from .mise.toml, so it carries no completeness obligation.
+#
+# Accepted consequence: a genuinely broken developer environment (say
+# MISE_AUTO_INSTALL=0) now surfaces here. That is fidelity, not flakiness --
+# their actual hook would fail the same way.
+# The third argument picks how much of mise's activation state to carry:
+#
+#   keep  drop __MISE_DIFF only. The faithful model -- a real agent session
+#         inherits a shell that mise activated, so it does carry the rest.
+#   bare  also drop __MISE_SESSION, MISE_SHELL and __MISE_EXE.
+#
+# Both are exercised, because neither is obviously the right one. `keep` leaves a
+# combination no real shell produces (activated, but with the PATH delta removed)
+# out of undocumented mise internals; `bare` is coherent but drifts from the
+# session being modelled. Rather than pick one interpretation and hope, assert
+# the hook resolves correctly under both -- which is the property actually
+# wanted, and which stays checked if a future mise changes what these mean.
+run_hook_inheriting() {
+  local path=$1 hook=$2 activation=${3:-keep} k
+  local scrub=()
+  for k in $env_keys; do scrub+=(-u "$k"); done
+  case $activation in
+    keep) ;;
+    bare) scrub+=(-u __MISE_SESSION -u MISE_SHELL -u __MISE_EXE) ;;
+    *) die "run_hook_inheriting: unknown activation mode '$activation'" ;;
+  esac
+  # ${scrub[@]+...} for the same bash 3.2 reason as $login_store below, even
+  # though $env_keys is fatal-if-empty above and so this array never is.
+  env ${scrub[@]+"${scrub[@]}"} -u __MISE_DIFF \
+    PATH="$path" __MISE_ORIG_PATH="$path" PROBE_ENV_KEYS="$env_keys" \
+    "$hook" 2>&1
+}
+
 # Ground truth, and it cannot be poisoned by the ordering these scenarios test,
 # which is worth saying because it looks like it could be: this runs in the
 # invoking environment, and that may itself be an agent shell with shims below
@@ -181,26 +246,31 @@ assert_run() {
   else
     no "$label: ruby is the project's $expected_ruby" "got: ${got:-<empty>}"
   fi
-  # The resolved path, for the agent scenario only. A version comparison cannot
-  # see the ordering bug on Arch, where /usr/bin/ruby is also 3.4.10 -- a broken
-  # hook passes. The path distinguishes them on both platforms.
+  # The resolved path, for the two inheriting scenarios only. A version
+  # comparison cannot see the ordering bug on Arch, where /usr/bin/ruby is also
+  # 3.4.10 -- a broken hook passes. The path distinguishes them on both
+  # platforms.
   #
   # Scoped rather than global: expected_ruby_path is derived in the invoking
   # environment, so it names the invoking environment's store. The GUI scenario
   # deliberately receives no store variables and therefore resolves the DEFAULT
   # store, so asserting this everywhere would contradict the GUI model and fail
-  # a working hook whenever the two stores differ. The agent scenario is exempt
-  # because it forwards those variables, so the two agree by construction.
-  # Neither of the others can reach the ordering bug anyway: one has no shims
-  # entry at all, the other harvests an already-ordered PATH.
-  if [ "$label" = agent ]; then
-    got=$(field "$out" ruby_path)
-    if [ "$got" = "$expected_ruby_path" ]; then
-      ok "$label: ruby resolves to $expected_ruby_path"
-    else
-      no "$label: ruby resolves to $expected_ruby_path" "got: ${got:-<empty>}"
-    fi
-  fi
+  # a working hook whenever the two stores differ. The agent and decoy scenarios
+  # are exempt -- in either activation mode -- because they inherit that
+  # environment wholesale, so the two agree by
+  # construction under any store configuration. Neither of the others can reach
+  # the ordering bug anyway: one has no shims entry at all, the other harvests
+  # an already-ordered PATH.
+  case $label in
+    agent* | decoy*)
+      got=$(field "$out" ruby_path)
+      if [ "$got" = "$expected_ruby_path" ]; then
+        ok "$label: ruby resolves to $expected_ruby_path"
+      else
+        no "$label: ruby resolves to $expected_ruby_path" "got: ${got:-<empty>}"
+      fi
+      ;;
+  esac
   for k in $env_keys; do
     want=$(printf '%s\n' "$env_section" | grep -E "^${k}[[:space:]]*=" | head -1 \
       | sed 's/^[^=]*=[[:space:]]*//; s/^"//; s/"$//')
@@ -230,6 +300,15 @@ echo "terminal launch (login profile applied):"
 # and rebuilding bcenv's multi-shell matrix to read four variables is not worth
 # it -- fish and anything else fall back to the environment this process
 # inherited, which is itself a terminal's.
+#
+# What $_mise_dirs is for, now that it serves only this scenario: model the
+# developer's store faithfully, so the terminal case exercises their actual
+# configuration rather than a default one they do not run. It names the store,
+# install-tree and state variables a login profile can set. It carries no
+# completeness obligation -- a variable missing from it means this scenario
+# models a slightly plainer store than the developer's, not that an assertion
+# goes wrong. (It once carried one, when the agent scenario forwarded the same
+# list into an `env -i`; that scenario now inherits the environment instead.)
 _mise_dirs='MISE_SHIMS_DIR MISE_INSTALLS_DIR MISE_SHARED_INSTALL_DIRS MISE_DATA_DIR XDG_DATA_HOME MISE_STATE_DIR XDG_STATE_HOME'
 login_shell=$(dscl . -read "/Users/$(id -un)" UserShell 2>/dev/null | sed 's/^UserShell: *//')
 [ -n "$login_shell" ] || login_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)
@@ -263,7 +342,7 @@ else
   _from="inherited environment (login shell ${login_shell:-unknown} not reconstructable)"
 fi
 echo "  environment from: $_from"
-unset _var _value _line
+unset _var _value _line _mise_dirs
 # ${login_store[@]+...} because macOS ships bash 3.2, where expanding an empty
 # array under `set -u` is an error.
 assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_probe login)" \
@@ -276,46 +355,90 @@ assert_run terminal "$(run_hook "${login_path:-$_inherited_path}" "$(hook_with_p
 # the toolchain. Neither scenario above can catch that: one has no shims entry
 # at all, the other harvests an already-correct order from the login profile.
 #
-# The store variables are forwarded, not re-derived: this models an agent
-# session, so the hook must resolve the same store the PATH below was built
-# from. __MISE_ORIG_PATH is what a real agent session carries.
-#
-# The same $_mise_dirs the terminal scenario harvests, deliberately not a second
-# list: the two exist for one reason -- name the mise configuration the expected
-# values were derived from -- and a copy drifts.
-#
-# The install-tree variables matter here specifically, because this scenario
-# asserts the resolved path and that is an INSTALL path. Three relocate it:
-# MISE_INSTALLS_DIR, MISE_SHARED_INSTALL_DIRS, and MISE_DATA_DIR (XDG_DATA_HOME
-# only through the latter's default). Omitting one resolves the default tree
-# here while expected_ruby_path names the custom one, failing a working hook.
-#
-# Establish that against an EMPTY local store, or the finding hides: a populated
-# local store satisfies the lookup first and masks every fallback behind it.
-# MISE_SHARED_INSTALL_DIRS was missed exactly that way. The check that keeps the
-# method honest is a made-up variable name -- MISE_TOTALLY_MADE_UP_DIRS must
-# leave `mise which ruby` unresolved, or the probe is proving nothing. mise also
-# distinguishes "Setting [x] is not set" (known, unset) from "Unknown setting:
-# x"; only the second means mise does not read it.
-#
-# The honest limit of this list: it is bounded by measurement, not enumerated
-# from mise. `mise settings --all` does not report the path settings at all --
-# not data_dir, not installs_dir, not shared_install_dirs -- so there is no
-# authoritative set to copy, and a variable nobody thought to probe would be
-# missed the same way. A miss shows up as this scenario failing a working hook
-# under a store override, never as a false pass: the assertion compares the
-# hook's resolution against mise's own, so the two disagreeing is the symptom.
+# This scenario runs through run_hook_inheriting: no store variables are
+# forwarded, because the environment is inherited whole. agent_shims gets the
+# same benefit incidentally -- it is computed from the invoking environment's
+# variables, and the hook now inherits those same variables, so the modelled
+# PATH and the hook's own derivation agree by construction rather than by
+# matching lists.
 echo "agent session (shims ordered below /usr/bin):"
 agent_shims=${MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims}
 agent_path="/usr/bin:/bin:$agent_shims:/usr/sbin:/sbin"
-agent_env=()
-for _var in $_mise_dirs; do
-  eval "_value=\${$_var-}"
-  [ -n "$_value" ] && agent_env+=("$_var=$_value")
+assert_run agent "$(run_hook_inheriting "$agent_path" "$(hook_with_probe agent)" keep)"
+assert_run agent-bare "$(run_hook_inheriting "$agent_path" "$(hook_with_probe agent-bare)" bare)"
+
+# --- an unrelated ruby earlier on PATH ---------------------------------------
+# A deterministic foreign-ruby fixture. NOT a different mise code path, which is
+# worth stating because it is the obvious thing to claim and it is wrong: the
+# agent scenario already carries a foreign ruby ahead of the shims entry, since
+# /usr/bin/ruby is itself foreign and mise never strips it.
+#
+# What this adds is independence and an unmistakable signal. The agent
+# scenario's competitor is whatever ruby the platform happens to ship at
+# /usr/bin -- 2.6.10 on macOS, 3.4.10 on Arch, and eventually nothing at all,
+# since Apple is removing it; on a host without one that scenario would quietly
+# have nothing left to beat, and would pass whatever the hook did. This one
+# always has a competitor, and it fails as DECOY_RUBY rather than as a version
+# string that might coincide with the project's.
+#
+# Kept separate rather than folded into the agent PATH deliberately: with a
+# decoy winning, a broken hook would fail by version everywhere, and the suite
+# would lose the Arch-specific evidence that it fails there by PATH alone
+# (/usr/bin/ruby is also 3.4.10 on Arch). Both properties are worth holding.
+echo "an unrelated ruby earlier on PATH does not win:"
+decoy="$workdir/decoy"
+mkdir -p "$decoy"
+printf '#!/bin/sh\necho DECOY_RUBY\n' > "$decoy/ruby"
+chmod +x "$decoy/ruby"
+decoy_path="$decoy:$agent_path"
+assert_run decoy "$(run_hook_inheriting "$decoy_path" "$(hook_with_probe decoy)" keep)"
+assert_run decoy-bare "$(run_hook_inheriting "$decoy_path" "$(hook_with_probe decoy-bare)" bare)"
+
+# --- the negative control -----------------------------------------------------
+# Everything above is green, and green proves nothing on its own: it has to be
+# possible for a broken hook to turn it red. That is not a theoretical worry
+# here. This file used to build its scenarios with `env -i`, and twice shipped
+# assertions that could not fail -- `env -i` stripped PWD, so the case under
+# test never ran at all. The scenarios above inherit the environment instead,
+# which trades that hazard for a new one: inherited mise state could
+# reconstitute the install directories and repair a hook that is actually
+# broken, leaving these assertions decorative in exactly the same way.
+#
+# So mutate the hook here, in the suite, rather than trusting a measurement
+# someone once took by hand and wrote in a pull request. Remove the two lines
+# that declare the shims directory -- the fix itself -- and require the decoy
+# scenario to notice. Failure to mutate is fatal, not a skip: a silently
+# unmutated hook would "pass" this control while proving nothing.
+echo "the inheriting scenarios are sensitive to the fix (negative control):"
+mutant="$workdir/hook.mutant-stripped"
+mutant_src=$(hook_with_probe mutant)
+# shellcheck disable=SC2016  # the literal text of the two lines being removed
+grep -v -e '^PATH="\$mise_shims:\$PATH"$' \
+        -e '^mise_shims=\${MISE_SHIMS_DIR' "$mutant_src" > "$mutant"
+chmod +x "$mutant"
+removed=$(( $(wc -l < "$mutant_src") - $(wc -l < "$mutant") ))
+[ "$removed" -eq 2 ] || die "negative control could not mutate the hook: removed $removed lines, expected 2"
+# Assert the decoy POSITIVELY -- name the exact path and the exact version --
+# rather than merely differing from expected_ruby_path. "Not the expected path"
+# is also satisfied by an empty field, which is what an early exit, a failed
+# probe substitution or a mutant that never executed would produce. That is the
+# same liveness hole this control exists to close, and it would close it for the
+# scenarios above while leaving it open here.
+for _mode in keep bare; do
+  out=$(run_hook_inheriting "$decoy_path" "$mutant" "$_mode")
+  got=$(field "$out" ruby_path)
+  want=$(field "$out" ruby)
+  if [ "$got" = "$decoy/ruby" ] && [ "$want" = DECOY_RUBY ]; then
+    ok "$_mode: without the shims prepend the decoy wins"
+  else
+    no "$_mode: without the shims prepend the decoy wins" \
+       "ruby_path: ${got:-<empty>} (want $decoy/ruby)" \
+       "ruby: ${want:-<empty>} (want DECOY_RUBY)" \
+       "if it resolved the project's ruby, inherited state is repairing the break" \
+       "and the decoy assertions above cannot fail"
+  fi
 done
-unset _var _value _mise_dirs
-assert_run agent "$(run_hook "$agent_path" "$(hook_with_probe agent)" \
-  "__MISE_ORIG_PATH=$agent_path" ${agent_env[@]+"${agent_env[@]}"})"
+unset _mode
 
 # --- coexisting installations ------------------------------------------------
 # bin/setup upgrades whichever mise it resolved and leaves the rest installed,


### PR DESCRIPTION
Two follow-ups to the toolchain-resolution fix that landed 2026-07-31. **Neither changes the hook's behaviour** — its 43 executable lines are byte-identical to master; the only hook edit is a comment.

## 1. The agent test scenario inherits its environment, and the forwarding list is deleted

The agent scenario rebuilt its environment under `env -i` and forwarded a hand-maintained list of the `MISE_*` variables that can relocate mise's install tree. `expected_ruby_path` is derived in the *invoking* environment while the probe ran under `env -i`, so any variable missing from that list made the two disagree and failed a working hook.

The list fell behind twice — `MISE_INSTALLS_DIR`, then `MISE_SHARED_INSTALL_DIRS` — and mise publishes no authoritative set to copy: `mise settings --all` reports none of the path settings. The shipped file admitted as much in a comment ("bounded by measurement, not enumerated"). That caveat was the smell: the list defended a boundary that need not exist.

So `run_hook_inheriting()` inherits the invoking environment and overrides only `PATH`, `__MISE_ORIG_PATH` and `PROBE_ENV_KEYS` — which is what an agent session actually does. The two now agree by construction under any store configuration, and both past bugs become structurally impossible rather than individually fixed.

The `[env]` keys are unset, because a mise-activated project shell already exports them and running the suite that way is normal — inheriting them would let those assertions pass on ambient state. That scrub is the one place `env -i`'s hazard is deliberately reintroduced, so it gets its own negative control below.

Both remaining lists are derived from the same source as the thing they serve, so neither can fall behind it:

| list | derived from | serves |
|---|---|---|
| `scrub` (`-u $env_keys`) | `.mise.toml` `[env]` | the `[env]` assertions, read from `.mise.toml` |
| store configuration | inherited wholesale | `expected_ruby_path`, derived in that same environment |

`_mise_dirs` stays, unchanged, for the terminal scenario; its rationale is rewritten, since it was written around the agent scenario's path assertion.

## 2. The mechanism comment understated what mise does

Both files said `mise exec` "substitutes the install dirs at the shims entry's position". That is the visible consequence, not the mechanism. Asked directly (`mise exec -- sh -c 'echo $PATH'`) rather than inferred from which binary won:

| PATH in | PATH mise hands the child | ruby |
|---|---|---|
| `/usr/bin : shims : /bin` | `/usr/bin : «installs» : shims : /bin` | `/usr/bin/ruby` |
| `installs/ruby/4/bin : /usr/bin : shims` | `/usr/bin : «installs» : shims` | `/usr/bin/ruby` |
| `/usr/bin : /bin` | `«installs» : /usr/bin : /bin` | project ruby |
| `decoy : /usr/bin : shims` | `decoy : /usr/bin : «installs» : shims` | **decoy** |

mise **strips the install directories it recognises out of the inherited PATH**, then inserts the resolved ones **immediately before the shims entry — keeping that entry** — or prepends them when there is no shims entry at all. Row 2 is the striking one: the leading `installs/ruby/4/bin` simply vanishes. Row 4 shows foreign entries are never touched.

Measured on mise **2026.7.10** (the project's `min_version` floor) and **2026.7.16**, on both platforms, identically. An earlier draft of this PR said mise removed the *shims* entry too; review caught it and direct measurement settled it.

This is why a globally activated `installs/ruby/4/bin` at **PATH #13**, nine places *ahead* of `/usr/bin` at #22, still lost to `/usr/bin/ruby` — the most counterintuitive fact in the investigation, and exactly the confusion behind "`mise exec -- ruby -v` prints 3.4.10 but the hook still fails". It was written down nowhere. Now it is, in both files.

## 3. A fourth scenario: an unrelated ruby earlier on PATH

A decoy `ruby` ahead of `/usr/bin`, in a PATH otherwise the agent shape. **Not a different mise code path** — I claimed it was, and review was right that it isn't: `/usr/bin/ruby` is already foreign and mise never strips it, so the agent scenario always had a foreign competitor. What the decoy adds is *determinism*. The agent scenario's competitor is whatever ruby the platform happens to ship — 2.6.10 on macOS, 3.4.10 on Arch, and eventually nothing at all, since Apple is removing it; on a host without one that scenario would quietly have nothing left to beat and would pass whatever the hook did. The decoy always has a competitor, and fails as `DECOY_RUBY` rather than as a version string that might coincide with the project's.

Kept as its own scenario rather than folded into the agent PATH: with a decoy winning, a broken hook would fail by *version* everywhere, and the suite would lose the Arch-specific evidence that it fails there by **path alone** (`/usr/bin/ruby` is also 3.4.10 on Arch). Both properties are worth holding.

## 4. Two activation states, and a permanent negative control

Review flagged that dropping `__MISE_DIFF` while keeping `__MISE_SESSION`/`MISE_SHELL`/`__MISE_EXE` leaves a combination no real shell produces, built from undocumented mise internals. Rather than pick one interpretation, `run_hook_inheriting` takes an activation mode and the agent and decoy scenarios each run under both — `keep` (drop `__MISE_DIFF` only, the faithful model) and `bare` (drop all four). The property asserted is that the hook resolves correctly either way, which stays checked if a future mise changes what these mean.

And the negative control is now **in the suite**, not a measurement someone took once by hand: it strips the two shims-prepend lines from the hook and requires the decoy to win — asserted **positively**, by exact path *and* exact version, in *both* activation modes. Positively, because "not the expected path" is also satisfied by an empty field from a mutant that never executed, which is the same liveness hole the control exists to close. Failure to mutate is fatal rather than a skip.

It earned its place twice over: it caught a real bug in itself on the first run (it was writing over its own input file), and review caught the `!=` liveness hole before merge. Sensitivity verified both directions — pointed at the *unmutated* hook it goes red, and with the probe output forced empty it goes red.

This matters because the file has form: `env -i` twice stripped `PWD`, so two shipped assertions could never fail. Inheriting the environment trades that hazard for a new one — inherited mise state repairing a broken hook — and this control is what keeps it honest.

Assertion count 17 → 28 (20 → 34 for launchpad, which has two `[env]` keys).

## 5. The forwarding list could not have been completed even in principle

Found while chasing my own review of this change, and it is the strongest argument for deleting the list rather than extending it a third time. `shared_install_dirs` is a **genuine mise setting**, so a config *file* relocates the install tree exactly as an environment variable does — and the deleted list named no config-dir variable at all. So it had a **third** latent hole waiting.

Demonstrated, same working hook, same environment, a fresh empty local store for each run, with `MISE_CONFIG_DIR` pointing at a config declaring `shared_install_dirs`:

- **old harness** — expected `…/sharedinstalls/ruby/3.4.10/bin/ruby`, got `…/storeX/installs/ruby/3.4.10/bin/ruby` → **fails a working hook**
- **new harness** — expected and got `…/sharedinstalls/ruby/3.4.10/bin/ruby` → **passes**

By contrast `data_dir`, `shims_dir` and `installs_dir` report `Unknown setting` and a config file setting them is ignored with a warning — they are environment-only. (That is the `Unknown setting` vs `Setting [x] is not set` distinction; misreading it once produced a confidently wrong rebuttal.)

## Verification

All on macOS **and** Arch, at this exact head; hook and test `sha256`-identical across all five repos.

1. `shellcheck` clean on both files, all five repos.
2. Suite green: 28/28 (34/34 launchpad), both platforms.
3. **Negative control — the gate for change 1.** Strip only the two prepend lines. The new configuration is one that had never been run: broken hook, *inherited* environment, *modelled* PATH, `__MISE_ORIG_PATH` supplied, `__MISE_DIFF` removed. The hazard was that inherited mise shell state might reconstitute install directories and mask the break. It does not — run from a fully mise-activated shell on both platforms (macOS: `__MISE_DIFF`/`__MISE_SESSION`/`MISE_SHELL` set and 9 install dirs ahead of `/usr/bin`; Arch likewise):
   - macOS — agent fails by version **and** path (`2.6.10`, `/usr/bin/ruby`); decoy fails by both.
   - Arch — agent fails by **path alone** (`/usr/bin/ruby`, also 3.4.10, so the version assertion passes); decoy fails by both.

   All four inheriting scenarios (`agent`, `agent-bare`, `decoy`, `decoy-bare`) fail correctly. This control is now also permanently in the suite — see section 4.
4. **Control that the `[env]` scrub earns its place.** A hook variant execing the probe *bare*, so nothing exports `[env]`, run from a mise-activated shell where `PROMETHEUS_EXPORTER_URL` is already set: (a) with the scrub → `<UNSET>`, the assertion fails; (b) without it → the ambient value, the assertion passes on state the hook never exported. Both platforms. The hazard is real and the scrub blocks it.
5. Whole suite with `MISE_DATA_DIR` at an **empty** store: green, with agent and decoy resolving out of *that* store because they inherit it. Repeated with `MISE_SHARED_INSTALL_DIRS` at a populated store, an empty local store and an empty `MISE_CONFIG_DIR` — the fixture that exposed the second bug: green **with no variable forwarding at all**. Method kept honest with a made-up-name control: `MISE_TOTALLY_MADE_UP_DIRS` leaves `mise which ruby` unresolved.
6. End-to-end in a real agent shell (shims below `/usr/bin`): the hook with its final `exec` swapped for a probe resolves `mise which ruby`, not `/usr/bin/ruby`. Plus the real thing — a staged Ruby file so `rubocop` actually runs: **Passed** under the merged hook; under the stripped one it reproduces the original report exactly, `bin/rubocop`'s `#!/usr/bin/env ruby` landing on 2.6.10 and dying in Bundler.
7. Inert where already correct: the hook's executable content is byte-identical to master, and the GUI and terminal scenarios are unchanged and green on both platforms.

## Note on adoption

Git runs `.githooks/pre-commit` **from the working tree**, so a branch created before 2026-07-31 executes the pre-fix file no matter what master says. The remedy is to pick up master (`git rebase origin/master`), *not* `--no-verify`. The same lag applies to this PR — but it only affects the test suite, which you run from whatever branch you are on.
