### PR TITLE
Pair the negative control's real and mutant probes under one setting

### DIFF
--- a/test/prek-hook-test
+++ b/test/prek-hook-test
@@ -425,17 +425,35 @@ removed=$(( $(wc -l < "$mutant_src") - $(wc -l < "$mutant") ))
 # same liveness hole this control exists to close, and it would close it for the
 # scenarios above while leaving it open here.
 #
-# MISE_ACTIVATE_AGGRESSIVE is forced off for the MUTANT invocations only. With it
+# MISE_ACTIVATE_AGGRESSIVE is forced off for BOTH halves of this control. With it
 # on, `mise exec` prepends the resolved installs to the very front of PATH --
 # ahead of the decoy -- instead of inserting them before the retained shims
-# entry, so it repairs the mutant and this control cannot demonstrate anything.
-# The scenarios above deliberately keep whatever the developer has set, because
-# that is their real session and the hook genuinely does resolve correctly for
-# them either way; it is only the mutation that needs the canonical ordering to
-# be meaningful. Forced to 0 rather than unset: activate_aggressive is a real
-# mise setting, so a config file can turn it on with no variable in the
-# environment at all, and only an explicit 0 overrides that.
+# entry, so it repairs the mutant and nothing can be demonstrated.
+#
+# Forcing it off for the mutant alone is not enough, and the reason is the whole
+# point of the control. On a machine with the setting on, the scenarios above
+# pass because mise prepends, NOT because the hook's shims prepend works -- they
+# are insensitive to the regression there. A mutant run under a *different*
+# setting than the scenarios it vouches for demonstrates nothing about them: the
+# suite would go green while a developer edited the prepend away, and ship a
+# hook broken for everyone whose activation is not aggressive. So the control
+# runs a REAL-hook probe and a mutant probe under one identical configuration,
+# and requires them to disagree. That is what sensitivity means here.
+#
+# Forced to 0 rather than unset: activate_aggressive is a real mise setting, so a
+# config file can turn it on with no variable in the environment at all, and only
+# an explicit 0 overrides that.
 for _mode in keep bare; do
+  # The real hook, under the same forced setting as the mutant below.
+  out=$(MISE_ACTIVATE_AGGRESSIVE=0 run_hook_inheriting "$decoy_path" "$mutant_src" "$_mode")
+  got=$(field "$out" ruby_path)
+  if [ "$got" = "$expected_ruby_path" ]; then
+    ok "$_mode: with the shims prepend the project's ruby beats the decoy"
+  else
+    no "$_mode: with the shims prepend the project's ruby beats the decoy" \
+       "ruby_path: ${got:-<empty>} (want $expected_ruby_path)" \
+       "the paired mutant check below is meaningless unless this passes"
+  fi
   out=$(MISE_ACTIVATE_AGGRESSIVE=0 run_hook_inheriting "$decoy_path" "$mutant" "$_mode")
   got=$(field "$out" ruby_path)
   want=$(field "$out" ruby)


### PR DESCRIPTION
Follow-up to #12495, which fixed the `activate_aggressive` defect only halfway. **Test harness only — the production hook is untouched.**

## The gap

#12495 forced `activate_aggressive` off for the mutant invocations, but left the scenarios it vouches for running under whatever the developer has set. That is not sensitivity. On a machine with aggressive activation the real probes pass because **mise prepends**, not because the hook's shims prepend works — so a mutant run under a *different* setting demonstrates nothing about them.

**Not theoretical.** Break the prepend without removing either line, so the fail-closed mutation guard still fires:

```sh
mise_shims=${MISE_SHIMS_DIR:-/nonexistent/shims}
```

Then, with `MISE_ACTIVATE_AGGRESSIVE=1`, against that genuinely broken hook — identical on macOS and Arch:

| suite | result |
|---|---|
| as merged (#12495) | **28 passed, 0 failed** |
| this PR | 28 passed, **2 failed** |

A developer with aggressive activation could edit the prepend away, run the suite, see green, and ship a hook broken for everyone whose activation is not aggressive. Since this suite is the contract test for a file that is byte-identical across five repos, that is the failure that matters.

## The fix

Run a real-hook probe and a mutant probe under one identical forced configuration, and require them to disagree. Four assertions instead of two:

```
ok keep: with the shims prepend the project's ruby beats the decoy
ok keep: without the shims prepend the decoy wins
ok bare: with the shims prepend the project's ruby beats the decoy
ok bare: without the shims prepend the decoy wins
```

The subtly-broken hook above now fails the real-hook half, naming it directly.

## Verification

Both platforms, this exact head; test `sha256`-identical across all five repos.

1. `shellcheck` clean.
2. 30/30 (36/36 launchpad) with the variable at `0`, at `1`, absent, and `activate_aggressive = true` via a **config file**.
3. The decisive comparison above, reproduced on macOS and Arch.
4. Outright removal of the two prepend lines still trips the fail-closed mutation guard (`removed 0 lines, expected 2`) rather than passing.
