### PR TITLE
Agent docs: trim to what agents get wrong, gate it, point SaaS at shared context

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop
 
+      - name: Agent docs
+        run: script/check_agents_docs
+
   zizmor:
     name: GitHub Actions audit
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,12 @@
 # Fizzy
 
-Guidance for AI coding agents working with this repository.
+Fizzy is a kanban-style project management and issue tracker: cards move
+across columns on boards, with comments, mentions, and assignments.
 
-Fizzy is a kanban-style project management and issue tracker: cards move across columns on boards, with comments, mentions, and assignments.
+These instructions are defaults with reasons, not law — when the code in
+front of you disagrees, take the better path and flag the conflict; invariants
+(data loss, security, CI gates) are surfaced, not overridden. Attack your own
+diff before calling it done.
 
 ## Deploy
 
@@ -14,58 +18,40 @@ Self-hosted deploys run Kamal against `config/deploy.yml` — see `docs/kamal-de
 
 For local agent work, `tmp/saas.txt` is the checkout-level SaaS switch used by `bin/setup`. When present, read `saas/AGENTS.md` before continuing. Otherwise, do not apply its instructions.
 
-## Architecture Overview
+## Multi-tenancy is URL-based
 
-### Multi-Tenancy (URL-Based)
+Accounts get a decimal `external_account_id` URL prefix (`/{account_id}/boards/...`).
+`AccountSlug::Extractor` middleware sets `Current.account` and moves the slug
+from `PATH_INFO` to `SCRIPT_NAME`, so Rails behaves as if mounted at that
+path — route helpers and request specs that assume a bare root will mislead
+you. Domain records are account-scoped; identity, session, and authentication
+records are the global exceptions. Background jobs serialize and restore
+`Current.account` themselves.
 
-Fizzy uses **URL path-based multi-tenancy**:
-- Accounts have a unique decimal `external_account_id` used in URL prefixes
-- URLs are prefixed: `/{account_id}/boards/...`
-- Middleware (`AccountSlug::Extractor`) extracts the account ID from the URL and sets `Current.account`
-- The slug is moved from `PATH_INFO` to `SCRIPT_NAME`, making Rails think it's "mounted" at that path
-- Tenant-scoped domain records are account-isolated; global identity, session, and authentication records are exceptions
-- Background jobs automatically serialize and restore account context
+A global `Identity` (email-based) can hold `Users` in multiple accounts, so
+an email address is not a single account membership. Board access is per-user
+`Access` records.
 
-**Key insight**: This architecture allows multi-tenancy without subdomains or separate databases, making local development and testing simpler.
+## UUID primary keys
 
-### Authentication & Authorization
+All tables use UUIDv7 keys, base36-encoded to 25 characters. Fixture UUIDs
+are generated to sort older than any runtime record, so `.first`/`.last`
+stay deterministic in tests — don't "fix" ordering by comparing insertion
+order to id order.
 
-Passwordless magic link authentication. A global `Identity` (email-based) can have `Users` in multiple Accounts, so an email is not a single account membership. Users have roles: owner, admin, member, system. Board-level access control via `Access` records.
+## Search is sharded on MySQL, single-index on SQLite
 
-### Entropy System
+Full-text search runs in the database, not Elasticsearch. On MySQL it is
+sharded 16 ways by CRC32 of the account ID (`Search::Record::Trilogy`); on
+SQLite it is a single FTS5 index (`Search::Record::SQLite`). Don't assume the
+sharded shape when working under SQLite. Models in `app/models/search/`.
 
-Cards automatically "postpone" (move to "not now") after inactivity:
-- Account-level default entropy period
-- Board-level entropy override
-- Prevents endless todo lists from accumulating
-- Configurable via Account/Board settings
+## Imports and exports
 
-### UUID Primary Keys
-
-All tables use UUIDs (UUIDv7 format, base36-encoded as 25-char strings):
-- Custom fixture UUID generation maintains deterministic ordering for tests
-- Fixtures are always "older" than runtime records
-- `.first`/`.last` work correctly in tests
-
-### Background Jobs (Solid Queue)
-
-Database-backed job queue (no Redis):
-- Custom `FizzyActiveJobExtensions` prepended to ActiveJob
-- Jobs automatically capture/restore `Current.account`
-- Mission Control::Jobs for monitoring
-
-Recurring tasks are declared in `config/recurring.yml`.
-
-### Sharded Full-Text Search
-
-Full-text search runs in the database, not Elasticsearch. On MySQL it is sharded 16 ways by CRC32 of the account ID (`Search::Record::Trilogy`); on SQLite it is a single FTS5 index (`Search::Record::SQLite`). Don't assume the sharded shape when working under SQLite. Models in `app/models/search/`.
-
-### Imports and exports
-
-Allow people to move between OSS and SAAS Fizzy instances:
-- Exports/Imports can be written to/read from local or S3 storage depending on the config of the instance (both must be supported)
-- Must be able to handle very large ZIP files (500+GB)
-- Models in `app/models/account/data_transfer/`, `app/models/zip_file`
+Data transfer between instances (`app/models/account/data_transfer/`,
+`app/models/zip_file`) must work against both local and S3 storage, and
+archives can exceed hundreds of gigabytes — stream, never buffer a whole
+file.
 
 ## Coding style
 

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -9,6 +9,8 @@ SYSTEM_TEST_ENV = "PARALLEL_WORKERS=1" # system tests can't run reliably in para
 CI.run do
   step "Setup", "bin/setup --skip-server"
 
+  step "Docs: agent instructions", "script/check_agents_docs"
+
   step "Style: Ruby", "bin/rubocop -f simple"
 
   step "Gemfile: Drift check", "bin/bundle-drift check"

--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -2,6 +2,8 @@
 
 37signals' hosted Fizzy: billing, our production setup, our deploy destinations. Apply this only when SaaS mode is enabled — the root `AGENTS.md` has the check.
 
+Shared 37signals context: if "37signals Development Context" isn't already loaded, read `~/.local/share/shipyard/share/AGENTS.md`. (It lives on 37signals machines, not in this repository; skip if absent.)
+
 `bin/rails saas:enable` creates `tmp/saas.txt`; `bin/rails saas:disable` removes it. `Fizzy.saas?` also reads `SAAS` from the environment, where anything but `false` enables and `SAAS=false` forces off even with the file present (`lib/fizzy.rb`) — that path is for the production image and `bin/ci`, not for switching a checkout. Enabling swaps the bundle to `Gemfile.saas` and the default database adapter to MySQL, so it changes what every `bin/rails` and `bin/kamal` command does.
 
 `README.md` covers the environments, Stripe, push credentials, and maintenance mode. What it doesn't say:

--- a/script/check_agents_docs
+++ b/script/check_agents_docs
@@ -1,0 +1,264 @@
+#!/usr/bin/env ruby
+#
+# CI check for agent instruction files. Ported from bc3's gate of the same
+# name; the rules and their rationale are shared, the pins are ours.
+#
+#   1. The import chain resolves: CLAUDE.md's @imports load, stay in the repo,
+#      and nest no deeper than Claude follows. An imported file is followed for
+#      its own imports; it is not otherwise scanned.
+#   2. AGENTS.md doesn't re-fork the shared shipyard instructions.
+#   3. Literal values restated in the docs match the file that defines them,
+#      at every site that restates them.
+#
+# Deliberately narrow. It does NOT check that every backticked path or rake task
+# in the docs is real — those were open-ended promises this script could not keep,
+# and each attempt to keep them added parsing surface with its own edge cases.
+# What is left is closed-form: a fixed set of pins against named authorities, and
+# a two-file import chain.
+#
+# Scan roots are part of the contract. A new place where agent-facing claims
+# live must be added here, or it isn't covered.
+#
+
+require "pathname"
+
+ROOT = Pathname.new(File.expand_path("..", __dir__))
+ROOT_REAL = ROOT.realpath
+
+# Containment must be canonical, not lexical: cleanpath collapses ".." textually
+# and cannot see that an in-repo symlink points out of the tree.
+def canonicalize(path)
+  if path.exist?
+    path.realpath
+  elsif path.dirname.exist?
+    path.dirname.realpath / path.basename
+  else
+    path.cleanpath
+  end
+end
+
+# Compare path COMPONENTS, not a string prefix: an in-root file legitimately
+# named "..notes.md" starts with ".." without escaping anything.
+def escapes_repository?(path)
+  path.relative_path_from(ROOT_REAL).each_filename.include?("..")
+rescue ArgumentError
+  true
+end
+
+# Fizzy's bridge file is .claude/CLAUDE.md (there is no root CLAUDE.md);
+# saas/AGENTS.md is the gated 37signals-only overlay.
+SCAN_ROOTS = [
+  ".claude/CLAUDE.md",
+  "AGENTS.md",
+  "STYLE.md",
+  "saas/AGENTS.md"
+]
+
+# Roots without a glob are required to exist. Without this, deleting AGENTS.md
+# just shrinks the scanned set and the gate still reports success.
+REQUIRED_ROOTS = SCAN_ROOTS.reject { it.include?("*") }
+
+# Claude loads CLAUDE.md and expands its @imports at session start, so a broken
+# import silently drops instructions everyone believes are in context.
+#
+# An import is recognised only as a line that is *nothing but* the import, at
+# column zero. That is the form every real import in this repo takes, and it is
+# a convention, not a guess: it means this script never has to decide whether a
+# given `@token` sits in a fence, a code span, an indented block, or
+# list-continuation text. Every one of those judgements was a bug at some point
+# in bc3's original; none of them exist now.
+#
+# The cost is that a literal example must avoid the exact standalone form:
+# indent it, or put it inline in a sentence. A fence does NOT exempt it — this
+# script no longer knows what a fence is, which is the point.
+IMPORT_PATTERN = /\A@([A-Za-z0-9_.~\/][\w.\/~-]*)[ \t]*\z/
+
+MAX_IMPORT_HOPS = 4
+
+# Every literal value the always-on instructions restate must be pinned to the
+# file that defines it. A literal that can't be pinned shouldn't be restated.
+#
+# `pattern` must capture the AUTHORITATIVE assignment, not merely find the
+# value somewhere in the file. Each pin is anchored at BOTH ends: a regex
+# locating the claim in the document that makes it, and a regex locating the
+# authoritative assignment. Comparing captures catches drift in either
+# direction.
+PINNED_LITERALS = [
+  { describes: "SaaS switch path",
+    claims: [ { path: "AGENTS.md", pattern: /`(tmp\/saas\.txt)` is the checkout-level SaaS switch/ } ],
+    defined_in: "lib/fizzy.rb", pattern: /File\.exist\?\(File\.expand_path\("\.\.\/(tmp\/saas\.txt)"/ },
+  { describes: "search shard count",
+    claims: [ { path: "AGENTS.md", pattern: /sharded (\d+) ways/ } ],
+    defined_in: "app/models/search/record/trilogy.rb", pattern: /SHARD_COUNT = (\d+)/ },
+  { describes: "beta deploy template gate",
+    claims: [ { path: "saas/AGENTS.md", pattern: /template requiring the `(\w+)` env var/ } ],
+    defined_in: "saas/config/deploy.beta.yml", pattern: /must be given" unless ENV\["(\w+)"\]/ }
+]
+
+# Identifiers owned by shipyard's share/AGENTS.md, which every session already
+# loads. Restating them here means maintaining a second, lossy copy.
+SHARED_FILE_IDENTIFIERS = [
+  "PC96415006F908B67",
+  "e38bdfea-097e-47fa-a7ab-774fd2487741",
+  "6PouH8j4z"
+]
+
+abort "Usage: script/check_agents_docs" if ARGV.any?
+
+errors = []
+
+files = SCAN_ROOTS.flat_map { Dir[ROOT.join(it)] }.uniq.sort
+if files.empty?
+  abort "check_agents_docs: no files matched SCAN_ROOTS; the scan contract is broken."
+end
+
+# Per-root, not just overall: a glob that stops matching shrinks what we check
+# while the other roots keep the run green — the same "passed without checking
+# anything" failure this script exists to prevent, one root at a time.
+SCAN_ROOTS.each do |root|
+  next unless root.include?("*")
+  abort "check_agents_docs: #{root} matched no files; the scan contract is broken." if Dir[ROOT.join(root)].empty?
+end
+
+# Canonicalize before reading. A scan root that is a symlink out of the tree
+# would otherwise be ingested wholesale — the alias is kept for reporting.
+documents = files.filter_map do |file|
+  path = Pathname.new(file)
+  alias_name = path.relative_path_from(ROOT)
+  resolved = canonicalize(path)
+
+  if escapes_repository?(resolved)
+    errors << "#{alias_name}: resolves outside the repository; refusing to read"
+    nil
+  elsif !resolved.file?
+    errors << "#{alias_name}: is not a regular file"
+    nil
+  else
+    [ alias_name, resolved.read ]
+  end
+end
+
+# 1. Required roots are present
+REQUIRED_ROOTS.each do |required|
+  errors << "required scan root #{required} is missing" unless ROOT.join(required).exist?
+end
+
+# 1b. @imports resolve, stay inside the repo, and nest no deeper than Claude follows
+# Depth is measured from CLAUDE.md, the only file Claude loads on its own —
+# everything else is reached *through* it. Seeding the frontier with every
+# scanned document would restart the count at each one, so a chain Claude
+# drops would pass here. The full scanned set is still checked for paths and
+# literals below; it just isn't a set of traversal roots.
+scanned = documents.map { canonicalize(ROOT.join(it.first)) }.to_set
+entry_point = documents.find { it.first.to_s == ".claude/CLAUDE.md" }
+visited = [ canonicalize(ROOT.join(".claude/CLAUDE.md")) ].to_set
+frontier = [ entry_point ].compact
+
+# An import inside a depth-d file is itself depth d+1. Files up to
+# MAX_IMPORT_HOPS load; one past that does not. A chain ending exactly at hop 4
+# is valid — it's an import *from* the hop-4 file that Claude would drop.
+(1..MAX_IMPORT_HOPS + 1).each do |depth|
+  beyond_limit = depth > MAX_IMPORT_HOPS
+  discovered = []
+
+  frontier.each do |relative, content|
+    content.lines.filter_map { it.chomp[IMPORT_PATTERN, 1] }.each do |target|
+      if beyond_limit
+        errors << "#{relative}: import `@#{target}` is hop #{depth}, past Claude's " \
+                  "#{MAX_IMPORT_HOPS}-hop limit; it is not loaded"
+        next
+      end
+
+      if target.start_with?("~")
+        errors << "#{relative}: import `@#{target}` points outside the repository " \
+                  "(home directory) and can't be verified here"
+        next
+      end
+
+      resolved = canonicalize(ROOT.join(relative).dirname / Pathname.new(target))
+
+      if escapes_repository?(resolved)
+        errors << "#{relative}: import `@#{target}` resolves outside the repository"
+      elsif !resolved.exist?
+        errors << "#{relative}: import `@#{target}` does not resolve — Claude would load nothing"
+      elsif !resolved.file?
+        errors << "#{relative}: import `@#{target}` is not a regular file, so Claude loads nothing from it"
+      elsif visited.add?(resolved)
+        discovered << [ resolved.relative_path_from(ROOT_REAL), resolved.read ]
+      end
+    end
+  end
+
+  break if discovered.empty?
+
+  # Imported files are loaded into every session exactly like the roots, so
+  # their claims must face the same checks below — not merely have their own
+  # imports followed. Imports that are already scan roots would otherwise be
+  # checked twice and report doubled errors.
+  documents.concat(discovered.reject { scanned.include?(canonicalize(ROOT.join(it.first))) })
+  frontier = discovered
+end
+
+# 2. No re-fork of the shared shipyard instructions
+documents.select { |relative, _| relative.to_s.end_with?("AGENTS.md") }.each do |relative, content|
+  SHARED_FILE_IDENTIFIERS.each do |identifier|
+    if content.include?(identifier)
+      errors << "#{relative}: contains `#{identifier}`, which belongs to shipyard's share/AGENTS.md. " \
+                "Sessions that need it already load that file — don't fork it."
+    end
+  end
+end
+
+# 3. Documented literals match their defining file, in both directions —
+#    at every site that restates them, not just the first.
+def read_contained(path, describes, errors)
+  file = ROOT.join(path)
+
+  if !file.exist?
+    errors << "#{path} is missing, so the #{describes} claim can't be checked"
+    nil
+  elsif escapes_repository?(canonicalize(file))
+    errors << "#{path} resolves outside the repository; refusing to read"
+    nil
+  else
+    file.read
+  end
+end
+
+PINNED_LITERALS.each do |literal|
+  describes = literal[:describes]
+  source = read_contained(literal[:defined_in], describes, errors)
+  next if source.nil?
+
+  defined = source[literal[:pattern], 1]
+
+  if defined.nil?
+    errors << "#{literal[:defined_in]}: the #{describes} assignment matching " \
+              "#{literal[:pattern].inspect} is gone — the docs still claim it"
+    next
+  end
+
+  literal[:claims].each do |site|
+    path, claim = site[:path], site[:pattern]
+    content = read_contained(path, describes, errors)
+    next if content.nil?
+
+    claimed = content[claim, 1]
+
+    if claimed.nil?
+      errors << "#{path}: the #{describes} claim matching #{claim.inspect} is " \
+                "gone — reword the doc or update this pin"
+    elsif claimed != defined
+      errors << "#{path} states #{describes} #{claimed}, but #{literal[:defined_in]} defines #{defined}"
+    end
+  end
+end
+
+if errors.any?
+  puts "Agent docs check failed:\n\n"
+  errors.each { puts "  #{it}" }
+  puts
+  exit 1
+else
+  puts "Agent docs check passed (#{documents.size} files)."
+end

--- a/script/check_agents_docs
+++ b/script/check_agents_docs
@@ -200,6 +200,14 @@ frontier = [ entry_point ].compact
   frontier = discovered
 end
 
+# 1c. The bridge actually reaches the root instructions. .claude/CLAUDE.md is the
+# only file Claude loads on its own, so an emptied bridge would load nothing
+# while AGENTS.md stays present, scanned, and green.
+unless visited.include?(canonicalize(ROOT.join("AGENTS.md")))
+  errors << ".claude/CLAUDE.md does not import AGENTS.md (directly or transitively) — " \
+            "Claude would load none of these instructions"
+end
+
 # 2. No re-fork of the shared shipyard instructions — checked in every file a
 #    session loads: the scan roots and everything they import.
 documents.each do |relative, content|
@@ -242,20 +250,23 @@ PINNED_LITERALS.each do |literal|
 
   literal[:claims].each do |site|
     path, claim = site[:path], site[:pattern]
-    content = read_contained(path, describes, errors)
-    next if content.nil?
 
-    # Every occurrence, not just the first: a correct first restatement must
-    # not shield a stale duplicate later in the same file.
-    claimed = content.scan(claim).flatten
+    # Checked against EVERY loaded document, not just the claim's declared
+    # home: an imported file restating a pinned value lands in sessions
+    # exactly like the roots, so every occurrence anywhere must agree. Only
+    # the declared home is required to make the claim at all.
+    declared_seen = false
+    documents.each do |relative, content|
+      values = content.scan(claim).flatten
+      declared_seen = true if relative.to_s == path && values.any?
+      values.reject { it == defined }.each do |value|
+        errors << "#{relative} states #{describes} #{value}, but #{literal[:defined_in]} defines #{defined}"
+      end
+    end
 
-    if claimed.empty?
+    unless declared_seen
       errors << "#{path}: the #{describes} claim matching #{claim.inspect} is " \
                 "gone — reword the doc or update this pin"
-    else
-      claimed.reject { it == defined }.each do |value|
-        errors << "#{path} states #{describes} #{value}, but #{literal[:defined_in]} defines #{defined}"
-      end
     end
   end
 end

--- a/script/check_agents_docs
+++ b/script/check_agents_docs
@@ -86,8 +86,11 @@ MAX_IMPORT_HOPS = 4
 # direction.
 PINNED_LITERALS = [
   { describes: "SaaS switch path",
-    claims: [ { path: "AGENTS.md", pattern: /`(tmp\/saas\.txt)` is the checkout-level SaaS switch/ } ],
-    defined_in: "lib/fizzy.rb", pattern: /File\.exist\?\(File\.expand_path\("\.\.\/(tmp\/saas\.txt)"/ },
+    # Both captures are permissive: a doc claiming a WRONG path (or a moved
+    # switch in lib/fizzy.rb) must be captured to be compared, not silently
+    # fail to match the pattern.
+    claims: [ { path: "AGENTS.md", pattern: /`([\w.\/]+)` is the checkout-level SaaS switch/ } ],
+    defined_in: "lib/fizzy.rb", pattern: /File\.exist\?\(File\.expand_path\("\.\.\/([\w.\/]+)", __dir__\)\)/ },
   { describes: "search shard count",
     claims: [ { path: "AGENTS.md", pattern: /sharded (\d+) ways/ } ],
     defined_in: "app/models/search/record/trilogy.rb", pattern: /SHARD_COUNT = (\d+)/ },

--- a/script/check_agents_docs
+++ b/script/check_agents_docs
@@ -21,6 +21,7 @@
 #
 
 require "pathname"
+require "set"
 
 ROOT = Pathname.new(File.expand_path("..", __dir__))
 ROOT_REAL = ROOT.realpath
@@ -199,12 +200,13 @@ frontier = [ entry_point ].compact
   frontier = discovered
 end
 
-# 2. No re-fork of the shared shipyard instructions
-documents.select { |relative, _| relative.to_s.end_with?("AGENTS.md") }.each do |relative, content|
+# 2. No re-fork of the shared shipyard instructions — checked in every file a
+#    session loads: the scan roots and everything they import.
+documents.each do |relative, content|
   SHARED_FILE_IDENTIFIERS.each do |identifier|
     if content.include?(identifier)
       errors << "#{relative}: contains `#{identifier}`, which belongs to shipyard's share/AGENTS.md. " \
-                "Sessions that need it already load that file — don't fork it."
+                "Sessions already load that file — don't fork it."
     end
   end
 end
@@ -243,13 +245,17 @@ PINNED_LITERALS.each do |literal|
     content = read_contained(path, describes, errors)
     next if content.nil?
 
-    claimed = content[claim, 1]
+    # Every occurrence, not just the first: a correct first restatement must
+    # not shield a stale duplicate later in the same file.
+    claimed = content.scan(claim).flatten
 
-    if claimed.nil?
+    if claimed.empty?
       errors << "#{path}: the #{describes} claim matching #{claim.inspect} is " \
                 "gone — reword the doc or update this pin"
-    elsif claimed != defined
-      errors << "#{path} states #{describes} #{claimed}, but #{literal[:defined_in]} defines #{defined}"
+    else
+      claimed.reject { it == defined }.each do |value|
+        errors << "#{path} states #{describes} #{value}, but #{literal[:defined_in]} defines #{defined}"
+      end
     end
   end
 end


### PR DESCRIPTION
Part of a docs pass across our repos.

**AGENTS.md trim** — the architecture essay kept its counterintuitive load-bearing facts and dropped the onboarding prose:

- Multi-tenancy: the `PATH_INFO` → `SCRIPT_NAME` slug move (Rails behaves as if mounted; route helpers mislead), the global identity/session exceptions, jobs restoring `Current.account`, and the Identity-spans-accounts gotcha — kept, failure-mode-first.
- UUID keys: kept the fixture-ordering guarantee with the "don't fix it" consequence.
- Search: the sharded-MySQL vs FTS5-SQLite split kept verbatim.
- Imports/exports: compressed to the real constraints (local **and** S3, stream never buffer).
- Entropy System, Solid Queue, "Key insight" editorializing: cut — context, not correction.
- Opener now states the file's epistemic status: defaults with reasons, not law; invariants (data loss, security, CI gates) surfaced, not overridden; attack your own diff before calling it done.

**SaaS overlay** — `saas/AGENTS.md` gains a pointer to shared 37signals development context, behind the existing `tmp/saas.txt` gate, with an explicit "skip if absent" for non-37signals readers. No 37signals-internal paths in the public root.

**Docs gate** — `script/check_agents_docs` (ported from bc3's CI gate): resolves the `.claude/CLAUDE.md` import chain, bans restating shared observability identifiers in either AGENTS.md, and pins three literals to their defining files (`tmp/saas.txt` ← `lib/fizzy.rb`; 16-way shard count ← `Search::Record::Trilogy`; `BETA_NUMBER` ← `saas/config/deploy.beta.yml`). Wired into `config/ci.rb` and the `ci-checks` workflow's lint job. Mutation-tested: seeded identifier restatements (root and overlay) and pin drift each fail the gate; the restored state passes.