### PR TITLE
Bump bootsnap to 1.24.6 (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -270,7 +270,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc


### PR DESCRIPTION
Bumps bootsnap 1.24.5 → 1.24.6 in both lockfiles. Lock-only; no `Gemfile` change.

## The defect

`bs_cache_path` in `ext/bootsnap/bootsnap.c` length-checked `cachedir` against `MAX_CACHEDIR_SIZE` (981) but did not account for the `namespace` argument at all, then formatted both into a fixed 1000-byte stack buffer. A long enough namespace overflows it — a stack buffer overflow.

1.24.6 folds the namespace length into the guard, and that one-line change is the whole of it:

```diff
-  if (RSTRING_LEN(cachedir_v) > MAX_CACHEDIR_SIZE) {
+  if (RSTRING_LEN(cachedir_v) + namespace_len > MAX_CACHEDIR_SIZE) {
```

## Why do this deliberately rather than wait

**Nothing would prompt the upgrade on its own.** The 1.24.6 release notes list only an unrelated Ruby 3.4 workaround fix — the overflow fix is not mentioned. There is no `ruby-advisory-db` entry either, so `bin/bundler-audit` is green before and after. An app tracking changelogs or audit output would have no reason to move.

That is the entire argument for landing it as a labelled security bump instead of letting it arrive as routine churn. Concretely: #2937 has proposed this exact version bump since 2026-06-12 and has sat unmerged for ~2 months, because as presented it is indistinguishable from the other nine open Dependabot bumps.

## Exposure in fizzy is low — this is defence in depth

Being accurate rather than alarming: **this is not an active incident.**

- We use bootsnap only via `bootsnap/setup` (`config/boot.rb`) and the `bootsnap precompile` CLI (`Dockerfile`, `saas/Dockerfile`). We never construct a `Compiler` or pass a `namespace` ourselves.
- Every `namespace` call site is bootsnap's own, and each passes a constant or `nil`. Nothing derives it from ENV, config, or request data.
- It becomes reachable only because `attr_accessor :default_compiler` is public, so an application injecting a `Compiler` with a ~960+ byte namespace would reach it.

**Fleet scope: fizzy is the only affected app.** `namespace` arrived in 1.24.0, so bc3 (1.18.6), haystack (1.18.4) and launchpad (1.23.0) are structurally unaffected — their `bs_cache_path` takes no namespace argument — and queenbee ships no bootsnap.

## The diff

Only bootsnap moves, in both locks:

```
 Gemfile.lock      | 2 +-
 Gemfile.saas.lock | 2 +-
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
```

Produced with `bundle update bootsnap --conservative` against each Gemfile, so no unrelated gems move. Note this is strictly narrower than #2937, which also carries an `msgpack` 1.8.1 → 1.8.3 line that `main` has since picked up anyway.

## Verified

- `bin/bundle-drift check` — both lockfiles in sync.
- Full Rails boot: `bin/rails runner` → `Rails 8.2.0.alpha booted; bootsnap 1.24.6`.
- `bundle check` satisfied; `bootsnap/setup` loads via `config/boot.rb`; native extension builds and `Bootsnap::CompileCache::Native` responds.
- `bundler-audit check --update` — no vulnerabilities (as expected; there is no advisory for this).
- Confirmed the fixed guard is present in the installed 1.24.6 extension source.

Not verified: the full test suite, and no deploy-related tasks were run.

## Note on the Gemfile

`gem "bootsnap", require: false` is left unconstrained. Every prior security bump here is lock-only (loofah/rails-html-sanitizer #2981, crass, nokogiri, addressable #2815, rexml), and the `Gemfile` carries no security floors or version-rationale comments today. A `>= 1.24.6` floor would document the intent and stop a future resolution sliding back, but it would be the first of its kind in this file, so I followed the existing convention. Happy to add the floor if reviewers would rather encode it.

Closes #2937.