### PR TITLE
Add a Kamal query alias for read-only database queries

### DIFF
--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -30,4 +30,5 @@ builder:
 
 aliases:
   console: app exec -i --reuse -e CONSOLE_USER:<%= ENV["USER"] %> "bin/rails console"
+  query: 'app exec -q --reuse -p -e CONSOLE_USER:<%= ENV["USER"] %> CLAUDECODE:<%= ENV["CLAUDECODE"] %> CODEX_THREAD_ID:<%= ENV["CODEX_THREAD_ID"] %> "bin/rails query"'
   ssh: app exec -i --reuse -e CONSOLE_USER:<%= ENV["USER"] %> /bin/bash


### PR DESCRIPTION
## What

- Adds a `query` alias to the SaaS Kamal config, exposing Rails 8.2's read-only `rails query` as `bin/kamal query`.

## Why

BC5 and HEY already carry this alias, so tooling that asks production data questions has one command shape across apps — Fizzy was the gap. Nothing else was needed: `configure_replica_connections` already points the reading role, which `rails query` uses by default, at the `replica` config and its `MYSQL_READONLY_USER` credentials.

## Testing

- Rendered the ERB and parsed the YAML: the alias expands to `app exec -q --reuse -p -e CONSOLE_USER:<user> ... "bin/rails query"`.
- Did not run `bin/kamal query` end to end — `bin/kamal` aborts locally in bundler before reaching the network, as `Gemfile.saas` has uninstalled gems. Worth a run against staging before this leaves draft.

---

*Composed with Claude Code (Opus 5)*
