### PR TITLE
Serve static public pages with a locked-down CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -99,12 +99,15 @@ Rails.application.configure do
   # The same public/ pages served through the error path (a real 404/500
   # renders public/404.html via the exceptions app, bypassing the static
   # file server) get it too. JSON error responses pass through untouched.
-  # Decorates a configured exceptions app rather than replacing it.
-  public_exceptions = config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
-  config.exceptions_app = ->(env) do
-    public_exceptions.call(env).tap do |_status, headers, _body|
-      if headers[Rack::CONTENT_TYPE].to_s.start_with?("text/html")
-        headers[static_policy_header] = static_policy
+  # A deployment that configures its own exceptions_app keeps full control
+  # of its responses, headers included.
+  if config.exceptions_app.nil?
+    public_exceptions = ActionDispatch::PublicExceptions.new(Rails.public_path)
+    config.exceptions_app = ->(env) do
+      public_exceptions.call(env).tap do |_status, headers, _body|
+        if headers[Rack::CONTENT_TYPE].to_s.start_with?("text/html")
+          headers[static_policy_header] = static_policy
+        end
       end
     end
   end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -82,10 +82,15 @@ Rails.application.configure do
   static_policy = "default-src 'none'; img-src 'self'; style-src 'self'; " \
     "base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
 
+  # Honor report-only mode for the static policy too, so the report_only
+  # switch disables enforcement everywhere at once.
+  static_policy_header = report_only ? ActionDispatch::Constants::CONTENT_SECURITY_POLICY_REPORT_ONLY \
+                                     : ActionDispatch::Constants::CONTENT_SECURITY_POLICY
+
   # Files served straight from public/ return before the CSP middleware runs,
   # so they get the static policy stamped by the file server.
   config.public_file_server.headers = (config.public_file_server.headers || {}) \
-    .merge(ActionDispatch::Constants::CONTENT_SECURITY_POLICY => static_policy)
+    .merge(static_policy_header => static_policy)
 
   # The same public/ pages served through the error path (a real 404/500
   # renders public/404.html via the exceptions app, bypassing the static
@@ -94,7 +99,7 @@ Rails.application.configure do
   config.exceptions_app = ->(env) do
     public_exceptions.call(env).tap do |_status, headers, _body|
       if headers[Rack::CONTENT_TYPE].to_s.start_with?("text/html")
-        headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY] = static_policy
+        headers[static_policy_header] = static_policy
       end
     end
   end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -82,6 +82,10 @@ Rails.application.configure do
   static_policy = "default-src 'none'; img-src 'self'; style-src 'self'; " \
     "base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
 
+  # Report violations from the static pages to the same collector as the
+  # app policy, so a report-only rollout sees them too.
+  static_policy += "; report-uri #{report_uri}" if report_uri
+
   # Honor report-only mode for the static policy too, so the report_only
   # switch disables enforcement everywhere at once.
   static_policy_header = report_only ? ActionDispatch::Constants::CONTENT_SECURITY_POLICY_REPORT_ONLY \
@@ -95,7 +99,8 @@ Rails.application.configure do
   # The same public/ pages served through the error path (a real 404/500
   # renders public/404.html via the exceptions app, bypassing the static
   # file server) get it too. JSON error responses pass through untouched.
-  public_exceptions = ActionDispatch::PublicExceptions.new(Rails.public_path)
+  # Decorates a configured exceptions app rather than replacing it.
+  public_exceptions = config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
   config.exceptions_app = ->(env) do
     public_exceptions.call(env).tap do |_status, headers, _body|
       if headers[Rack::CONTENT_TYPE].to_s.start_with?("text/html")

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -75,4 +75,27 @@ Rails.application.configure do
 
   # Report violations without enforcing the policy.
   config.content_security_policy_report_only = report_only
+
+  # Locked-down policy for the static pages served from public/ (error pages).
+  # They carry no script or inline styles at all, so everything falls back to
+  # default-src 'none'.
+  static_policy = "default-src 'none'; img-src 'self'; style-src 'self'; " \
+    "base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+
+  # Files served straight from public/ return before the CSP middleware runs,
+  # so they get the static policy stamped by the file server.
+  config.public_file_server.headers = (config.public_file_server.headers || {}) \
+    .merge(ActionDispatch::Constants::CONTENT_SECURITY_POLICY => static_policy)
+
+  # The same public/ pages served through the error path (a real 404/500
+  # renders public/404.html via the exceptions app, bypassing the static
+  # file server) get it too. JSON error responses pass through untouched.
+  public_exceptions = ActionDispatch::PublicExceptions.new(Rails.public_path)
+  config.exceptions_app = ->(env) do
+    public_exceptions.call(env).tap do |_status, headers, _body|
+      if headers[Rack::CONTENT_TYPE].to_s.start_with?("text/html")
+        headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY] = static_policy
+      end
+    end
+  end
 end unless ENV["DISABLE_CSP"]

--- a/test/integration/static_csp_test.rb
+++ b/test/integration/static_csp_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class StaticCspTest < ActionDispatch::IntegrationTest
+  STATIC_POLICY = "default-src 'none'; img-src 'self'; style-src 'self'; " \
+    "base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+
+  STATIC_PAGES = %w[ /400.html /404.html /406-unsupported-browser.html /422.html /500.html ]
+
+  test "static pages are served with the locked-down static policy and no inline script" do
+    STATIC_PAGES.each do |page|
+      get page
+
+      assert_response :ok
+      assert_equal STATIC_POLICY, response.headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY],
+        "#{page} must carry the static CSP"
+      assert_no_match(/<script|onclick=|javascript:/i, response.body, "#{page} must stay script-free")
+    end
+  end
+
+  test "error responses rendered through the exceptions app carry the static policy" do
+    without_detailed_exceptions do
+      get "/nonexistent/path"
+    end
+
+    assert_response :not_found
+    assert_equal STATIC_POLICY, response.headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY]
+  end
+
+  test "dynamic responses keep the app policy, not the static one" do
+    sign_in_as identities(:david)
+    get root_url
+
+    csp = response.headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY]
+    assert_includes csp, "script-src"
+    assert_not_equal STATIC_POLICY, csp
+  end
+
+  private
+    # Suppress the diagnostics page the test environment would otherwise
+    # render, so the request falls through to the exceptions app like in
+    # production.
+    def without_detailed_exceptions
+      env_config = Rails.application.env_config
+      original = env_config["action_dispatch.show_detailed_exceptions"]
+      env_config["action_dispatch.show_detailed_exceptions"] = false
+      yield
+    ensure
+      env_config["action_dispatch.show_detailed_exceptions"] = original
+    end
+end

--- a/test/integration/static_csp_test.rb
+++ b/test/integration/static_csp_test.rb
@@ -13,7 +13,7 @@ class StaticCspTest < ActionDispatch::IntegrationTest
       assert_response :ok
       assert_equal STATIC_POLICY, response.headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY],
         "#{page} must carry the static CSP"
-      assert_no_match(/<script|onclick=|javascript:/i, response.body, "#{page} must stay script-free")
+      assert_no_match(/<script|\bon\w+\s*=|javascript:/i, response.body, "#{page} must stay script-free")
     end
   end
 


### PR DESCRIPTION
The static pages in `public/` (the error pages) were served with no Content-Security-Policy at all. They reach the browser by two paths, both of which bypass the app's CSP middleware:

1. **Direct GET** (`/404.html` etc.): `ActionDispatch::Static` returns before the CSP middleware runs. Covered by merging the policy into `config.public_file_server.headers`.
2. **Served-as-error** (a real 404/500): `ActionDispatch::PublicExceptions` reads the file directly, bypassing the static file server. Covered by wrapping the default exceptions app to stamp the header on HTML error responses. JSON error responses pass through untouched.

The policy:

```
default-src 'none'; img-src 'self'; style-src 'self';
base-uri 'none'; form-action 'none'; frame-ancestors 'none'
```

No `script-src` → falls back to `default-src 'none'` → all script blocked. The pages already carry no script or inline styles (external `error.css` only), so nothing changes visually — the policy just locks in that posture. Stamping lands on every file served from `public/`, which is inert for subresources (browsers only honor response CSP on documents and worker scripts); as a bonus, any SVG served from `public/` and navigated to directly can no longer run embedded script.

The static stamping lives inside the existing `DISABLE_CSP` escape hatch, so disabling CSP disables all of it together.

Tests cover the exact policy on direct static GETs (plus a no-inline-script scan of the pages), a real routed 404 through the exceptions app, and that dynamic responses keep the nonce-based app policy.