### PR TITLE
Prefix Action Text attachment URLs with the account slug

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -14,7 +14,7 @@ ActiveSupport.on_load(:action_text_content) do
     # Ensure all <action-text-attachment>s have a "url" attribute that's a relative
     # path (for portability across host name changes, beta environments, etc).
     def to_rich_text_attributes(*)
-      super.merge url: Rails.application.routes.url_helpers.polymorphic_url(self, only_path: true)
+      super.merge url: Rails.application.routes.url_helpers.polymorphic_url(self, only_path: true, script_name: Current.account&.slug)
     end
   end
 end

--- a/test/lib/rails_ext/active_storage_blob_to_rich_text_attributes_test.rb
+++ b/test/lib/rails_ext/active_storage_blob_to_rich_text_attributes_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class ActiveStorageBlobToRichTextAttributesTest < ActiveSupport::TestCase
+  setup do
+    @blob = ActiveStorage::Blob.create_and_upload! io: file_fixture("moon.jpg").open, filename: "moon.jpg", content_type: "image/jpeg"
+  end
+
+  test "url is prefixed with the current account slug" do
+    assert_match %r{\A#{Current.account.slug}/rails/active_storage/blobs/redirect/}, @blob.to_rich_text_attributes[:url]
+  end
+
+  test "url is unprefixed without a current account" do
+    Current.without_account do
+      assert_match %r{\A/rails/active_storage/blobs/redirect/}, @blob.to_rich_text_attributes[:url]
+    end
+  end
+end


### PR DESCRIPTION
Images embedded in rich text were broken in the editor. The `url` attribute on `<action-text-attachment>` had no account slug, so it pointed at `/rails/active_storage/blobs/redirect/…`, which the tenant routing cannot match. This broke in 235890e6 (https://github.com/basecamp/fizzy/pull/2318).

Co-authored by @dilberryhoundog