### PR TITLE
Reject vips transformations that dispatch arbitrary libvips operations

### DIFF
--- a/lib/rails_ext/active_storage_vips_transformation_guard.rb
+++ b/lib/rails_ext/active_storage_vips_transformation_guard.rb
@@ -1,35 +1,57 @@
 # Active Storage's ImageMagick transformer enforces ActiveStorage.supported_image_processing_methods,
-# but the vips transformer never reads that allowlist. So CVE-2025-24293's removal of apply, loader,
-# and saver from the allowlist is inert on the vips path we run, and a signed variation key can still
-# carry them.
+# but the vips transformer never reads that allowlist -- ImageMagick#validate_transformation is its
+# only reader in the whole tree, and the base ImageProcessingTransformer#validate_transformation
+# rejects only combine_options. So on the vips path we run there is no method-name enforcement at
+# all, and CVE-2025-24293's removal of apply, loader, and saver from that list is inert.
 #
-# They are not inert on vips. ImageProcessing dispatches the loader/saver by name --
-# Vips::Image.public_send(:"#{loader}load", ...) and image.public_send(:"#{saver}save", ...) --
-# whenever the options carry a nested loader:/saver: selector, and apply re-enters the builder for
-# each of its entries, reaching those same selectors regardless of any per-method check.
+# Every transformation name reaches libvips by dispatch. ImageProcessing's builder handles apply,
+# loader, and saver itself and sends every other name through Chainable#method_missing into the
+# operations list, where Processor#apply_operation hands it to Vips::Image#public_send. That leaves a
+# signed variation key three distinct primitives:
 #
-# config/initializers/vips.rb calls Vips.block_untrusted(true), which gates untrusted *loaders*, so
-# loader: { loader: "openslide" } is already blocked. But savers are not flagged untrusted, so
-# saver: { saver: "dz" } (dzsave, which expands one request into an unbounded tile pyramid on disk)
-# and csv/matrix (text served back as an image) still reach libvips. Only method-level enforcement
-# removes that primitive.
+#   loader: { loader: "x" }  ->  Vips::Image.public_send(:"xload", path, **options)
+#   saver:  { saver:  "x" }  ->  image.public_send(:"xsave", path, **options)
+#   <any other name>         ->  image.public_send(:<name>, argument)
 #
-# Reject apply outright, and reject a nested loader:/saver: selector, while still accepting ordinary
-# option hashes -- notably loader: { n: -1 }, which Attachments::VARIANTS relies on to keep animated
-# GIF frames, and which is signed into immortal variant URLs.
+# and apply launders all three: it re-enters the builder for each of its entries, and those entries
+# are never revalidated because only top-level transformations reach validate_transformation.
+#
+# Vips.block_untrusted(true) in config/initializers/vips.rb gates untrusted *loaders* only. Savers
+# are not flagged untrusted, and direct dispatch is not gated at all. With blocking on,
+# dzsave: "<path>" writes an unbounded tile pyramid to an attacker-chosen path, and on our locked
+# image_processing 1.14.0 instance_eval: "<ruby>" runs arbitrary code -- the side effect lands before
+# the pipeline fails on the operation's nil return, so the eventual error is not a defense.
+#
+# So enforce the allowlist here the way ImageMagick does. It admits nothing dangerous on this path:
+# of its 284 names, 6 reach an ImageProcessing macro, 6 reach a pure Vips::Image accessor (clone,
+# format, log, median, scale, size), and the remaining 272 resolve to nothing.
 module ActiveStorageVipsTransformationGuard
+  # CVE-2025-24293 removed loader and saver from the allowlist, but Attachments::VARIANTS signs
+  # loader: { n: -1 } into variant URLs that never expire, so those names have to keep resolving.
+  # Only a nested same-name selector is a dispatch primitive; ordinary option hashes are not.
+  DISPATCHING_METHODS = %w[ loader saver ]
+
   private
     def validate_transformation(name, argument)
-      case name.to_s
-      when "apply"
-        raise unsupported_transformation_method("apply")
-      when "loader", "saver"
-        if argument.is_a?(Hash) && argument.any? { |key, _| key.to_s == name.to_s }
-          raise unsupported_transformation_method("#{name} with a nested #{name} selector")
-        end
+      method_name = name.to_s.tr("-", "_")
+
+      if nested_selector?(method_name, argument)
+        raise unsupported_transformation_method("#{method_name} with a nested #{method_name} selector")
+      elsif !supported_vips_transformation_method?(method_name)
+        raise unsupported_transformation_method(method_name)
       end
 
       super
+    end
+
+    def nested_selector?(method_name, argument)
+      DISPATCHING_METHODS.include?(method_name) && argument.is_a?(Hash) &&
+        argument.any? { |key, _| key.to_s == method_name }
+    end
+
+    def supported_vips_transformation_method?(method_name)
+      DISPATCHING_METHODS.include?(method_name) ||
+        ActiveStorage.supported_image_processing_methods.include?(method_name)
     end
 
     def unsupported_transformation_method(description)

--- a/lib/rails_ext/active_storage_vips_transformation_guard.rb
+++ b/lib/rails_ext/active_storage_vips_transformation_guard.rb
@@ -1,0 +1,43 @@
+# Active Storage's ImageMagick transformer enforces ActiveStorage.supported_image_processing_methods,
+# but the vips transformer never reads that allowlist. So CVE-2025-24293's removal of apply, loader,
+# and saver from the allowlist is inert on the vips path we run, and a signed variation key can still
+# carry them.
+#
+# They are not inert on vips. ImageProcessing dispatches the loader/saver by name --
+# Vips::Image.public_send(:"#{loader}load", ...) and image.public_send(:"#{saver}save", ...) --
+# whenever the options carry a nested loader:/saver: selector, and apply re-enters the builder for
+# each of its entries, reaching those same selectors regardless of any per-method check.
+#
+# config/initializers/vips.rb calls Vips.block_untrusted(true), which gates untrusted *loaders*, so
+# loader: { loader: "openslide" } is already blocked. But savers are not flagged untrusted, so
+# saver: { saver: "dz" } (dzsave, which expands one request into an unbounded tile pyramid on disk)
+# and csv/matrix (text served back as an image) still reach libvips. Only method-level enforcement
+# removes that primitive.
+#
+# Reject apply outright, and reject a nested loader:/saver: selector, while still accepting ordinary
+# option hashes -- notably loader: { n: -1 }, which Attachments::VARIANTS relies on to keep animated
+# GIF frames, and which is signed into immortal variant URLs.
+module ActiveStorageVipsTransformationGuard
+  private
+    def validate_transformation(name, argument)
+      case name.to_s
+      when "apply"
+        raise unsupported_transformation_method("apply")
+      when "loader", "saver"
+        if argument.is_a?(Hash) && argument.any? { |key, _| key.to_s == name.to_s }
+          raise unsupported_transformation_method("#{name} with a nested #{name} selector")
+        end
+      end
+
+      super
+    end
+
+    def unsupported_transformation_method(description)
+      ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingMethod.new \
+        "The provided transformation method is not supported: #{description}."
+    end
+end
+
+Rails.application.config.to_prepare do
+  ActiveStorage::Transformers::Vips.prepend ActiveStorageVipsTransformationGuard
+end

--- a/lib/rails_ext/active_storage_vips_transformation_guard.rb
+++ b/lib/rails_ext/active_storage_vips_transformation_guard.rb
@@ -22,9 +22,14 @@
 # image_processing 1.14.0 instance_eval: "<ruby>" runs arbitrary code -- the side effect lands before
 # the pipeline fails on the operation's nil return, so the eventual error is not a defense.
 #
-# So enforce the allowlist here the way ImageMagick does. It admits nothing dangerous on this path:
-# of its 284 names, 6 reach an ImageProcessing macro, 6 reach a pure Vips::Image accessor (clone,
-# format, log, median, scale, size), and the remaining 272 resolve to nothing.
+# So enforce the allowlist here the way ImageMagick does. It admits nothing dangerous on this path.
+# Note the reachable surface is wider than Vips::Image's own methods: Vips::Image#method_missing
+# resolves an unknown name against libvips operation nicknames, so allowlisted names reach those too.
+# Counting all three routes, 30 of its 284 names resolve to anything at all -- 6 ImageProcessing
+# macros, 21 libvips operations (affine, canny, colourspace, crop, flip, resize, sharpen, thumbnail
+# and the like), and a few pure accessors (clone, format, log, median, size). None of them writes to
+# disk or takes a filename, and every *save/*load nickname is absent. The other 254 resolve to
+# nothing.
 module ActiveStorageVipsTransformationGuard
   # CVE-2025-24293 removed loader and saver from the allowlist, but Attachments::VARIANTS signs
   # loader: { n: -1 } into variant URLs that never expire, so those names have to keep resolving.

--- a/test/lib/rails_ext/active_storage_vips_transformation_guard_test.rb
+++ b/test/lib/rails_ext/active_storage_vips_transformation_guard_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ActiveStorageVipsTransformationGuardTest < ActiveSupport::TestCase
+  UnsupportedMethod = ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingMethod
+
+  setup do
+    @blob = ActiveStorage::Blob.create_and_upload! \
+      io: file_fixture("moon.jpg").open, filename: "moon.jpg", content_type: "image/jpeg"
+  end
+
+  # The guard rejects the transformation methods that let a signed variation key choose an
+  # arbitrary libvips operation. On the vips path ImageProcessing dispatches the loader/saver by
+  # name -- Vips::Image.public_send(:"#{loader}load") / image.public_send(:"#{saver}save") -- when
+  # the options carry a nested loader:/saver: selector, and apply re-enters the builder to reach
+  # the same selectors.
+
+  test "apply is rejected outright as builder machinery" do
+    assert_raises(UnsupportedMethod) { @blob.variant(apply: { resize_to_limit: [ 100, 100 ] }).processed }
+    assert_raises(UnsupportedMethod) { @blob.variant(apply: { saver: { saver: "dz" } }).processed }
+  end
+
+  test "a nested loader selector is rejected" do
+    assert_raises(UnsupportedMethod) { @blob.variant(loader: { loader: "magick" }).processed }
+  end
+
+  test "a nested saver selector is rejected" do
+    # saver dispatch is NOT gated by Vips.block_untrusted(true); this guard is the only thing that
+    # stops saver: { saver: "dz" } (a tile-pyramid resource amplifier) from reaching libvips.
+    assert_raises(UnsupportedMethod) { @blob.variant(saver: { saver: "dz" }).processed }
+  end
+
+  # Non-vacuity: the guard must not reject legitimate transformations. Attachments::VARIANTS depends
+  # on loader: { n: -1 } to keep animated GIF frames, and those keys are signed into immortal URLs.
+
+  test "loader option hashes without a nested selector still process" do
+    assert_nothing_raised do
+      @blob.variant(loader: { n: -1 }, resize_to_limit: [ 100, 100 ]).processed
+    end
+  end
+
+  test "the real Attachments::VARIANTS still process" do
+    Attachments::VARIANTS.each_value do |options|
+      assert_nothing_raised { @blob.variant(**options).processed }
+    end
+  end
+
+  test "an ordinary resize still processes" do
+    assert_nothing_raised { @blob.variant(resize_to_limit: [ 50, 50 ]).processed }
+  end
+end

--- a/test/lib/rails_ext/active_storage_vips_transformation_guard_test.rb
+++ b/test/lib/rails_ext/active_storage_vips_transformation_guard_test.rb
@@ -32,6 +32,19 @@ class ActiveStorageVipsTransformationGuardTest < ActiveSupport::TestCase
     assert_raises(UnsupportedMethod) { @blob.variant(bogusnotreal: true).processed }
   end
 
+  test "a libvips operation nickname is rejected even though libvips knows it" do
+    # Vips::Image#method_missing resolves unknown names against libvips operation nicknames, so the
+    # reachable surface is wider than Vips::Image's own methods. These are real operations.
+    assert_raises(UnsupportedMethod) { @blob.variant(gaussblur: 5).processed }
+    assert_raises(UnsupportedMethod) { @blob.variant(invert: true).processed }
+  end
+
+  test "combine_options is still rejected by the base transformer" do
+    # Pins the super chain: the guard raises for its own cases but must keep delegating, or the
+    # base ImageProcessingTransformer's only check silently disappears.
+    assert_raises(ArgumentError) { @blob.variant(combine_options: { resize: "100x100" }).processed }
+  end
+
   # A direct operation name needs no nested selector: Chainable#method_missing turns it into an
   # operation and Processor#apply_operation calls Vips::Image#public_send with it. The argument is
   # the *destination path*, so this writes where the transformation says, not to Active Storage's

--- a/test/lib/rails_ext/active_storage_vips_transformation_guard_test.rb
+++ b/test/lib/rails_ext/active_storage_vips_transformation_guard_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "tmpdir"
 
 class ActiveStorageVipsTransformationGuardTest < ActiveSupport::TestCase
   UnsupportedMethod = ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingMethod
@@ -8,13 +9,11 @@ class ActiveStorageVipsTransformationGuardTest < ActiveSupport::TestCase
       io: file_fixture("moon.jpg").open, filename: "moon.jpg", content_type: "image/jpeg"
   end
 
-  # The guard rejects the transformation methods that let a signed variation key choose an
-  # arbitrary libvips operation. On the vips path ImageProcessing dispatches the loader/saver by
-  # name -- Vips::Image.public_send(:"#{loader}load") / image.public_send(:"#{saver}save") -- when
-  # the options carry a nested loader:/saver: selector, and apply re-enters the builder to reach
-  # the same selectors.
+  # The guard enforces ActiveStorage.supported_image_processing_methods on the vips path, which
+  # nothing in Rails does. Without it a signed variation key picks any libvips operation: the builder
+  # handles apply/loader/saver itself, and hands every other name to Vips::Image#public_send.
 
-  test "apply is rejected outright as builder machinery" do
+  test "apply is rejected as builder machinery that launders its unvalidated entries" do
     assert_raises(UnsupportedMethod) { @blob.variant(apply: { resize_to_limit: [ 100, 100 ] }).processed }
     assert_raises(UnsupportedMethod) { @blob.variant(apply: { saver: { saver: "dz" } }).processed }
   end
@@ -24,13 +23,56 @@ class ActiveStorageVipsTransformationGuardTest < ActiveSupport::TestCase
   end
 
   test "a nested saver selector is rejected" do
-    # saver dispatch is NOT gated by Vips.block_untrusted(true); this guard is the only thing that
+    # Saver dispatch is NOT gated by Vips.block_untrusted(true); this guard is the only thing that
     # stops saver: { saver: "dz" } (a tile-pyramid resource amplifier) from reaching libvips.
     assert_raises(UnsupportedMethod) { @blob.variant(saver: { saver: "dz" }).processed }
   end
 
+  test "an unknown method name is rejected rather than dispatched to the image" do
+    assert_raises(UnsupportedMethod) { @blob.variant(bogusnotreal: true).processed }
+  end
+
+  # A direct operation name needs no nested selector: Chainable#method_missing turns it into an
+  # operation and Processor#apply_operation calls Vips::Image#public_send with it. The argument is
+  # the *destination path*, so this writes where the transformation says, not to Active Storage's
+  # tempfile. Asserting the exception alone would be vacuous -- before the guard these raised too,
+  # on the operation's nil return, long after the write had landed. Assert the side effect is absent.
+
+  test "direct saver operation names are rejected before libvips writes anything" do
+    Dir.mktmpdir do |dir|
+      { dzsave: "pyramid", csvsave: "leak.csv", matrixsave: "leak.mat" }.each do |name, basename|
+        assert_raises(UnsupportedMethod, "#{name} must not reach libvips") do
+          @blob.variant(name => File.join(dir, basename)).processed
+        end
+      end
+
+      assert_empty Dir.children(dir), "the guard must reject before any saver runs"
+    end
+  end
+
+  test "write_to_file is rejected before libvips writes anything" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "arbitrary.png")
+      assert_raises(UnsupportedMethod) { @blob.variant(write_to_file: path).processed }
+      assert_not File.exist?(path), "write_to_file must not reach the image"
+    end
+  end
+
+  test "Ruby object methods are rejected before they execute" do
+    # image_processing 1.14.0 does not restrict dispatch to libvips operations, so an inherited
+    # Object method is reachable on the accumulator. 2.0 hardens apply but not this path.
+    Dir.mktmpdir do |dir|
+      marker = File.join(dir, "executed.txt")
+      assert_raises(UnsupportedMethod) do
+        @blob.variant(instance_eval: "File.write(#{marker.inspect}, 'x')").processed
+      end
+      assert_not File.exist?(marker), "instance_eval must never reach the image"
+    end
+  end
+
   # Non-vacuity: the guard must not reject legitimate transformations. Attachments::VARIANTS depends
-  # on loader: { n: -1 } to keep animated GIF frames, and those keys are signed into immortal URLs.
+  # on loader: { n: -1 } to keep animated GIF frames, and those keys are signed into variant URLs
+  # that never expire, so an allowlist that drops loader/saver would break every existing URL.
 
   test "loader option hashes without a nested selector still process" do
     assert_nothing_raised do
@@ -38,10 +80,18 @@ class ActiveStorageVipsTransformationGuardTest < ActiveSupport::TestCase
     end
   end
 
+  test "saver option hashes without a nested selector still process" do
+    assert_nothing_raised { @blob.variant(saver: { quality: 80 }).processed }
+  end
+
   test "the real Attachments::VARIANTS still process" do
     Attachments::VARIANTS.each_value do |options|
       assert_nothing_raised { @blob.variant(**options).processed }
     end
+  end
+
+  test "the real User::Avatar variant still processes" do
+    assert_nothing_raised { @blob.variant(resize_to_fill: [ 256, 256 ]).processed }
   end
 
   test "an ordinary resize still processes" do


### PR DESCRIPTION
## The defect

CVE-2025-24293 (rails/rails `1ca278a6a7`, "Active Storage: Remove dangerous transformations") removed `apply`, `loader`, and `saver` from `ActiveStorage.supported_image_processing_methods`. But **that allowlist is only enforced by the ImageMagick transformer** — `ImageMagick#validate_transformation` is the sole reader of `supported_image_processing_methods` in the whole tree. The vips transformer (`transformers/vips.rb`, 15 lines) only defines `processor`; it never overrides `validate_transformation`, and the base `ImageProcessingTransformer#validate_transformation` rejects only `combine_options`.

Fizzy renders variants with vips (Rails default under `load_defaults 8.1`). **So on our path there is no method-name enforcement at all** — not merely a three-method gap. A signed variation key picks the method.

Worth naming because it is why this was easy to miss: **the CVE commit names neither ImageMagick nor mini_magick.** `git show 1ca278a6a7 --stat` touches exactly two files (`lib/active_storage.rb`, `test/models/variant_test.rb`) and **no CHANGELOG** — `activestorage/CHANGELOG.md` at our pinned Rails revision contains zero mention of the CVE. The only in-repo signal that the fix is ImageMagick-only is that both changed tests sit inside `process_variants_with :mini_magick` blocks; the `:vips` blocks in the same file were never extended.

### Every transformation name reaches libvips by dispatch

`ImageProcessing`'s builder handles `apply`, `loader`, and `saver` itself, and sends **every other name** through `Chainable#method_missing` into the operations list, where `Processor#apply_operation` hands it to `Vips::Image#public_send`:

```ruby
# Processor#apply_operation
receiver = respond_to?(name) ? self : @accumulator   # @accumulator is a Vips::Image
receiver.public_send(name, *args, &block)
```

That leaves three distinct primitives:

```ruby
loader: { loader: "x" }  ->  Vips::Image.public_send(:"xload", path, **options)
saver:  { saver:  "x" }  ->  image.public_send(:"xsave", path, **options)
<any other name>         ->  image.public_send(:<name>, argument)
```

and `apply` launders all three: it re-enters the builder for each of its entries, and those entries are **never revalidated**, because only top-level transformations reach `validate_transformation`.

`config/initializers/vips.rb` already calls `Vips.block_untrusted(true)`, which gates untrusted **loaders** — so `loader: { loader: "openslide" }` is blocked. **Savers are not flagged untrusted, and direct dispatch is not gated at all.**

### Threat model — defense-in-depth, not standalone RCE

A variation key is a signed serialization of the transformations hash (signed with `secret_key_base`); an attacker cannot forge one without the key. This is defense-in-depth on the live `RAILS_MASTER_KEY`-exfiltration incident (HEY #3916984): if the key leaks, arbitrary `Vips::Image` method dispatch is the attacker's next hop.

The impact of that next hop is worse than this PR first claimed. For the **direct-dispatch** case the argument *is* the destination path, so it is not confined to Active Storage's tempfile — it is arbitrary-path write, and on our locked `image_processing 1.14.0` the accumulator's inherited `Object` methods are reachable too.

## Reproduction

Replicating `ImageProcessingTransformer#process` on the vips path at Fizzy's locked `image_processing 1.14.0` / `ruby-vips 2.2.5` / libvips 8.18.4, with `Vips.block_untrusted(true)` **on**, and with the first version of this guard (rejecting only `apply` + nested `loader:`/`saver:`) **in place**:

```
== Cases that first guard rejected ==
  apply: {resize_to_limit:[100,100]}     GUARD REJECTED                    -
  loader: {loader: 'magick'}             GUARD REJECTED                    -
  saver: {saver: 'dz'}                   GUARD REJECTED                    -

== Direct operation names — NOT rejected by that guard ==
  dzsave: '<path>'                       NoMethodError (nil) AFTER write   WROTE 36 entries
  csvsave: '<path>'                      NoMethodError (nil) AFTER write   WROTE 1 entry
  matrixsave: '<path>'                   NoMethodError (nil) AFTER write   WROTE 1 entry
  write_to_file: '<path>'                NoMethodError (nil) AFTER write   WROTE 1 entry
  instance_eval: 'File.write(...)'       NoMethodError AFTER execution     WROTE 1 entry

== Non-vacuity: legitimate transformations ==
  resize_to_limit: [50,50]               PROCESSED                         -
  loader:{n:-1} + resize (VARIANTS)      PROCESSED                         -
  saver: {quality: 80}                   PROCESSED                         -
```

Each dangerous case **does** raise — on the operation's `nil` return, when the pipeline tries to save it. The side effect has already landed by then. **The exception is not a defense**, which is why the tests assert the absence of the file, not just the exception class.

## The fix

Prepend a guard onto `ActiveStorage::Transformers::Vips` (via the app's `lib/rails_ext` + `to_prepare` idiom) that enforces `ActiveStorage.supported_image_processing_methods`, the way the ImageMagick transformer does.

The allowlist admits nothing dangerous on this path. Measuring that needs care, because the reachable surface is wider than `Vips::Image`'s own methods: `Vips::Image#method_missing` resolves an unknown name against **libvips operation nicknames**, so an allowlisted name reaches those too. Counting all three routes, **30** of its 284 names resolve to anything at all:

- **6** reach an `ImageProcessing` macro (`resize_to_limit`, `resize_to_fit`, `resize_to_fill`, `resize_and_pad`, `rotate`, `composite`)
- **21** reach a real libvips operation (`affine`, `canny`, `clamp`, `colourspace`, `complex`, `copy`, `crop`, `flatten`, `flip`, `gamma`, `gravity`, `insert`, `morph`, `mosaic`, `resize`, `scale`, `sharpen`, `thumbnail`, `cache`, plus the two macro-shadowed ones)
- the rest are pure accessors (`clone`, `format`, `log`, `median`, `size`)
- **254** resolve to nothing

**None of the 30 writes to disk or takes a filename**, and every `*save` / `*load` nickname (`dzsave`, `csvsave`, `matrixsave`, `rawsave`, `magickload`, `openslideload`, `pdfload`, `svgload`, …) is absent from the list. The only `Object` method admitted is `clone`.

`loader` and `saver` stay permitted **as names** — CVE-2025-24293 removed them, but `Attachments::VARIANTS` signs `loader: { n: -1 }` into variant URLs that **never expire**, so dropping the names would break every existing animated-GIF URL. Only their **nested same-name selector** is rejected; ordinary option hashes (`loader: { n: -1 }`, `saver: { quality: 80 }`) keep working. `apply` needs no special case, being absent from the list.

### Residual, out of scope for this PR

`composite` is on the upstream allowlist, and its `ImageProcessing` macro accepts a **String path**, which it opens with `Vips::Image.new_from_file`. So with a compromised key it still reads an arbitrary server-side file:

```
composite: "<a real image path>"   PROCESSED          # contents composited into the output
composite: "/etc/passwd"           Vips::Error: "is not a known file format"
composite: "/nonexistent/nope"     Vips::Error: "file ... does not exist"
```

Two distinguishable errors make that a file-existence oracle, and a readable image gets composited into the returned variant.

This is **not a regression here and not something this guard introduces**: `composite` is allowlisted upstream and behaves the same on the ImageMagick path, where `validate_arg_string` only screens for ImageMagick CLI flags and lets a plain path through. Closing it means departing from the upstream list, which is a separate decision from closing the dispatch primitive. Flagging it rather than folding it in.

### Options considered

1. **Re-allow `loader` in the allowlist** (what HEY does on its mini_magick path) — rejected: it re-opens the nested-selector dispatch it is meant to close.
2. **Reject only `apply` + nested `loader:`/`saver:`** (this PR's first commit) — rejected: closes the three builder entry points but leaves direct dispatch to any `Vips::Image` (or `Object`) method wide open. Caught in review by Codex.
3. **Enforce the allowlist, re-permitting `loader`/`saver` as names** (this PR) — closes the whole primitive, preserves `loader: { n: -1 }` and every immortal URL.
4. **Strip `loader` out of `VARIANTS` and internalize it** (what bc3 did — "moved out of URLs into internal boilerplate") — cleaner long-term (stops putting loader options in immortal URLs) but materially more invasive, and orthogonal. Worth doing later; not required to fix this.

Holds across the pending `image_processing` 2.0 upgrade (#2922): 2.0 hardens `apply` against `Kernel`/`Object` methods but **not** against `loader`/`saver` dispatch or direct operation names, so this guard stays necessary.

## Mutation tests

Each mutation was verified to have actually applied (marker grepped in the mutated file) before its run was trusted.

| Mutation | Expected | Result |
|---|---|---|
| Neuter guard (`validate_transformation` → just `super`) | all reject tests fail | **7 failures**, 5 non-vacuity pass |
| Reject everything (raise at top of guard) | non-vacuity tests fail | **5 errors** (VARIANTS, `loader:{n:-1}`, `saver:{quality:80}`, resize_to_fill, resize) |
| Remove allowlist enforcement, keep nested-selector reject | direct-dispatch + `apply` + unknown-name fail; nested pass | **5 failures**, nested loader/saver pass |
| Remove nested-selector reject, keep allowlist | nested `loader`/`saver` fail; direct dispatch still caught | **2 failures**, rest pass |

(Counts are for the final 14-test suite: neuter → 8, reject-all → 1 failure + 5 errors, no-allowlist → 6, no-nested-selector → 2.)

The last two are the load-bearing pair: they show neither half is redundant. The allowlist alone does not cover nested selectors (because `loader`/`saver` are permitted as names), and the nested-selector check alone does not cover direct dispatch.

With the fix in place: **14 tests, 23 assertions, 0 failures.** Variant-adjacent suites (`test/lib/rails_ext`, avatar, comment, storage, exportable): **127 tests, 307 assertions, 0 failures.** Full suite at `f3f6dc4fe`: **1556 tests, 5850 assertions, 0 failures, 0 errors, 3 skips.**

Do not merge yet — coordinated with the bc3 and upstream Rails companions.
