### PR TITLE
Force activate_aggressive off for the mutated-hook checks only

### DIFF
--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -424,8 +424,19 @@ removed=$(( $(wc -l < "$mutant_src") - $(wc -l < "$mutant") ))
 # probe substitution or a mutant that never executed would produce. That is the
 # same liveness hole this control exists to close, and it would close it for the
 # scenarios above while leaving it open here.
+#
+# MISE_ACTIVATE_AGGRESSIVE is forced off for the MUTANT invocations only. With it
+# on, `mise exec` prepends the resolved installs to the very front of PATH --
+# ahead of the decoy -- instead of inserting them before the retained shims
+# entry, so it repairs the mutant and this control cannot demonstrate anything.
+# The scenarios above deliberately keep whatever the developer has set, because
+# that is their real session and the hook genuinely does resolve correctly for
+# them either way; it is only the mutation that needs the canonical ordering to
+# be meaningful. Forced to 0 rather than unset: activate_aggressive is a real
+# mise setting, so a config file can turn it on with no variable in the
+# environment at all, and only an explicit 0 overrides that.
 for _mode in keep bare; do
-  out=$(run_hook_inheriting "$decoy_path" "$mutant" "$_mode")
+  out=$(MISE_ACTIVATE_AGGRESSIVE=0 run_hook_inheriting "$decoy_path" "$mutant" "$_mode")
   got=$(field "$out" ruby_path)
   want=$(field "$out" ruby)
   if [ "$got" = "$decoy/ruby" ] && [ "$want" = DECOY_RUBY ]; then


### PR DESCRIPTION
Follow-up to the negative control added in the previous PR. Reported on [queenbee#1513](https://github.com/basecamp/queenbee/pull/1513#discussion_r3696209596). **Test harness only — the production hook is untouched and was never affected.**

## The defect

With `MISE_ACTIVATE_AGGRESSIVE` on, `mise exec` prepends the resolved install dirs to the **very front** of PATH — ahead of the decoy — instead of inserting them before the retained shims entry. Measured:

```
AGGRESSIVE=0   in  decoy:/usr/bin:$shims:/bin   out  decoy:/usr/bin:«installs»:$shims:/bin
AGGRESSIVE=1   in  decoy:/usr/bin:$shims:/bin   out  «installs»:decoy:/usr/bin:$shims:/bin
```

That repairs the *mutated* hook, so the negative control cannot demonstrate sensitivity and correctly goes red. A developer with the setting on sees **26/28 against a completely correct production hook** — a false failure, which is the exact class of harness bug this whole line of work exists to remove.

Confirmed on merged master, both platforms: `AGGRESSIVE=1` → 26/28, `AGGRESSIVE=0` → 28/28.

## The fix

Force `MISE_ACTIVATE_AGGRESSIVE=0` for the **mutated-hook invocations only**.

The real-hook scenarios keep whatever the developer has set. That is their actual session, and the hook genuinely resolves correctly for them either way — under aggressive activation the installs are prepended, which is if anything *more* robust. It is only the mutation that needs the canonical ordering in order to mean anything.

**Forced to `0`, not unset.** `activate_aggressive` is a real mise setting — `mise settings get activate_aggressive` reports it rather than `Unknown setting` — so a config file can turn it on with no variable in the environment at all, and only an explicit `0` overrides that. An `env -u` would have left that case broken.

## Verification

Both platforms, at this exact head; test file `sha256`-identical across all five repos.

1. `shellcheck` clean.
2. Green under every configuration of the setting: variable `=0`, variable `=1`, variable absent, and `activate_aggressive = true` set via a **config file** (the case a bare unset would have missed). 28/28, launchpad 34/34.
3. **The control is still sensitive** — forcing the setting off did not make it vacuous. Pointed at the *unmutated* hook it goes red in both activation modes under both `AGGRESSIVE=0` and `AGGRESSIVE=1`; with the probe output forced empty it goes red too.
4. Pre-fix behaviour reproduced on Arch for the record: merged master's test is 26/28 under `AGGRESSIVE=1`.
