### PR TITLE
Fix board watch button not updating after toggle

### DIFF
--- a/app/controllers/boards/involvements_controller.rb
+++ b/app/controllers/boards/involvements_controller.rb
@@ -6,7 +6,6 @@ class Boards::InvolvementsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.turbo_stream
       format.json { head :no_content }
     end
   end


### PR DESCRIPTION
## Summary
- Watching/stop watching a board left the button stale until a full refresh
- `format.turbo_stream` was declared without a template
- Drop that format and keep the existing HTML response

## How to reproduce
- [ ] Open a board
- [ ] Click STOP WATCHIN, or WATCH THIS, button should flip to opposite
- [ ] Confirm avatars/watchers list updates with the toggle


### Problem 
https://github.com/user-attachments/assets/c3c70d53-2892-4ed0-a9f7-4253d140993a

### Fix
https://github.com/user-attachments/assets/02765f6e-6fbd-4534-8682-5031b275e3cb

