### PR TITLE
SaaS deployments process Active Storage attachments with HotCell

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -23,6 +23,9 @@ PROMETHEUS_EXPORTER_URL = "http://127.0.0.1:9306/metrics"
 "pacman:poppler-glib" = "latest"
 "pacman:libcgif" = "latest"
 "pacman:ffmpeg" = "latest"
+# An uncontainerized dev cell shells out to the host, so every tool in saas/hotcell/Dockerfile needs an
+# equivalent here or those operations fail in development only.
+"pacman:mupdf-tools" = "latest"
 "pacman:rav1e" = "latest"
 "pacman:svt-av1" = "latest"
 "pacman:gitleaks" = "latest"

--- a/Brewfile
+++ b/Brewfile
@@ -2,3 +2,8 @@ brew "imagemagick"
 brew "openslide"
 brew "vips"
 brew "gitleaks"
+
+# An uncontainerized dev cell shells out to the host, so every tool in saas/hotcell/Dockerfile needs an
+# equivalent here or those operations fail in development only.
+brew "ffmpeg"
+brew "mupdf-tools"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: d0e506f131fa0e8abead37b6c31505ce4ad8d93e
+  revision: ce95deb79b0402a21cf2fe854f47179427af98c7
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -247,7 +247,7 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -376,7 +376,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-session (2.1.2)
@@ -396,7 +396,7 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.2)
+    rbs (4.1.3)
       logger
       prism (>= 1.6.0)
       tsort
@@ -406,7 +406,7 @@ GEM
       rbs (>= 4.0.0)
       tsort
     regexp_parser (2.11.3)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     rexml (3.4.4)
     rouge (4.7.0)
@@ -637,7 +637,7 @@ CHECKSUMS
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
-  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
@@ -693,7 +693,7 @@ CHECKSUMS
   puma (7.2.1) sha256=d7bf0e9cabd532e0d401e142cd94e3ac531e993610e2d80e6fbf9c26961414b0
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
@@ -705,10 +705,10 @@ CHECKSUMS
   railties (8.2.0.alpha)
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.1.2) sha256=050eb1d8b508f1233bed929c0f2c7052302f7adf295230d9cb314e9024078f48
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
-  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   rqrcode (3.2.0) sha256=64c1494ca6bb67d731330f38b50e3fd09eeab4f5dcd04b608e21218d1d0b9542

--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -10,6 +10,10 @@ gem "fizzy-saas", path: "saas"
 gem "console1984", bc: "console1984"
 gem "audits1984", bc: "audits1984"
 
+# Attachment processing in an unprivileged sibling container
+gem "hotcell-client", "~> 0.1.0"
+gem "activestorage-hotcell-client", "~> 0.1.0"
+
 # Native push notifications (iOS/Android)
 gem "action_push_native"
 

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -63,7 +63,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: d0e506f131fa0e8abead37b6c31505ce4ad8d93e
+  revision: ce95deb79b0402a21cf2fe854f47179427af98c7
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -359,7 +359,7 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -527,7 +527,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-session (2.1.2)
@@ -550,7 +550,7 @@ GEM
     rake-compiler-dock (1.9.1)
     rb_sys (0.9.117)
       rake-compiler-dock (= 1.9.1)
-    rbs (4.1.2)
+    rbs (4.1.3)
       logger
       prism (>= 1.6.0)
       tsort
@@ -560,7 +560,7 @@ GEM
       rbs (>= 4.0.0)
       tsort
     regexp_parser (2.11.3)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     rexml (3.4.4)
     rinku (2.0.6)
@@ -874,7 +874,7 @@ CHECKSUMS
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
-  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
@@ -941,7 +941,7 @@ CHECKSUMS
   queenbee (3.2.0)
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
@@ -956,10 +956,10 @@ CHECKSUMS
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rake-compiler-dock (1.9.1) sha256=e73720a29aba9c114728ce39cc0d8eef69ba61d88e7978c57bac171724cd4d53
   rb_sys (0.9.117) sha256=755feaf6c640baceca7a9362dfb0ae87ff4ff16e3566d9ef86533896eb85cb59
-  rbs (4.1.2) sha256=050eb1d8b508f1233bed929c0f2c7052302f7adf295230d9cb314e9024078f48
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
-  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rinku (2.0.6) sha256=8b60670e3143f3db2b37efa262971ce3619ec23092045498ef9f077d82828d7d
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -611,12 +611,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.2.0)
+    sentry-rails (6.7.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.2.0)
-    sentry-ruby (6.2.0)
+      sentry-ruby (~> 6.7.0)
+    sentry-ruby (6.7.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     signet (0.21.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -976,8 +977,8 @@ CHECKSUMS
   rubyzip (3.3.0) sha256=a372fc67892a4f8c0bc8ec906b720353d8e48807a64b2e63adf99b1e3583a034
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
-  sentry-rails (6.2.0) sha256=e1a1977e58099231774b85ca40ce9e1d185326cee814bed4f59bc3192f1f77e6
-  sentry-ruby (6.2.0) sha256=d7b8a358a3a0d0536bd194b19cc282c85f295b6d242731e9b4a934ccdb71ac17
+  sentry-rails (6.7.0) sha256=d295dc5aa239eb91d4fb123c55d9ff2d3c40e7c29921539c5b4ae684b1490293
+  sentry-ruby (6.7.0) sha256=b4b915d79a0395ad02106d4012aa1914641456e042ce36393f15bd1630d8db42
   signet (0.21.0) sha256=d617e9fbf24928280d39dcfefba9a0372d1c38187ffffd0a9283957a10a8cd5b
   sniffer (0.5.0) sha256=cd040cc51929c04749b20baa4dd8f5985174210e13437491f4923b8de27e1359
   solid_cable (4.0.0)

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -239,6 +239,9 @@ GEM
       activemodel (>= 7.0)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 7.0)
+    activestorage-hotcell-client (0.1.0)
+      activestorage (>= 8.2.0.alpha)
+      hotcell-client (= 0.1.0)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ansi (1.6.0)
@@ -347,6 +350,10 @@ GEM
       signet (>= 0.16, < 2.a)
     gvltools (0.5.0)
     hashdiff (1.2.1)
+    hotcell-client (0.1.0)
+      activesupport (>= 7.1)
+      hotcell-core (= 0.1.0)
+    hotcell-core (0.1.0)
     http-2 (1.1.1)
     httpx (1.7.1)
       http-2 (>= 1.0.0)
@@ -727,6 +734,7 @@ DEPENDENCIES
   action_push_native
   actionpack-xml_parser
   activeresource
+  activestorage-hotcell-client (~> 0.1.0)
   audits1984!
   autotuner
   aws-sdk-s3
@@ -742,6 +750,7 @@ DEPENDENCIES
   fizzy-saas!
   geared_pagination (~> 1.2)
   gvltools
+  hotcell-client (~> 0.1.0)
   image_processing (~> 1.14)
   importmap-rails
   jbuilder
@@ -808,6 +817,7 @@ CHECKSUMS
   activerecord (8.2.0.alpha)
   activeresource (6.2.0) sha256=818ca60d3cd1ff7bbb7277f41250ad4d61a7cdbe30fbf52b2145e1b66ed13900
   activestorage (8.2.0.alpha)
+  activestorage-hotcell-client (0.1.0) sha256=987c8447c3875f5110b18b8858eb62c24de1ec55798c806ff8bfb206dc7acf3b
   activesupport (8.2.0.alpha)
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
@@ -869,6 +879,8 @@ CHECKSUMS
   googleauth (1.16.1) sha256=36776bce9d55d8c1a0c6638c939b000dcee5954ca5b728f06ec4c2df4a46709c
   gvltools (0.5.0) sha256=a15e480b3860e7e9661e5e53aff9b1802fe9018fa42a5e845adc2a19a7bcc65d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  hotcell-client (0.1.0) sha256=4317940c1619f016b2a28f1d43b730b5efddfc766ebfc3b42b9d74bbadcf2607
+  hotcell-core (0.1.0) sha256=0bfbe2f9850ad0ed3139fb60701c46aa5d9a01741f2f512ad80fb244ce6b9a36
   http-2 (1.1.1) sha256=1141a5a03c2f4e6b8d2fa62394de581e1ff6387711cd7ed577212e9d95562bba
   httpx (1.7.1) sha256=ae380461539203c92f3ee65c13b22dfccb0d975156426869f57820505cacdf56
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,1 @@
+web: bin/rails server -b 0.0.0.0 -p ${PORT:-3006}

--- a/bin/dev
+++ b/bin/dev
@@ -3,7 +3,6 @@
 PORT=3006
 USE_TAILSCALE=0
 USE_PUSH=0
-USE_HOTCELL=0
 FOREMAN_ARGS=()
 
 export PORT
@@ -21,7 +20,6 @@ for arg in "$@"; do
   case $arg in
     --tailscale) USE_TAILSCALE=1 ;;
     --push) USE_PUSH=1 ;;
-    --hotcell) USE_HOTCELL=1 ;;
     --help|-h)
       cat <<USAGE
 Usage: bin/dev [options]
@@ -31,12 +29,10 @@ Starts the Fizzy development processes using foreman.
 Options:
   --tailscale   Expose the dev server via tailscale serve
   --push        Load push notification credentials from 1Password (implies SaaS mode)
-  --hotcell     Route attachment processing through the cell, not just boot it
   -h, --help    Show this help
 
-In SaaS mode a hotcell cell boots beside the server with HOTCELL_ROOT set, while
-every conversion still runs in the app — the same position production step one
-is in. --hotcell moves the work to the cell.
+In SaaS mode a hotcell cell boots beside the server with HOTCELL_ROOT set, and
+attachment processing runs in it — the same position production is in.
 USAGE
       exit 0
       ;;
@@ -76,9 +72,6 @@ PROCFILE=Procfile.dev
 if [ -f tmp/saas.txt ]; then
   PROCFILE=saas/Procfile.dev
   export HOTCELL_ROOT=tmp/hotcell
-  if [ "$USE_HOTCELL" = "1" ]; then
-    export HOTCELL_ACTIVE_STORAGE=all
-  fi
   if [ ! -f saas/hotcell/Gemfile.lock ]; then
     echo "Error: the cell has no bundle. Run bin/setup." >&2
     exit 1

--- a/bin/dev
+++ b/bin/dev
@@ -1,8 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 PORT=3006
 USE_TAILSCALE=0
 USE_PUSH=0
+USE_HOTCELL=0
+FOREMAN_ARGS=()
+
+export PORT
 
 if [ -t 1 ]; then
   c_bar='\033[2m▎\033[0m'    # dim
@@ -17,6 +21,26 @@ for arg in "$@"; do
   case $arg in
     --tailscale) USE_TAILSCALE=1 ;;
     --push) USE_PUSH=1 ;;
+    --hotcell) USE_HOTCELL=1 ;;
+    --help|-h)
+      cat <<USAGE
+Usage: bin/dev [options]
+
+Starts the Fizzy development processes using foreman.
+
+Options:
+  --tailscale   Expose the dev server via tailscale serve
+  --push        Load push notification credentials from 1Password (implies SaaS mode)
+  --hotcell     Route attachment processing through the cell, not just boot it
+  -h, --help    Show this help
+
+In SaaS mode a hotcell cell boots beside the server with HOTCELL_ROOT set, while
+every conversion still runs in the app — the same position production step one
+is in. --hotcell moves the work to the cell.
+USAGE
+      exit 0
+      ;;
+    *) FOREMAN_ARGS+=("$arg") ;;
   esac
 done
 
@@ -42,6 +66,23 @@ fi
 
 if [ -f tmp/oss-config.txt ]; then
   export OSS_CONFIG=1
+fi
+
+# The cell is SaaS-only, so it lives in saas/Procfile.dev — its gems come from a private repository,
+# and the root Procfile.dev must run for an open-source checkout that can never install them. It runs
+# uncontainerized here: a container cannot receive a descriptor on macOS, where Docker runs a Linux VM
+# and SCM_RIGHTS has nothing meaningful to hand across two kernels.
+PROCFILE=Procfile.dev
+if [ -f tmp/saas.txt ]; then
+  PROCFILE=saas/Procfile.dev
+  export HOTCELL_ROOT=tmp/hotcell
+  if [ "$USE_HOTCELL" = "1" ]; then
+    export HOTCELL_ACTIVE_STORAGE=all
+  fi
+  if [ ! -f saas/hotcell/Gemfile.lock ]; then
+    echo "Error: the cell has no bundle. Run bin/setup." >&2
+    exit 1
+  fi
 fi
 
 if [ "$USE_TAILSCALE" = "1" ]; then
@@ -72,9 +113,17 @@ else
   DEV_URL="http://app.fizzy.localhost:$PORT/"
 fi
 
+# Not in the bundle, on purpose: it manages the bundle's processes rather than running inside one.
+if ! foreman version >/dev/null 2>&1; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
 printf "\n"
 printf " ${c_bar} ${c_label}URL${c_reset}     ${c_url}${DEV_URL}${c_reset}\n"
 printf " ${c_bar} ${c_label}Login${c_reset}   david@example.com\n"
 printf "\n"
 
-./bin/rails server -b 0.0.0.0 -p $PORT
+# -d ".": foreman roots itself at the Procfile's own directory, which for saas/Procfile.dev would run
+# everything from saas/.
+foreman start -f "$PROCFILE" -d . "${FOREMAN_ARGS[@]}"

--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -1,24 +1,29 @@
-raise LoadError, "Please install libvips" unless defined?(Vips::LIBRARY_VERSION)
-
-# Disable unfuzzed libvips operations.
-#
-# To block loaders we need to call `Vips.block` after Rails and image_processing set their
-# defaults. Force the order of operations by autoloading the file now.
-ActiveStorage::Transformers::Vips
-Vips.block_untrusted(true)
-Vips.block("VipsForeignLoadOpenslide", true) # prevent sqlite segfault in forked parallel workers
-Vips.block("VipsForeignLoadTiff", true) # unused; list below only gates variants, not parsing
-
+# These formats are never varied, whether conversions run in-app or in a cell.
 Rails.application.config.active_storage.variable_content_types -=
     %w[ image/bmp image/tiff image/vnd.microsoft.icon image/vnd.adobe.photoshop ]
 
-# Limit libvips to 4 threads for each thread pool. Default is #CPUs.
-Vips.concurrency_set 4
+# When a hotcell cell carries the conversions, no image is ever parsed in this process and the cell
+# configures its own libvips.
+unless defined?(Fizzy::Saas::Cell) && Fizzy::Saas::Cell.enabled?
+  raise LoadError, "Please install libvips" unless defined?(Vips::LIBRARY_VERSION)
 
-# Limit libvips caches to reduce memory pressure.
-#
-# Do not disable entirely since libvips relies on some caching internally.
-# (When we disabled caches, we hit a ton of JPEG out of order read errors.)
-Vips.cache_set_max 10               # Default 100
-Vips.cache_set_max_mem 10.megabytes # Default 100MB
-Vips.cache_set_max_files 10         # Default 100
+  # Disable unfuzzed libvips operations.
+  #
+  # To block loaders we need to call `Vips.block` after Rails and image_processing set their
+  # defaults. Force the order of operations by autoloading the file now.
+  ActiveStorage::Transformers::Vips
+  Vips.block_untrusted(true)
+  Vips.block("VipsForeignLoadOpenslide", true) # prevent sqlite segfault in forked parallel workers
+  Vips.block("VipsForeignLoadTiff", true) # unused; the variable_content_types list above only gates variants, not parsing
+
+  # Limit libvips to 4 threads for each thread pool. Default is #CPUs.
+  Vips.concurrency_set 4
+
+  # Limit libvips caches to reduce memory pressure.
+  #
+  # Do not disable entirely since libvips relies on some caching internally.
+  # (When we disabled caches, we hit a ton of JPEG out of order read errors.)
+  Vips.cache_set_max 10               # Default 100
+  Vips.cache_set_max_mem 10.megabytes # Default 100MB
+  Vips.cache_set_max_files 10         # Default 100
+end

--- a/saas/Dockerfile
+++ b/saas/Dockerfile
@@ -61,6 +61,12 @@ RUN apt-get update -qq && \
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
+# Where the hotcell socket volume mounts, owned by the cell's uid rather than this image's user. A new
+# named volume takes its ownership from the directory it covers in whichever container mounts it first,
+# and on a new host that is the app. Left to Docker to create, it is root-owned and the cell cannot create
+# its sockets in it — which fails as EACCES when the accessory boots, with nothing here to say why.
+RUN mkdir -p /run/hotcell/active_storage && chown -R 10001:10001 /run/hotcell
+
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \
     chown -R rails:rails db log storage tmp

--- a/saas/Dockerfile
+++ b/saas/Dockerfile
@@ -54,7 +54,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips build-essential ffmpeg groff libreoffice-writer libreoffice-impress libreoffice-calc mupdf-tools sqlite3 libjemalloc-dev && \
+    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips build-essential ffmpeg mupdf-tools sqlite3 libjemalloc-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/saas/Dockerfile
+++ b/saas/Dockerfile
@@ -52,9 +52,12 @@ RUN SECRET_KEY_BASE_DUMMY=1 \
 # Final stage for app image
 FROM base
 
-# Install packages needed for deployment
+# Install packages needed for deployment. No libvips, ffmpeg or mupdf-tools: every conversion runs
+# in the hotcell cell, whose image carries its own. Rails' active_storage/vips tolerates the missing
+# library (ActiveStorage::VIPS_AVAILABLE=false), and config/initializers/vips.rb only demands it
+# when no cell is registered.
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips build-essential ffmpeg mupdf-tools sqlite3 libjemalloc-dev && \
+    apt-get install --no-install-recommends -y curl libsqlite3-0 build-essential sqlite3 libjemalloc-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/saas/Dockerfile
+++ b/saas/Dockerfile
@@ -57,7 +57,7 @@ FROM base
 # library (ActiveStorage::VIPS_AVAILABLE=false), and config/initializers/vips.rb only demands it
 # when no cell is registered.
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 build-essential sqlite3 libjemalloc-dev && \
+    apt-get install --no-install-recommends -y libsqlite3-0 sqlite3 libjemalloc-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/saas/Procfile.dev
+++ b/saas/Procfile.dev
@@ -1,0 +1,5 @@
+# SaaS development: the app plus a hotcell cell beside it. The cell's gems come from a private
+# repository, which is why this file lives here rather than in the root Procfile.dev — the open-source
+# checkout must be able to run foreman against a Procfile that never names the cell.
+web: bin/rails server -b 0.0.0.0 -p ${PORT:-3006}
+cell: env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE BUNDLE_GEMFILE=$PWD/saas/hotcell/Gemfile HOTCELL_DIR=$PWD/tmp/hotcell/active_storage HOTCELL_CONFIG=$PWD/saas/hotcell/config.rb HOTCELL_OPERATIONS=$PWD/saas/hotcell/operations bundle exec hotcell

--- a/saas/Procfile.dev
+++ b/saas/Procfile.dev
@@ -1,5 +1,4 @@
-# SaaS development: the app plus a hotcell cell beside it. The cell's gems come from a private
-# repository, which is why this file lives here rather than in the root Procfile.dev — the open-source
-# checkout must be able to run foreman against a Procfile that never names the cell.
+# SaaS development: the app plus a hotcell cell beside it. This file lives here rather than in the root
+# Procfile.dev because the cell is SaaS-only and the open-source checkout must never boot one.
 web: bin/rails server -b 0.0.0.0 -p ${PORT:-3006}
 cell: env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE BUNDLE_GEMFILE=$PWD/saas/hotcell/Gemfile HOTCELL_DIR=$PWD/tmp/hotcell/active_storage HOTCELL_CONFIG=$PWD/saas/hotcell/config.rb HOTCELL_OPERATIONS=$PWD/saas/hotcell/operations bundle exec hotcell

--- a/saas/README.md
+++ b/saas/README.md
@@ -56,6 +56,117 @@ bin/dev --push
 
 This will ask for your 1Password authorization to fetch the push credentials. Note that this loads the **production** APNs and FCM credentials into your environment.
 
+## Attachment processing in a hotcell cell
+
+Image variants, blob analysis and PDF and video previews can run in an unprivileged sibling container with no network, instead of in the app process beside the database credentials. The cell lives in `saas/hotcell/` — its `Dockerfile`, its own `Gemfile`, its limits in `config.rb`, and the operations it serves.
+
+### Running it
+
+In SaaS mode `bin/dev` boots a cell beside the server, through `saas/Procfile.dev` and foreman. The cell runs uncontainerized, because a container cannot receive a file descriptor on macOS — Docker runs a Linux VM there and `SCM_RIGHTS` has nothing meaningful to hand across two kernels.
+
+```sh
+bin/dev            # the cell boots and /hotcellz answers; conversions still run in the app
+bin/dev --hotcell  # attachment processing goes to the cell
+```
+
+`/hotcellz` says whether the cell is reachable. It asks the control socket only — `describe` and `metrics`, which the supervisor answers inline with no fork — and replies `OK` or `FAIL` with a 200 or a 503. It is unauthenticated so a monitor can poll it, and it says nothing else, because a stranger has no business knowing the cell's inventory or how loaded it is.
+
+`/hotcellz/test` is staff-only and returns the full diagnosis as JSON, including two round trips over the work socket, the socket that carries real files. The two prove different halves of it: `example.echo` reads its descriptor directly, while `example.reopen` re-opens it by name, which is what every operation that hands a tool a filename does. A cell whose group is wrong answers echo perfectly and fails reopen — so echo alone will tell you a broken cell is healthy. Each round trip forks a worker, which is why this is the half behind authentication.
+
+**A monitor therefore cannot see a broken work socket.** Only the round trips can, and they are staff-only. That is deliberate: it is a configuration error rather than something that degrades on its own, so run `/hotcellz/test` — or the `Cell.diagnostics(work: true)` runner — by hand whenever the configuration changes.
+
+Because the dev cell shells out to your laptop rather than to the image, every tool in `saas/hotcell/Dockerfile` needs a host equivalent. `bin/setup` installs them; if you add a tool to the image, add it to `.mise.toml` and the `Brewfile` too, or that operation will fail in development only.
+
+### The switches
+
+| variable | what it does | where it lives |
+| --- | --- | --- |
+| `HOTCELL_ROOT` | Registers the cell. Metrics, `describe`, the healthcheck and `/hotcellz` answer, and every conversion still runs in the app. | `saas/config/deploy.yml` |
+| `HOTCELL_GROUP` | The gid the app and the cell share, so the cell can open a file the app hands it by name. Must match the `group-add` on the app's roles and the cell's own gid. Unset in development, where both sides run as one user. | `saas/config/deploy.yml` |
+| `HOTCELL_ACTIVE_STORAGE` | Moves the work. A comma-separated list of `images`, `pdfs`, `media`, or `all`. | each `saas/config/deploy.<destination>.yml` |
+
+Registering and moving work are separate questions, and the second is a list because the rollout moves
+operations in groups. `images` carries the image analyzer along with the transformer whether or not you
+ask: Rails' image analyzers test `variant_processor == :vips`, so pointing the transformer at a class makes
+them decline and blobs get marked analyzed with no dimensions.
+
+The first two are the same everywhere and belong in the base file. **`HOTCELL_ACTIVE_STORAGE` belongs in
+the destination files**, because how far a destination has rolled out is a per-destination decision — in
+the base it moves every destination at once. A destination naming no list keeps its cell registered and
+idle, which is where one that has not started should be.
+
+An unknown group name raises at boot rather than meaning "off".
+
+### Building and shipping the image
+
+Kamal builds app images and not accessory images, so the cell's image has its own two scripts. They are separate so that building can happen anywhere and publishing is deliberate.
+
+```sh
+saas/hotcell/bin/build                        # locks the gem version, builds, pins deploy.yml to the tag
+saas/hotcell/bin/build --platform=linux/amd64 # what the hosts run
+saas/hotcell/bin/push                         # pushes that tag to the registry
+```
+
+**The tag is a content hash**, the first 12 characters of a SHA-256 over the `Dockerfile`, `Gemfile`,
+`Gemfile.lock`, `config.rb` and `operations/*.rb` — see `bin/image`. Not a git revision: the commit that
+bumps the gem and pins the result could never name itself, because amending it changed the SHA the pin was
+meant to hold. Identical bytes give an identical tag, and changing something the image does not contain
+leaves it alone. `saas/test/lib/hotcell_accessory_test.rb` holds the pin in `deploy.yml` equal to what the
+tree builds, so a stale pin fails in CI.
+
+**`build` locks the cell's `Gemfile.lock` to the hotcell version in the app's `Gemfile.saas.lock`**,
+writing it if the two differ, and then builds. The app's lockfile is the source of truth: a client and
+server one version apart is a `protocol` failure on every request. So move the gem in the application
+first, then build.
+
+**`build` also writes the pin in `saas/config/deploy.yml`**, and it belongs there rather than in `push`:
+the tag is a hash of the tree's contents, so the pin has to land in the same commit as the contents that
+produced it. `push` happens after that commit, so pinning there would leave every commit holding a stale
+pin. Both lockfiles, the operations, and the pin go in one change.
+
+Tags are immutable and there is no `latest`: a deploy does not update an accessory, so `bin/kamal accessory reboot hotcell -d <destination>` pulls whatever the tag names at that moment. A moving tag would make what a host runs depend on when it last rebooted.
+
+### Deploying the cell: the runbook
+
+Deploy the cell when anything under `saas/hotcell/` changes, or when the hotcell gems move in
+`Gemfile.saas.lock`. CI tells you when you owe one: `hotcell_accessory_test.rb` fails if the pin in
+`deploy.yml` no longer matches what the tree builds.
+
+1. Build the image and pin it:
+
+   ```sh
+   saas/hotcell/bin/build --platform=linux/amd64
+   ```
+
+2. Run the tests:
+
+   ```sh
+   bin/rails test saas/test/lib/hotcell_accessory_test.rb
+   ```
+
+3. Commit everything together: the lockfiles, the `saas/config/deploy.yml` pin, and whatever
+   changed under `saas/hotcell/`.
+
+4. Push the image:
+
+   ```sh
+   saas/hotcell/bin/push
+   ```
+
+5. Reboot the accessory on each destination:
+
+   ```sh
+   bin/kamal accessory reboot hotcell -d <destination>
+   ```
+
+6. Verify the destination: `/hotcellz` answers `OK`, `/hotcellz/test` (staff-only) passes all four
+   checks, `hotcell_up == 1` for every host in Prometheus, and no `WARN`/`ERROR` lines in Loki
+   under `{service_name="hotcell"}`.
+
+When the hotcell gems moved, the app has to be deployed too — the usual rollout, separate from
+this one. A client and server more than one revision apart fail every request with a `protocol`
+error, so keep the two close together.
+
 ## Environments
 
 Fizzy is deployed with [Kamal](https://kamal-deploy.org/). You'll need to have the 1Password CLI set up in order to access the secrets that are used when deploying. Provided you have that, it should be as simple as `bin/kamal deploy` to the correct environment.

--- a/saas/README.md
+++ b/saas/README.md
@@ -65,8 +65,7 @@ Image variants, blob analysis and PDF and video previews can run in an unprivile
 In SaaS mode `bin/dev` boots a cell beside the server, through `saas/Procfile.dev` and foreman. The cell runs uncontainerized, because a container cannot receive a file descriptor on macOS — Docker runs a Linux VM there and `SCM_RIGHTS` has nothing meaningful to hand across two kernels.
 
 ```sh
-bin/dev            # the cell boots and /hotcellz answers; conversions still run in the app
-bin/dev --hotcell  # attachment processing goes to the cell
+bin/dev            # the cell boots and carries attachment processing, as in production
 ```
 
 `/hotcellz` says whether the cell is reachable. It asks the control socket only — `describe` and `metrics`, which the supervisor answers inline with no fork — and replies `OK` or `FAIL` with a 200 or a 503. It is unauthenticated so a monitor can poll it, and it says nothing else, because a stranger has no business knowing the cell's inventory or how loaded it is.
@@ -81,21 +80,8 @@ Because the dev cell shells out to your laptop rather than to the image, every t
 
 | variable | what it does | where it lives |
 | --- | --- | --- |
-| `HOTCELL_ROOT` | Registers the cell. Metrics, `describe`, the healthcheck and `/hotcellz` answer, and every conversion still runs in the app. | `saas/config/deploy.yml` |
+| `HOTCELL_ROOT` | Registers the cell, which then carries every conversion. Unset, everything runs in the app. | `saas/config/deploy.yml` |
 | `HOTCELL_GROUP` | The gid the app and the cell share, so the cell can open a file the app hands it by name. Must match the `group-add` on the app's roles and the cell's own gid. Unset in development, where both sides run as one user. | `saas/config/deploy.yml` |
-| `HOTCELL_ACTIVE_STORAGE` | Moves the work. A comma-separated list of `images`, `pdfs`, `media`, or `all`. | each `saas/config/deploy.<destination>.yml` |
-
-Registering and moving work are separate questions, and the second is a list because the rollout moves
-operations in groups. `images` carries the image analyzer along with the transformer whether or not you
-ask: Rails' image analyzers test `variant_processor == :vips`, so pointing the transformer at a class makes
-them decline and blobs get marked analyzed with no dimensions.
-
-The first two are the same everywhere and belong in the base file. **`HOTCELL_ACTIVE_STORAGE` belongs in
-the destination files**, because how far a destination has rolled out is a per-destination decision — in
-the base it moves every destination at once. A destination naming no list keeps its cell registered and
-idle, which is where one that has not started should be.
-
-An unknown group name raises at boot rather than meaning "off".
 
 ### Building and shipping the image
 

--- a/saas/app/controllers/hotcellz_controller.rb
+++ b/saas/app/controllers/hotcellz_controller.rb
@@ -1,18 +1,8 @@
-# Two actions, because the two questions cost different things to answer.
-#
-# `show` is unauthenticated, like the /up beside it, so an alerting system holding no session can poll it.
-# It asks the control socket only: describe and metrics are answered by the supervisor inline, with no fork
-# and no queue, so no stranger can make this cell do work. It says `OK` or `FAIL` and nothing else — the
-# status is the alertable signal, and the cell's inventory, counters and configuration are not a stranger's
-# business.
-#
-# `test` crosses the work socket, which forks a worker per round trip. That is why it is staff-only: the
-# gate is what bounds who may spend one.
-#
-# The trade this makes: only the round trips can see a work socket the app cannot use, and they now sit
-# behind authentication — so a group or ownership mistake is not something a monitor will catch. It is a
-# configuration error rather than something that degrades on its own, and finding it is a person running
-# the checks, once, when the configuration changes.
+# Two actions, because the two questions cost different things to answer. `show` is unauthenticated so a
+# monitor can poll it, and asks only the control socket, which the supervisor answers inline with no fork.
+# `test` crosses the work socket, which forks a worker per round trip — the staff gate bounds who may
+# spend one. The trade: a broken work socket is invisible to a monitor, so a person runs `test` whenever
+# the configuration changes.
 class HotcellzController < ApplicationController
   allow_unauthenticated_access
   disallow_account_scope

--- a/saas/app/controllers/hotcellz_controller.rb
+++ b/saas/app/controllers/hotcellz_controller.rb
@@ -1,0 +1,44 @@
+# Two actions, because the two questions cost different things to answer.
+#
+# `show` is unauthenticated, like the /up beside it, so an alerting system holding no session can poll it.
+# It asks the control socket only: describe and metrics are answered by the supervisor inline, with no fork
+# and no queue, so no stranger can make this cell do work. It says `OK` or `FAIL` and nothing else — the
+# status is the alertable signal, and the cell's inventory, counters and configuration are not a stranger's
+# business.
+#
+# `test` crosses the work socket, which forks a worker per round trip. That is why it is staff-only: the
+# gate is what bounds who may spend one.
+#
+# The trade this makes: only the round trips can see a work socket the app cannot use, and they now sit
+# behind authentication — so a group or ownership mistake is not something a monitor will catch. It is a
+# configuration error rather than something that degrades on its own, and finding it is a person running
+# the checks, once, when the configuration changes.
+class HotcellzController < ApplicationController
+  allow_unauthenticated_access
+  disallow_account_scope
+
+  before_action :ensure_staff_access, only: :test
+
+  def show
+    reachable = healthy? Fizzy::Saas::Cell.diagnostics
+
+    render plain: reachable ? "OK" : "FAIL", status: reachable ? :ok : :service_unavailable
+  end
+
+  def test
+    diagnostics = Fizzy::Saas::Cell.diagnostics(work: true)
+
+    render json: diagnostics, status: healthy?(diagnostics) ? :ok : :service_unavailable
+  end
+
+  private
+    # Authorization#ensure_staff reads Current.identity.staff?, and this controller is reachable with no
+    # identity at all. Signed out is refused rather than sent to a login page: a prober wants an answer.
+    def ensure_staff_access
+      head :forbidden unless Current.identity&.staff?
+    end
+
+    def healthy?(diagnostics)
+      diagnostics.values_at(:describe, :metrics, :echo, :reopen).compact.all? { it[:ok] }
+    end
+end

--- a/saas/bin/setup
+++ b/saas/bin/setup
@@ -107,3 +107,29 @@ if [ -e tmp/minio-dev.txt ]; then
 fi
 
 step "Starting mysql" ~/Work/basecamp/docker-dev/setup mysql84
+
+# The cell has its own Gemfile — the same one its image build copies — and nothing in the app's setup
+# installs it, so without this a fresh checkout cannot boot a cell.
+#
+# Every one of these must be unset, not just BUNDLE_GEMFILE overridden. Bundler exports its whole
+# environment into each child, and BUNDLE_LOCKFILE outranks an explicit BUNDLE_GEMFILE — so run from
+# inside a bundle, as bin/ci does, the cell's Gemfile resolves against the app's lockfile and bundler
+# reports the git source as "not yet checked out". That variable is new in Bundler 4, which is how a list
+# that used to be enough stopped being enough.
+step "Installing the cell's RubyGems" \
+  env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE \
+    BUNDLE_GEMFILE="$app_root/saas/hotcell/Gemfile" bundle install
+
+# The dev cell runs uncontainerized and does not need the image. Build it anyway, where that is possible:
+# a Dockerfile that only ever builds in CI or at deploy time is one that breaks at the worst moment. A
+# failed build stops setup on purpose — but not being able to attempt one is not a failure, so probe for
+# the script before docker, and skip rather than abort when either is missing.
+if [ ! -x "$app_root/saas/hotcell/bin/build" ]; then
+  echo "▸ Skipping the cell's image (saas/hotcell/bin/build is not here)"
+  echo
+elif ! docker info &> /dev/null; then
+  echo "▸ Skipping the cell's image (docker is not running)"
+  echo
+else
+  step "Building the cell's image" "$app_root/saas/hotcell/bin/build"
+fi

--- a/saas/config/deploy.beta.yml
+++ b/saas/config/deploy.beta.yml
@@ -53,6 +53,7 @@ env:
     MYSQL_SOLID_CABLE_HOST: fizzy-mysql-primary
     MYSQL_SOLID_QUEUE_HOST: <%= @solidqueue_db %>
     MYSQL_SOLID_CACHE_HOST: fizzy-beta-solidcache-db-101.df-iad-int.37signals.com
+    HOTCELL_ACTIVE_STORAGE: images,pdfs,media
   secret:
     - RAILS_MASTER_KEY
     - MYSQL_ALTER_PASSWORD

--- a/saas/config/deploy.beta.yml
+++ b/saas/config/deploy.beta.yml
@@ -53,7 +53,6 @@ env:
     MYSQL_SOLID_CABLE_HOST: fizzy-mysql-primary
     MYSQL_SOLID_QUEUE_HOST: <%= @solidqueue_db %>
     MYSQL_SOLID_CACHE_HOST: fizzy-beta-solidcache-db-101.df-iad-int.37signals.com
-    HOTCELL_ACTIVE_STORAGE: images,pdfs,media
   secret:
     - RAILS_MASTER_KEY
     - MYSQL_ALTER_PASSWORD

--- a/saas/config/deploy.production.yml
+++ b/saas/config/deploy.production.yml
@@ -34,6 +34,7 @@ env:
     MYSQL_DATABASE_REPLICA_HOST: fizzy-mysql-replica
     MYSQL_SOLID_CABLE_HOST: fizzy-mysql-primary
     MYSQL_SOLID_QUEUE_HOST: fizzy-mysql-primary
+    HOTCELL_ACTIVE_STORAGE: images,pdfs,media
   secret:
     - RAILS_MASTER_KEY
     - MYSQL_ALTER_PASSWORD

--- a/saas/config/deploy.production.yml
+++ b/saas/config/deploy.production.yml
@@ -34,7 +34,6 @@ env:
     MYSQL_DATABASE_REPLICA_HOST: fizzy-mysql-replica
     MYSQL_SOLID_CABLE_HOST: fizzy-mysql-primary
     MYSQL_SOLID_QUEUE_HOST: fizzy-mysql-primary
-    HOTCELL_ACTIVE_STORAGE: images,pdfs,media
   secret:
     - RAILS_MASTER_KEY
     - MYSQL_ALTER_PASSWORD

--- a/saas/config/deploy.staging.yml
+++ b/saas/config/deploy.staging.yml
@@ -28,6 +28,7 @@ ssh:
 
 env:
   clear:
+    HOTCELL_ACTIVE_STORAGE: images,pdfs,media
     RAILS_ENV: staging
     RAILS_LOG_LEVEL: fatal # suppress unstructured log lines
     MYSQL_DATABASE_HOST: fizzy-staging-mysql-primary

--- a/saas/config/deploy.staging.yml
+++ b/saas/config/deploy.staging.yml
@@ -28,7 +28,6 @@ ssh:
 
 env:
   clear:
-    HOTCELL_ACTIVE_STORAGE: images,pdfs,media
     RAILS_ENV: staging
     RAILS_LOG_LEVEL: fatal # suppress unstructured log lines
     MYSQL_DATABASE_HOST: fizzy-staging-mysql-primary

--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -68,7 +68,7 @@ accessories:
     # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
     # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
     # way for an unbuilt image to fail.
-    image: registry.37signals.com/basecamp/fizzy-hotcell:01d41b257e90
+    image: registry.37signals.com/basecamp/fizzy-hotcell:528d7ff16737
     roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
     # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
     # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker

--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -68,7 +68,7 @@ accessories:
     # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
     # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
     # way for an unbuilt image to fail.
-    image: registry.37signals.com/basecamp/fizzy-hotcell:528d7ff16737
+    image: registry.37signals.com/basecamp/fizzy-hotcell:88eef30a6b62
     roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
     # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
     # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker

--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -29,14 +29,11 @@ volumes:
 
 env:
   clear:
-    # HOTCELL_ROOT registers the cell, so metrics, describe, the healthcheck and /hotcellz answer.
+    # HOTCELL_ROOT registers the cell, which then carries every conversion.
     # HOTCELL_GROUP is the gid both sides hold, and it must match the group-add above; the client puts
     # each descriptor in it and narrows the mode, so a cell may read an input and write an output and
     # neither the reverse nor wider. It is read from the environment rather than written in the source
     # because development runs the app and its cell as one user, where it must stay unset.
-    # HOTCELL_ACTIVE_STORAGE is what moves work, one group at a time: images, pdfs, media, or all. It
-    # lives in each destination's own file rather than here, because how far a destination has rolled out
-    # is a per-destination decision and a list here advances all of them at once.
     HOTCELL_ROOT: /run/hotcell
     HOTCELL_GROUP: 10001
 
@@ -71,7 +68,7 @@ accessories:
     # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
     # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
     # way for an unbuilt image to fail.
-    image: registry.37signals.com/basecamp/fizzy-hotcell:d09e4791b4c3
+    image: registry.37signals.com/basecamp/fizzy-hotcell:01d41b257e90
     roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
     # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
     # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker

--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -5,11 +5,40 @@ hooks_path: <%= File.join(Gem::Specification.find_by_name("fizzy-saas").gem_dir,
 secrets_path: <%= File.join(Gem::Specification.find_by_name("fizzy-saas").gem_dir, ".kamal/secrets") %>
 
 servers:
+  # group-add on both roles, because an operation that hands a tool a filename re-opens the caller's
+  # descriptor as /dev/fd/N. That is a fresh open, rechecked against the cell's uid, so a mode 0600
+  # tempfile the app owns is EACCES — which is every Active Storage operation this cell carries except the
+  # analyzers. The app owns the files, so it must be in the group to put them in it: without this the
+  # failure moves rather than goes, from EACCES in the cell to EPERM in the app. Must match HOTCELL_GROUP.
+  web:
+    options:
+      group-add: 10001
   jobs:
     cmd: bin/jobs
+    options:
+      group-add: 10001
 
 volumes:
   - fizzy:/rails/storage
+  # The cell's sockets. The app resolves a cell's name under HOTCELL_ROOT, so this path is
+  # $HOTCELL_ROOT/<cell name> while the cell writes them at its own HOTCELL_DIR — only the volume name
+  # has to match. saas/Dockerfile creates this directory owned by 10001, because a new named volume takes
+  # its ownership from the directory it covers in whichever container mounts it first, and on a new host
+  # that is the app.
+  - hotcell-active-storage:/run/hotcell/active_storage
+
+env:
+  clear:
+    # HOTCELL_ROOT registers the cell, so metrics, describe, the healthcheck and /hotcellz answer.
+    # HOTCELL_GROUP is the gid both sides hold, and it must match the group-add above; the client puts
+    # each descriptor in it and narrows the mode, so a cell may read an input and write an output and
+    # neither the reverse nor wider. It is read from the environment rather than written in the source
+    # because development runs the app and its cell as one user, where it must stay unset.
+    # HOTCELL_ACTIVE_STORAGE is what moves work, one group at a time: images, pdfs, media, or all. It
+    # lives in each destination's own file rather than here, because how far a destination has rolled out
+    # is a per-destination decision and a list here advances all of them at once.
+    HOTCELL_ROOT: /run/hotcell
+    HOTCELL_GROUP: 10001
 
 proxy:
   ssl: true
@@ -27,6 +56,54 @@ builder:
     - GITHUB_TOKEN
   remote: ssh://app@docker-builder-102
   local: <%= ENV.fetch("KAMAL_BUILDER_LOCAL", "true") %>
+
+# Attachment processing, in a container with no network that holds nothing worth stealing. Declared here
+# rather than per destination because a deploy never touches an accessory — booting one is explicit —
+# so this is inert until someone runs:
+#
+#   bin/kamal accessory reboot hotcell -d <destination>
+#
+# An accessory rather than an app role because Kamal hard-codes --network kamal for roles, and network:
+# none is the point.
+accessories:
+  hotcell:
+    # Immutable, and never `latest`: a reboot pulls whatever the tag names at that moment, so a moving tag
+    # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
+    # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
+    # way for an unbuilt image to fail.
+    image: registry.37signals.com/basecamp/fizzy-hotcell:d09e4791b4c3
+    roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
+    # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
+    # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker
+    # refuses the container outright.
+    network: none
+    volumes:
+      - hotcell-active-storage:/run/hotcell/cell
+      # Scratch from the host's disk rather than a tmpfs, so it stops being RAM charged to the cgroup and
+      # its size stops moving with file_size. The source is the capped loopback filesystem chef's
+      # app_kamal cookbook provisions on every cell host — 4G, mounted nosuid,nodev,noexec, owned by the
+      # cell's uid — because Docker can neither cap a bind mount nor set those flags on one. A fill stays
+      # inside it and reaches the caller as ENOSPC — transient, never recorded against a blob.
+      - /var/lib/hotcell-scratch:/tmp
+    options:
+      # Performance. Docker applies no limit to a flag left out, so a cell without these can take the
+      # host. With scratch on disk the cgroup holds only processes, so memory is sized from
+      # concurrency × peak RSS, kept above the cell's 1536MB rlimit so a breach is a verdict rather than
+      # a SIGKILL. Load testing owns the real numbers.
+      cpus: 2
+      memory: 2g
+      memory-swap: 2g  # equal to memory; omitted, Docker allows twice memory in swap and the limit stops holding
+      # Deliberately no `ulimit: stack`, so the cell inherits the daemon's 8MB. A thread that overflows a
+      # smaller stack dies on SIGSEGV, which the supervisor maps to killed/memory — permanent, so the
+      # verdict is written against the customer's file. Raise the cell's own memory instead.
+
+      # Security. Omit one and the protection is gone while the cell serves requests exactly as before.
+      # `network: none` is above, because it is an accessory key rather than a raw Docker flag.
+      read-only: true
+      cap-drop: ALL
+      security-opt: no-new-privileges:true
+      user: 10001:10001
+      pids-limit: 512
 
 aliases:
   console: app exec -i --reuse -e CONSOLE_USER:<%= ENV["USER"] %> "bin/rails console"

--- a/saas/config/routes.rb
+++ b/saas/config/routes.rb
@@ -5,6 +5,11 @@ Fizzy::Saas::Engine.routes.draw do
     resources :devices, only: [ :index, :create, :destroy ]
   end
 
+  # Beside "up", because it answers the same kind of question and is polled the same way. The work-socket
+  # round trips are a separate action because they fork a worker, and only staff may spend one.
+  get "hotcellz", to: "hotcellz#show"
+  get "hotcellz/test", to: "hotcellz#test"
+
   namespace :admin do
     mount Audits1984::Engine, at: "/console"
     get "stats", to: "stats#show"

--- a/saas/hotcell/Dockerfile
+++ b/saas/hotcell/Dockerfile
@@ -1,0 +1,65 @@
+# The cell's image. HotCell installed this file once; it is yours to customize, and nothing inherits
+# from a published base image — this is the whole recipe.
+#
+# A cell carries a Ruby runtime and every gem in its loaded graph, all inside the blast radius, so treat
+# this file as a budget rather than an inventory. Which tools it holds is what decides its blast radius.
+
+ARG RUBY_VERSION=3.4
+
+# The bundle is built in a stage of its own, because installing it needs a compiler for the native
+# extensions, which the image that runs untrusted bytes must not carry.
+FROM ruby:${RUBY_VERSION}-slim AS build
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV BUNDLE_PATH=/hotcell/bundle \
+    BUNDLE_WITHOUT=development \
+    BUNDLE_FROZEN=true
+
+WORKDIR /hotcell
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle install && rm -rf "$BUNDLE_PATH"/ruby/*/cache
+
+
+FROM ruby:${RUBY_VERSION}-slim
+
+# The tools this cell's operations run, and nothing else. No LibreOffice: Fizzy accepts office documents
+# and never previews them, so its parsers would be blast radius bought for nothing.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libvips42 mupdf-tools ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+# The cell's user: high and outside any host user range, with no home directory and no shell.
+RUN groupadd --gid 10001 hotcell && \
+    useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin hotcell
+
+# The socket volume's mount point must exist here, owned by the cell's user, because a new named volume
+# takes its ownership from the directory it covers.
+RUN mkdir -p /run/hotcell/cell /hotcell/operations && chown -R hotcell:hotcell /run/hotcell /hotcell
+
+# HOME is /tmp because the cell's user has no home directory, and bundler wants one. A worker replaces
+# it with its slot's home before it serves a request.
+ENV HOME=/tmp \
+    BUNDLE_PATH=/hotcell/bundle \
+    BUNDLE_WITHOUT=development \
+    BUNDLE_FROZEN=true \
+    HOTCELL_OPERATIONS=/hotcell/operations \
+    HOTCELL_DIR=/run/hotcell/cell
+
+WORKDIR /hotcell
+
+COPY --from=build --chown=hotcell:hotcell /hotcell/bundle /hotcell/bundle
+COPY --chown=hotcell:hotcell Gemfile Gemfile.lock ./
+COPY --chown=hotcell:hotcell config.rb /hotcell/config.rb
+COPY --chown=hotcell:hotcell operations/ /hotcell/operations/
+
+USER hotcell
+
+# Probes the supervisor's control socket from inside the container, where network: none does not apply.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["bundle", "exec", "hotcell-health"]
+
+CMD ["bundle", "exec", "hotcell"]

--- a/saas/hotcell/Dockerfile
+++ b/saas/hotcell/Dockerfile
@@ -1,8 +1,5 @@
-# The cell's image. HotCell installed this file once; it is yours to customize, and nothing inherits
-# from a published base image — this is the whole recipe.
-#
-# A cell carries a Ruby runtime and every gem in its loaded graph, all inside the blast radius, so treat
-# this file as a budget rather than an inventory. Which tools it holds is what decides its blast radius.
+# The cell's image. Everything here is inside the blast radius, so treat this file as a budget rather
+# than an inventory.
 
 ARG RUBY_VERSION=3.4
 

--- a/saas/hotcell/Gemfile
+++ b/saas/hotcell/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# The cell's Gemfile. Keep it short: every gem loaded here is inside the blast radius and paid for on
+# every request. hotcell-client and rails do not belong here.
+#
+# The app and the cell lock separately, and a client/server version skew is a `protocol` failure at
+# runtime. bin/build locks these to the version in Gemfile.saas.lock, and a test asserts the two
+# lockfiles agree.
+
+source "https://rubygems.org"
+
+gem "hotcell-server", "~> 0.1.0"
+gem "activestorage-hotcell-server", "~> 0.1.0"

--- a/saas/hotcell/Gemfile.lock
+++ b/saas/hotcell/Gemfile.lock
@@ -1,0 +1,70 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activestorage-hotcell-server (0.1.0)
+      hotcell-server (= 0.1.0)
+      image_processing (>= 2.0)
+      mini_magick (>= 4.0)
+      ruby-vips (>= 2.2)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    hotcell-core (0.1.0)
+    hotcell-server (0.1.0)
+      hotcell-core (= 0.1.0)
+    image_processing (2.0.3)
+    logger (1.7.0)
+    mini_magick (5.3.3)
+      logger
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  activestorage-hotcell-server (~> 0.1.0)
+  hotcell-server (~> 0.1.0)
+
+CHECKSUMS
+  activestorage-hotcell-server (0.1.0) sha256=a4d2dfe5046726e1321ec274036ac48006c9f17fa6d102461920f491c3070110
+  bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
+  ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86-linux-gnu) sha256=38e150df5f4ca555e25beca4090823ae09657bceded154e3c52f8631c1ed72cf
+  ffi (1.17.4-x86-linux-musl) sha256=fbeec0fc7c795bcf86f623bb18d31ea1820f7bd580e1703a3d3740d527437809
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  hotcell-core (0.1.0) sha256=0bfbe2f9850ad0ed3139fb60701c46aa5d9a01741f2f512ad80fb244ce6b9a36
+  hotcell-server (0.1.0) sha256=6f5f335a66bb382ace86b861244b61d4ff40e9d580538300e6f0c71eef6a05c9
+  image_processing (2.0.3) sha256=793e33f38470edd0a2d6bfd00acf8cb239c76284ba2e3dfb76633ac2b457f23a
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mini_magick (5.3.3) sha256=b3beed8a8cef36bd03666365f14b89cd344da0ecd373af53e617c71bfd426aab
+  ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
+
+BUNDLED WITH
+  4.0.18

--- a/saas/hotcell/bin/build
+++ b/saas/hotcell/bin/build
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Builds the cell's image, at the hotcell version the application is running.
+#
+# The application's lockfile is the source of truth. This makes the cell's lockfile name the same version
+# — writing it if it differs — builds, and pins the accessory to what it built. A client and server one
+# version apart is a `protocol` failure on every request, so neither lockfile nor the pin is ever set on
+# its own: update the gem in the app, run this, commit the lot as one change.
+#
+# It touches no registry: publishing is saas/hotcell/bin/push, so this can run on every laptop from
+# bin/setup. Tags are immutable and there is no `latest`, because a deploy does not update an accessory —
+# `kamal accessory reboot` pulls whatever the tag names at that moment, and a moving tag would make what a
+# host runs depend on when it last rebooted.
+set -euo pipefail
+
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+cell_dir="$(cd "$bin_dir/.." && pwd)"
+repo_root="$(cd "$cell_dir/../.." && pwd)"
+
+source "$bin_dir/image"
+
+platform=""
+for arg in "$@"; do
+  case $arg in
+    --platform=*) platform="${arg#*=}" ;;
+    --help|-h)
+      cat <<USAGE
+Usage: saas/hotcell/bin/build [--platform=linux/amd64]
+
+Locks saas/hotcell/Gemfile.lock to the hotcell version in Gemfile.saas.lock, builds the cell image, tags
+it with a hash of what went into it, and pins saas/config/deploy.yml to that tag. Pushing is a separate
+step: saas/hotcell/bin/push.
+
+To move the cell to a new hotcell version, update the gem in the application first:
+
+    BUNDLE_GEMFILE=Gemfile.saas bundle update --conservative hotcell-client activestorage-hotcell-client hotcell-core
+    saas/hotcell/bin/build
+
+then commit the two lockfiles, the deploy.yml pin, and anything else, together.
+USAGE
+      exit 0
+      ;;
+  esac
+done
+
+# The version the application runs, anchored on hotcell-core because both sides depend on it with an
+# exact constraint. Read off the lockfile rather than asked of bundler, so this needs no bundle to be
+# installed and cannot be answered by a stale one.
+app_version="$(awk '$1 == "hotcell-core" && $2 ~ /^\([0-9]/ {gsub(/[()]/, "", $2); print $2; exit}' "$repo_root/Gemfile.saas.lock")"
+cell_version="$(awk '$1 == "hotcell-core" && $2 ~ /^\([0-9]/ {gsub(/[()]/, "", $2); print $2; exit}' "$cell_dir/Gemfile.lock")"
+
+if [ -z "$app_version" ]; then
+  echo "Gemfile.saas.lock names no hotcell-core version. Is the app in SaaS mode?" >&2
+  exit 1
+fi
+
+# Written into the lockfile rather than resolved by bundler, because `bundle update` takes the newest
+# release the Gemfile's constraint admits — which makes RubyGems the source of truth and an app
+# deliberately holding an older version a build failure. The application's lockfile is the source of
+# truth, and pinning below a requirement is exactly what a lockfile is for.
+if [ "$cell_version" != "$app_version" ]; then
+  echo "Locking the cell to the application's hotcell $app_version (was ${cell_version:-none})"
+  sed -i "/hotcell/s/$cell_version/$app_version/g" "$cell_dir/Gemfile.lock"
+  env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE \
+    BUNDLE_GEMFILE="$cell_dir/Gemfile" bundle install --quiet
+
+  # Re-read rather than trust: a sed that matched nothing leaves the old version behind a green
+  # install, and the two sides skew silently.
+  cell_version="$(awk '$1 == "hotcell-core" && $2 ~ /^\([0-9]/ {gsub(/[()]/, "", $2); print $2; exit}' "$cell_dir/Gemfile.lock")"
+  if [ "$cell_version" != "$app_version" ]; then
+    echo "The cell's lockfile still resolves hotcell-core $cell_version against the application's $app_version." >&2
+    echo "Regenerate it: rm saas/hotcell/Gemfile.lock && BUNDLE_GEMFILE=saas/hotcell/Gemfile bundle install, then rerun." >&2
+    exit 1
+  fi
+fi
+
+tag="$(hotcell_image_tag "$repo_root")"
+
+echo "Building $tag"
+docker build \
+  ${platform:+--platform="$platform"} \
+  --tag "$tag" \
+  "$cell_dir"
+
+# Written here rather than in push, because the tag is a hash of the image's contents: the commit that
+# changes them is the commit that has to carry the new pin. Left to push, the pin moves after that commit
+# is already made, which is how a tree that builds one image and deploys another gets committed.
+#
+# Verified rather than assumed. A pin this cannot find is a silent no-op that reports success, which is the
+# one failure a script whose whole job is writing that line must not have.
+# `|| true` because a file naming no image at all is what the check below reports: under pipefail and
+# set -e, grep finding nothing would kill the script here instead, with nothing printed.
+pinned="$(grep -o "$HOTCELL_IMAGE_REPOSITORY:[a-f0-9]*" "$repo_root/saas/config/deploy.yml" | head -1 | cut -d: -f2 || true)"
+
+echo
+echo "Built $tag. It is local only — publish it with saas/hotcell/bin/push."
+if [ "$pinned" != "${tag##*:}" ]; then
+  sed -i "s|image: $HOTCELL_IMAGE_REPOSITORY:[a-f0-9]*|image: $tag|" "$repo_root/saas/config/deploy.yml"
+
+  if ! grep -q "image: $tag\$" "$repo_root/saas/config/deploy.yml"; then
+    echo "Could not pin saas/config/deploy.yml: it names no $HOTCELL_IMAGE_REPOSITORY image to replace." >&2
+    echo "Set it by hand:" >&2
+    echo "    image: $tag" >&2
+    exit 1
+  fi
+
+  echo "Pinned saas/config/deploy.yml to ${tag##*:} (was ${pinned:-none})"
+fi

--- a/saas/hotcell/bin/image
+++ b/saas/hotcell/bin/image
@@ -1,0 +1,18 @@
+# Sourced by build and deploy, so the two cannot disagree about what an image is called.
+
+HOTCELL_IMAGE_REPOSITORY="${HOTCELL_IMAGE_REPOSITORY:-registry.37signals.com/basecamp/fizzy-hotcell}"
+
+# A hash of exactly what the Dockerfile copies in — Dockerfile, both Gemfiles, config.rb, operations/ —
+# rather than a commit. A commit-derived tag moved whenever anything in this directory changed, including
+# the build script and the pin that names the tag, so a commit that bumped the gem and pinned the result
+# could never name itself: amending it changed the SHA the pin was supposed to hold. Identical bytes,
+# identical tag, and a change to nothing the image contains leaves it alone.
+hotcell_image_tag() {
+  local repo_root="$1"
+  local cell_dir="$repo_root/saas/hotcell"
+  local digest
+
+  digest="$(cat "$cell_dir/Dockerfile" "$cell_dir/Gemfile" "$cell_dir/Gemfile.lock" "$cell_dir/config.rb" \
+                "$cell_dir"/operations/*.rb | sha256sum | cut -c1-12)"
+  echo "$HOTCELL_IMAGE_REPOSITORY:$digest"
+}

--- a/saas/hotcell/bin/push
+++ b/saas/hotcell/bin/push
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Publishes an already-built cell image. The pin in saas/config/deploy.yml is saas/hotcell/bin/build's job,
+# because the tag is a hash of the image's contents and belongs in the commit that changes them.
+#
+# Pushing is the irreversible half, which is why it is not in saas/hotcell/bin/build. Rebooting the accessory
+# stays explicit and is not done here:
+#
+#   bin/kamal accessory reboot hotcell -d <destination>
+set -euo pipefail
+
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+cell_dir="$(cd "$bin_dir/.." && pwd)"
+repo_root="$(cd "$cell_dir/../.." && pwd)"
+
+source "$bin_dir/image"
+
+for arg in "$@"; do
+  case $arg in
+    --help|-h)
+      cat <<USAGE
+Usage: saas/hotcell/bin/push
+
+Pushes the image saas/hotcell/bin/build made to $HOTCELL_IMAGE_REPOSITORY. Build it first if it is not
+there; build is also what pins saas/config/deploy.yml to the tag.
+USAGE
+      exit 0
+      ;;
+  esac
+done
+
+tag="$(hotcell_image_tag "$repo_root")"
+
+if ! docker image inspect "$tag" > /dev/null 2>&1; then
+  echo "No local image $tag. Build it first: saas/hotcell/bin/build" >&2
+  exit 1
+fi
+
+# Production runs amd64. An arm64 image pushed from a laptop reaches a host that cannot run it, and the
+# accessory crash-loops with nothing in the app to say why.
+architecture="$(docker image inspect --format '{{.Architecture}}' "$tag")"
+if [ "$architecture" != "amd64" ]; then
+  echo "$tag is $architecture and the hosts are amd64." >&2
+  echo "Rebuild it: saas/hotcell/bin/build --platform=linux/amd64" >&2
+  exit 1
+fi
+
+echo "Pushing $tag"
+docker push "$tag"
+
+cat <<NEXT
+
+Published $tag, which saas/config/deploy.yml already pins — saas/hotcell/bin/build wrote it.
+
+Boot it, which a deploy does not do:
+
+    bin/kamal accessory reboot hotcell -d <destination>
+NEXT

--- a/saas/hotcell/config.rb
+++ b/saas/hotcell/config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Loaded when the cell boots, before any operation.
+#
+# These are a ceiling, not a default: an operation's own limits are clamped to them, so these numbers only
+# ever take away. They are sized to the most demanding operation this cell carries — the video previewer's
+# 120s deadline, the image transformer's 256MB file_size.
+#
+# deadline and queue_wait are seconds; memory and file_size are bytes.
+HotCell.limits concurrency: 4,
+               queue_size: 8,
+               queue_wait: 10,
+               deadline: 120,
+               memory: 1536 * 1024**2,
+               file_size: 256 * 1024**2

--- a/saas/hotcell/config.rb
+++ b/saas/hotcell/config.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-# Loaded when the cell boots, before any operation.
-#
-# These are a ceiling, not a default: an operation's own limits are clamped to them, so these numbers only
-# ever take away. They are sized to the most demanding operation this cell carries — the video previewer's
-# 120s deadline, the image transformer's 256MB file_size.
-#
+# A ceiling, not a default: an operation's own limits are clamped to these, so they are sized to the most
+# demanding operation — the video previewer's 120s deadline, the image transformer's 256MB file_size.
 # deadline and queue_wait are seconds; memory and file_size are bytes.
 HotCell.limits concurrency: 4,
                queue_size: 8,

--- a/saas/hotcell/operations/active_storage.rb
+++ b/saas/hotcell/operations/active_storage.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# The five Active Storage operations this cell serves, required one file at a time rather than through the
-# gem's entry point. That entry point also loads the ImageMagick and Poppler operations, whose tools this
-# image deliberately does not carry, and a cell should advertise only what it can actually do.
+# Required one file at a time rather than through the gem's entry point, which also loads the ImageMagick
+# and Poppler operations — tools this image does not carry.
 
 require "active_storage/hot_cell/server/transformers/image/vips"
 require "active_storage/hot_cell/server/analyzers/image/vips"
@@ -13,7 +12,7 @@ require "active_storage/hot_cell/server/previewers/video/ffmpeg"
 # The gem's 48MB is too small for a 48MP phone photo. 256MB covers every current phone.
 ActiveStorage::HotCell::Server::Transformers::Image::Vips.limits file_size: 256 * 1024**2
 
-# Mirrors config/initializers/vips.rb: openslide segfaults sqlite in forked workers, and tiff is a
-# format Fizzy never reads. Workers inherit these from the supervisor.
+# Mirrors config/initializers/vips.rb: openslide segfaults sqlite in forked workers, and tiff is a format
+# Fizzy never reads.
 Vips.block "VipsForeignLoadOpenslide", true
 Vips.block "VipsForeignLoadTiff", true

--- a/saas/hotcell/operations/active_storage.rb
+++ b/saas/hotcell/operations/active_storage.rb
@@ -3,10 +3,6 @@
 # The five Active Storage operations this cell serves, required one file at a time rather than through the
 # gem's entry point. That entry point also loads the ImageMagick and Poppler operations, whose tools this
 # image deliberately does not carry, and a cell should advertise only what it can actually do.
-#
-# All five ship from the first build, including the ones the rollout reaches last. The application's
-# HOTCELL_ACTIVE_STORAGE switch is what stages the traffic; staging the image instead would make every
-# rollout step an accessory rebuild and reboot.
 
 require "active_storage/hot_cell/server/transformers/image/vips"
 require "active_storage/hot_cell/server/analyzers/image/vips"

--- a/saas/hotcell/operations/active_storage.rb
+++ b/saas/hotcell/operations/active_storage.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# The five Active Storage operations this cell serves, required one file at a time rather than through the
+# gem's entry point. That entry point also loads the ImageMagick and Poppler operations, whose tools this
+# image deliberately does not carry, and a cell should advertise only what it can actually do.
+#
+# All five ship from the first build, including the ones the rollout reaches last. The application's
+# HOTCELL_ACTIVE_STORAGE switch is what stages the traffic; staging the image instead would make every
+# rollout step an accessory rebuild and reboot.
+
+require "active_storage/hot_cell/server/transformers/image/vips"
+require "active_storage/hot_cell/server/analyzers/image/vips"
+require "active_storage/hot_cell/server/analyzers/media/ffprobe"
+require "active_storage/hot_cell/server/previewers/pdf/mutool"
+require "active_storage/hot_cell/server/previewers/video/ffmpeg"
+
+# The gem's 48MB is too small for a 48MP phone photo. 256MB covers every current phone.
+ActiveStorage::HotCell::Server::Transformers::Image::Vips.limits file_size: 256 * 1024**2
+
+# Mirrors config/initializers/vips.rb: openslide segfaults sqlite in forked workers, and tiff is a
+# format Fizzy never reads. Workers inherit these from the supervisor.
+Vips.block "VipsForeignLoadOpenslide", true
+Vips.block "VipsForeignLoadTiff", true

--- a/saas/hotcell/operations/echo.rb
+++ b/saas/hotcell/operations/echo.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copied from the hotcell repository's examples/operations/echo.rb, and it stays permanently. The message
+# arrives through the caller's own input descriptor and leaves through the caller's own output descriptor,
+# with no copy onto scratch — so one round-trip proves the SCM_RIGHTS descriptor passing end to end.
+#
+# It carries no library and runs no tool, so it costs the blast radius nothing. /hotcellz calls it, and it
+# is the only check there that says anything about the work socket: describe and metrics both answer on the
+# control socket, which a descriptor never crosses.
+module Examples
+  class Echo < HotCell::Operation
+    operation "example.echo"
+
+    def perform(inputs, outputs)
+      bytes = outputs.first.to_io.write(inputs.first.to_io.read)
+
+      { bytes: bytes, staged: inputs.first.staged? }
+    end
+  end
+end

--- a/saas/hotcell/operations/echo.rb
+++ b/saas/hotcell/operations/echo.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
-# Copied from the hotcell repository's examples/operations/echo.rb, and it stays permanently. The message
-# arrives through the caller's own input descriptor and leaves through the caller's own output descriptor,
-# with no copy onto scratch — so one round-trip proves the SCM_RIGHTS descriptor passing end to end.
-#
-# It carries no library and runs no tool, so it costs the blast radius nothing. /hotcellz calls it, and it
-# is the only check there that says anything about the work socket: describe and metrics both answer on the
-# control socket, which a descriptor never crosses.
+# Copied from the hotcell repository's examples/operations/echo.rb. /hotcellz calls it: one round trip
+# through the caller's own descriptors proves SCM_RIGHTS passing end to end, and it is the only check
+# there that touches the work socket.
 module Examples
   class Echo < HotCell::Operation
     operation "example.echo"

--- a/saas/hotcell/operations/reopen.rb
+++ b/saas/hotcell/operations/reopen.rb
@@ -1,21 +1,10 @@
 # frozen_string_literal: true
 
-# Copied from the hotcell repository's examples/operations/reopen.rb, and it stays permanently. The same
-# round trip as echo, through both paths instead of both descriptors.
-#
-# `/dev/fd/N` is a fresh open, rechecked against the opening process's uid and the file's mode, so this
-# succeeds only where the cell can open files the app owns by name. Echo consumes the descriptors directly
-# and never establishes that, which is why both exist: a cell missing the shared group answers echo
-# perfectly and fails this with EACCES, and every operation that hands a tool a filename fails with it.
-#
-# Both directions, because they are different permissions and a tool may need either: an input is readable
-# by the group and an output is writable by it, and one shipped operation re-opens each — the ffmpeg
-# previewer writes its destination by name. Reading alone passed on a cell whose outputs the group could
-# not write, where every video preview failed on the write.
-#
-# `staged` is always false here, because this reads and writes fd_path and never path. The caller fails
-# the check on a true, because that would mean this had been rewritten to stage onto scratch — reading or
-# writing a copy the worker owns, which tests nothing about the group.
+# Copied from the hotcell repository's examples/operations/reopen.rb. The same round trip as echo, but
+# re-opening both descriptors by `/dev/fd/N` — a fresh open, rechecked against the cell's uid — which is
+# what every operation that hands a tool a filename does. A cell missing the shared group answers echo
+# perfectly and fails only this. It re-opens in both directions because reading and writing are different
+# permissions, and shipped operations do each.
 module Examples
   class Reopen < HotCell::Operation
     operation "example.reopen"

--- a/saas/hotcell/operations/reopen.rb
+++ b/saas/hotcell/operations/reopen.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copied from the hotcell repository's examples/operations/reopen.rb, and it stays permanently. The same
+# round trip as echo, through both paths instead of both descriptors.
+#
+# `/dev/fd/N` is a fresh open, rechecked against the opening process's uid and the file's mode, so this
+# succeeds only where the cell can open files the app owns by name. Echo consumes the descriptors directly
+# and never establishes that, which is why both exist: a cell missing the shared group answers echo
+# perfectly and fails this with EACCES, and every operation that hands a tool a filename fails with it.
+#
+# Both directions, because they are different permissions and a tool may need either: an input is readable
+# by the group and an output is writable by it, and one shipped operation re-opens each — the ffmpeg
+# previewer writes its destination by name. Reading alone passed on a cell whose outputs the group could
+# not write, where every video preview failed on the write.
+#
+# `staged` is always false here, because this reads and writes fd_path and never path. The caller fails
+# the check on a true, because that would mean this had been rewritten to stage onto scratch — reading or
+# writing a copy the worker owns, which tests nothing about the group.
+module Examples
+  class Reopen < HotCell::Operation
+    operation "example.reopen"
+
+    def perform(inputs, outputs)
+      source, = inputs
+      destination, = outputs
+
+      bytes = File.open(source.fd_path, "rb") do |input|
+        File.open(destination.fd_path, "wb") { |output| output.write(input.read) }
+      end
+
+      { bytes: bytes, staged: source.staged? || destination.staged? }
+    end
+  end
+end

--- a/saas/lib/fizzy/saas/cell.rb
+++ b/saas/lib/fizzy/saas/cell.rb
@@ -12,10 +12,9 @@ module Fizzy
     # Deliberately not named HotCell, or any near-spelling of it: a cell is forked from a process that may
     # have loaded the client, and a shared constant across the two sides is a superclass mismatch at boot.
     #
-    # Two switches, because a cell being reachable and a cell taking traffic are different questions.
-    # HOTCELL_ROOT registers the cell, so metrics, describe, the healthcheck and /hotcellz all answer while
-    # every conversion still runs in the app. HOTCELL_ACTIVE_STORAGE is what moves the work, and it is a
-    # list rather than a flag because the rollout moves operations in groups.
+    # One switch: HOTCELL_ROOT registers the cell, and a registered cell carries every conversion.
+    # Unset — an open-source checkout, or SaaS mode without a cell — Active Storage keeps its own
+    # analyzers and previewers and everything runs in the app.
     module Cell
       NAME = "active_storage"
 
@@ -36,10 +35,6 @@ module Fizzy
       # A /hotcellz check that answered, but answered badly. Its message is already a sentence, so it is
       # reported without an exception class in front of it.
       class CheckFailed < StandardError; end
-
-      # Listed in the order Active Storage should see their classes, because the first analyzer or
-      # previewer that accepts a blob is the one that runs.
-      GROUPS = %i[ images pdfs media ]
 
       class << self
         def root
@@ -69,29 +64,20 @@ module Fizzy
           ::HotCell.cell NAME
         end
 
-        def processing_attachments?
-          enabled? && groups.any?
-        end
-
-        def processing?(group)
-          processing_attachments? && groups.include?(group)
-        end
-
-        # Everything Active Storage should be configured with. `analyzers` and `previewers` are arrays
-        # Rails replaces wholesale, so a group that is off has to contribute Rails' own classes back or a
-        # partial rollout would not stage the work — it would delete it. Step two hands Rails a mixed
-        # array: this cell's PDF previewer beside Rails' own video one. That works only while the app
-        # image still carries the tools Rails' built-ins shell out to, which is why they leave last.
+        # Everything Active Storage should be configured with, resolved here rather than in a constant
+        # because this file is required during Bundler.require, before Active Storage has defined its own
+        # classes. The image analyzer moves with the transformer whether or not you ask: Rails' image
+        # analyzers test `variant_processor == :vips`, so pointing the transformer at a class makes them
+        # decline and blobs get marked analyzed with no dimensions.
         def active_storage_configuration
-          return {} unless processing_attachments?
+          return {} unless enabled?
 
-          GROUPS.each_with_object({ analyzers: [], previewers: [] }) do |group, merged|
-            configuration = configuration_for(group, moved: processing?(group))
-
-            merged[:variant_processor] = configuration[:variant_processor] if configuration.key?(:variant_processor)
-            merged[:analyzers] += configuration.fetch(:analyzers, [])
-            merged[:previewers] += configuration.fetch(:previewers, [])
-          end
+          { variant_processor: ActiveStorage::HotCell::Client::Transformers::Image::Vips,
+            analyzers: [ ActiveStorage::HotCell::Client::Analyzers::Image::Vips,
+                         ActiveStorage::HotCell::Client::Analyzers::Video::FFprobe,
+                         ActiveStorage::HotCell::Client::Analyzers::Audio::FFprobe ],
+            previewers: [ ActiveStorage::HotCell::Client::Previewers::Pdf::Mutool,
+                          ActiveStorage::HotCell::Client::Previewers::Video::FFmpeg ] }
         end
 
         # What /hotcellz reports. Every check answers rather than raises, because the page's job is to be
@@ -119,8 +105,7 @@ module Fizzy
 
           checks.merge! echo: reporting { echo }, reopen: reporting { reopen } if work
 
-          { at: Time.now.utc.iso8601(3), host: Socket.gethostname,
-            root: root, groups: processing_attachments? ? groups : [] }.merge(checks)
+          { at: Time.now.utc.iso8601(3), host: Socket.gethostname, root: root }.merge(checks)
         end
 
         # A fixed payload through example.echo, which reads the descriptor directly.
@@ -190,52 +175,6 @@ module Fizzy
             raise CheckFailed, response.failure.to_s unless response.ok?
 
             response.result
-          end
-
-          # What each group installs when it has moved, and what Rails runs when it has not. The constants
-          # resolve here rather than in a table at load time, because this file is required during
-          # Bundler.require, before Active Storage has defined its own.
-          def configuration_for(group, moved:)
-            case [ group, moved ]
-            in [ :images, true ]
-              # Rails' image analyzers answer accept? with `variant_processor == :vips` (or
-              # :mini_magick), so pointing the transformer at a class makes both decline and blobs get
-              # marked analyzed with no dimensions. The two move together or not at all.
-              { variant_processor: ActiveStorage::HotCell::Client::Transformers::Image::Vips,
-                analyzers: [ ActiveStorage::HotCell::Client::Analyzers::Image::Vips ] }
-            in [ :images, false ]
-              { analyzers: [ ActiveStorage::Analyzer::ImageAnalyzer::Vips,
-                             ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick ] }
-            in [ :pdfs, true ]
-              { previewers: [ ActiveStorage::HotCell::Client::Previewers::Pdf::Mutool ] }
-            in [ :pdfs, false ]
-              { previewers: [ ActiveStorage::Previewer::PopplerPDFPreviewer,
-                              ActiveStorage::Previewer::MuPDFPreviewer ] }
-            in [ :media, true ]
-              { analyzers: [ ActiveStorage::HotCell::Client::Analyzers::Video::FFprobe,
-                             ActiveStorage::HotCell::Client::Analyzers::Audio::FFprobe ],
-                previewers: [ ActiveStorage::HotCell::Client::Previewers::Video::FFmpeg ] }
-            in [ :media, false ]
-              { analyzers: [ ActiveStorage::Analyzer::VideoAnalyzer,
-                             ActiveStorage::Analyzer::AudioAnalyzer ],
-                previewers: [ ActiveStorage::Previewer::VideoPreviewer ] }
-            end
-          end
-
-          # An unrecognized name raises rather than meaning "off": a typo in a deploy file would otherwise
-          # be a rollout that appears to have happened.
-          def groups
-            names = ENV["HOTCELL_ACTIVE_STORAGE"].to_s.split(",").filter_map { it.strip.downcase.presence&.to_sym }
-            return GROUPS if names.include?(:all)
-
-            names.each do |name|
-              unless GROUPS.include?(name)
-                raise ArgumentError, "unknown HOTCELL_ACTIVE_STORAGE group #{name.inspect} " \
-                                     "(known: #{GROUPS.join(", ")}, all)"
-              end
-            end
-
-            names
           end
       end
 

--- a/saas/lib/fizzy/saas/cell.rb
+++ b/saas/lib/fizzy/saas/cell.rb
@@ -13,8 +13,10 @@ module Fizzy
     # have loaded the client, and a shared constant across the two sides is a superclass mismatch at boot.
     #
     # One switch: HOTCELL_ROOT registers the cell, and a registered cell carries every conversion.
-    # Unset — an open-source checkout, or SaaS mode without a cell — Active Storage keeps its own
-    # analyzers and previewers and everything runs in the app.
+    # Only development and test may run without one — there Active Storage keeps its own analyzers
+    # and previewers and everything runs in the app. A deployed app has no in-app fallback any more,
+    # so a deployment without a cell is a misconfiguration caught at boot rather than a 500 on the
+    # first upload.
     module Cell
       NAME = "active_storage"
 
@@ -37,8 +39,16 @@ module Fizzy
       class CheckFailed < StandardError; end
 
       class << self
+        # SECRET_KEY_BASE_DUMMY is asset precompilation in the Dockerfile, which boots the production
+        # environment with no cell.
         def root
-          ENV["HOTCELL_ROOT"].presence
+          value = ENV["HOTCELL_ROOT"].presence
+
+          if value.nil? && !Rails.env.local? && !ENV["SECRET_KEY_BASE_DUMMY"]
+            raise ::HotCell::ConfigurationError, "HOTCELL_ROOT must be set outside development and test"
+          end
+
+          value
         end
 
         # Unset in development, where the app and its cell run as one user and there is no group to share.

--- a/saas/lib/fizzy/saas/cell.rb
+++ b/saas/lib/fizzy/saas/cell.rb
@@ -1,0 +1,253 @@
+# The engine loads during Bundler.require, before it reaches these gems, so Gemfile order cannot be
+# relied on to have defined HotCell by the time this file is read.
+require "socket"
+require "tmpdir"
+require "hot_cell/client"
+require "active_storage/hot_cell/client"
+
+module Fizzy
+  module Saas
+    # Attachment processing in an unprivileged sibling container.
+    #
+    # Deliberately not named HotCell, or any near-spelling of it: a cell is forked from a process that may
+    # have loaded the client, and a shared constant across the two sides is a superclass mismatch at boot.
+    #
+    # Two switches, because a cell being reachable and a cell taking traffic are different questions.
+    # HOTCELL_ROOT registers the cell, so metrics, describe, the healthcheck and /hotcellz all answer while
+    # every conversion still runs in the app. HOTCELL_ACTIVE_STORAGE is what moves the work, and it is a
+    # list rather than a flag because the rollout moves operations in groups.
+    module Cell
+      NAME = "active_storage"
+
+      # A cell may wait queue_wait in the queue and then run for deadline before it gets to say what
+      # happened. Below its answer_within, a saturated cell arrives here as a transport failure rather than
+      # as its own verdict, and the client warns about it at every boot.
+      TIMEOUT = 135
+
+      # An input this cell will never decode, which is a verdict about one file and may be recorded
+      # against it.
+      class UnprocessableAttachment < StandardError; end
+
+      # Everything uncertain: a saturated cell, a restarting accessory, a deadline. Must not descend from
+      # UnprocessableAttachment — the gem raises ConfigurationError if it does, because the inheritance
+      # graph is the classification and every retryable failure would be written down as permanent.
+      class ProcessingUnavailable < StandardError; end
+
+      # A /hotcellz check that answered, but answered badly. Its message is already a sentence, so it is
+      # reported without an exception class in front of it.
+      class CheckFailed < StandardError; end
+
+      # Listed in the order Active Storage should see their classes, because the first analyzer or
+      # previewer that accepts a blob is the one that runs.
+      GROUPS = %i[ images pdfs media ]
+
+      class << self
+        def root
+          ENV["HOTCELL_ROOT"].presence
+        end
+
+        # Unset in development, where the app and its cell run as one user and there is no group to share.
+        # The gem's setter coerces and raises ConfigurationError for a value that is not a numeric gid.
+        def group
+          ENV["HOTCELL_GROUP"].presence
+        end
+
+        def enabled?
+          root.present?
+        end
+
+        # Registration happens even with no root, so a caller asking whether the cell is up gets an answer
+        # rather than an UnregisteredCell, and the metrics collector has one shape to iterate.
+        def register!
+          ::HotCell.root = root
+          ::HotCell.group = group
+          ::HotCell.register NAME, timeout: TIMEOUT,
+            permanent: UnprocessableAttachment, transient: ProcessingUnavailable
+        end
+
+        def cell
+          ::HotCell.cell NAME
+        end
+
+        def processing_attachments?
+          enabled? && groups.any?
+        end
+
+        def processing?(group)
+          processing_attachments? && groups.include?(group)
+        end
+
+        # Everything Active Storage should be configured with. `analyzers` and `previewers` are arrays
+        # Rails replaces wholesale, so a group that is off has to contribute Rails' own classes back or a
+        # partial rollout would not stage the work — it would delete it. Step two hands Rails a mixed
+        # array: this cell's PDF previewer beside Rails' own video one. That works only while the app
+        # image still carries the tools Rails' built-ins shell out to, which is why they leave last.
+        def active_storage_configuration
+          return {} unless processing_attachments?
+
+          GROUPS.each_with_object({ analyzers: [], previewers: [] }) do |group, merged|
+            configuration = configuration_for(group, moved: processing?(group))
+
+            merged[:variant_processor] = configuration[:variant_processor] if configuration.key?(:variant_processor)
+            merged[:analyzers] += configuration.fetch(:analyzers, [])
+            merged[:previewers] += configuration.fetch(:previewers, [])
+          end
+        end
+
+        # What /hotcellz reports. Every check answers rather than raises, because the page's job is to be
+        # the last step of booting an accessory — the moment when a cell most likely cannot answer.
+        #
+        # describe and metrics ask the control socket, and a descriptor never crosses that, so both answer
+        # happily for a cell whose work socket the app cannot use at all. The echo round trip is the only
+        # one of the three that says anything about the socket real files travel over. The volume-ownership
+        # mistakes fail as EACCES on the first real request, and nothing else here would say so.
+        # Neither control call raises for itself: describe returns nil after warning, and metrics returns a
+        # response that is simply not ok. Reported as they come back, both say "ok" with an empty result
+        # for a cell that never answered — the same shape as a healthy one.
+        # `at` is spelled the way the cell spells it in its own log lines — same key, same UTC ISO8601 with
+        # milliseconds — so a reading taken here lines up mechanically against the cell's logs in Loki.
+        # `host` because every answer here is about one host's cell: a cell's sockets are host-local, a poll
+        # through the load balancer lands on whichever host it lands on, and an answer that does not say
+        # which one cannot be acted on. Kamal boots a container with the deploy host and a random suffix as
+        # its hostname, so this names the machine and the container on it.
+        # Control socket only by default, which the supervisor answers inline with no fork and no queue.
+        # `work: true` is opt-in because it puts a request on the cell's queue and forks a worker for each
+        # round trip: the caller that wants to spend that has to say so.
+        def diagnostics(work: false)
+          checks = { describe: reporting { cell.describe or raise CheckFailed, "the cell did not answer; see metrics" },
+                     metrics: reporting { answered cell.metrics } }
+
+          checks.merge! echo: reporting { echo }, reopen: reporting { reopen } if work
+
+          { at: Time.now.utc.iso8601(3), host: Socket.gethostname,
+            root: root, groups: processing_attachments? ? groups : [] }.merge(checks)
+        end
+
+        # A fixed payload through example.echo, which reads the descriptor directly.
+        def echo(message = "hotcell")
+          round_trip Echo, message
+        end
+
+        # The same payload through example.reopen, which reads the input by name. `/dev/fd/N` is a fresh
+        # open, rechecked against the cell's uid and the file's mode, so this succeeds only where the two
+        # sides share a group. Every operation that hands a tool a filename does exactly this, and echo
+        # never does — so a cell missing the group answers echo perfectly and fails every real conversion.
+        def reopen(message = "hotcell")
+          round_trip Reopen, message
+        end
+
+        private
+          # The checks that cross the work socket. describe and metrics both answer on the control socket,
+          # and a descriptor never crosses that.
+          #
+          # Both verdicts raise rather than being reported beside an `ok`, because a caller reads the
+          # status and not the body: a cell that answers with the wrong bytes is not a healthy cell, and
+          # reporting `echoed: false` under `ok: true` is a 200 for a broken one.
+          #
+          # The client verifies access modes, so the input must be "rb" and the output "wb";
+          # Tempfile.create yields "r+", which it rejects.
+          def round_trip(client, message)
+            Dir.mktmpdir do |directory|
+              source = File.join(directory, "in")
+              destination = File.join(directory, "out")
+              File.write source, message
+
+              result = File.open(source, "rb") do |input|
+                File.open(destination, "wb") { |output| client.perform_in_hotcell input, output }
+              end
+
+              verified result, File.read(destination), message
+            end
+          end
+
+          # Staged means the worker read a copy on its own scratch rather than the caller's file, so the
+          # round trip proved nothing about the descriptor it exists to prove.
+          def verified(result, returned, message)
+            raise CheckFailed, "the cell returned #{returned.bytesize} bytes, not the #{message.bytesize} " \
+                               "sent" unless returned == message
+            raise CheckFailed, "the input was staged onto the worker's scratch, so this did not cross a " \
+                               "descriptor" if result[:staged]
+
+            result.merge(echoed: true)
+          end
+
+          # The registered cell answers this rather than the module, because a cell registered with an
+          # explicit dir: is reachable whatever HOTCELL_ROOT says.
+          def reporting
+            if cell.enabled?
+              { ok: true, result: yield }
+            else
+              { ok: false, error: "HOTCELL_ROOT is unset, so no cell is configured" }
+            end
+          rescue CheckFailed => error
+            { ok: false, error: error.message }
+          rescue => error
+            { ok: false, error: "#{error.class}: #{error.message}" }
+          end
+
+          def answered(response)
+            raise CheckFailed, "no answer from the control socket" if response.nil?
+            raise CheckFailed, response.failure.to_s unless response.ok?
+
+            response.result
+          end
+
+          # What each group installs when it has moved, and what Rails runs when it has not. The constants
+          # resolve here rather than in a table at load time, because this file is required during
+          # Bundler.require, before Active Storage has defined its own.
+          def configuration_for(group, moved:)
+            case [ group, moved ]
+            in [ :images, true ]
+              # Rails' image analyzers answer accept? with `variant_processor == :vips` (or
+              # :mini_magick), so pointing the transformer at a class makes both decline and blobs get
+              # marked analyzed with no dimensions. The two move together or not at all.
+              { variant_processor: ActiveStorage::HotCell::Client::Transformers::Image::Vips,
+                analyzers: [ ActiveStorage::HotCell::Client::Analyzers::Image::Vips ] }
+            in [ :images, false ]
+              { analyzers: [ ActiveStorage::Analyzer::ImageAnalyzer::Vips,
+                             ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick ] }
+            in [ :pdfs, true ]
+              { previewers: [ ActiveStorage::HotCell::Client::Previewers::Pdf::Mutool ] }
+            in [ :pdfs, false ]
+              { previewers: [ ActiveStorage::Previewer::PopplerPDFPreviewer,
+                              ActiveStorage::Previewer::MuPDFPreviewer ] }
+            in [ :media, true ]
+              { analyzers: [ ActiveStorage::HotCell::Client::Analyzers::Video::FFprobe,
+                             ActiveStorage::HotCell::Client::Analyzers::Audio::FFprobe ],
+                previewers: [ ActiveStorage::HotCell::Client::Previewers::Video::FFmpeg ] }
+            in [ :media, false ]
+              { analyzers: [ ActiveStorage::Analyzer::VideoAnalyzer,
+                             ActiveStorage::Analyzer::AudioAnalyzer ],
+                previewers: [ ActiveStorage::Previewer::VideoPreviewer ] }
+            end
+          end
+
+          # An unrecognized name raises rather than meaning "off": a typo in a deploy file would otherwise
+          # be a rollout that appears to have happened.
+          def groups
+            names = ENV["HOTCELL_ACTIVE_STORAGE"].to_s.split(",").filter_map { it.strip.downcase.presence&.to_sym }
+            return GROUPS if names.include?(:all)
+
+            names.each do |name|
+              unless GROUPS.include?(name)
+                raise ArgumentError, "unknown HOTCELL_ACTIVE_STORAGE group #{name.inspect} " \
+                                     "(known: #{GROUPS.join(", ")}, all)"
+              end
+            end
+
+            names
+          end
+      end
+
+      class Echo < ::HotCell::Client
+        hotcell NAME
+        operation "example.echo"
+      end
+
+      class Reopen < ::HotCell::Client
+        hotcell NAME
+        operation "example.reopen"
+      end
+    end
+  end
+end

--- a/saas/lib/fizzy/saas/cell.rb
+++ b/saas/lib/fizzy/saas/cell.rb
@@ -9,33 +9,23 @@ module Fizzy
   module Saas
     # Attachment processing in an unprivileged sibling container.
     #
-    # Deliberately not named HotCell, or any near-spelling of it: a cell is forked from a process that may
-    # have loaded the client, and a shared constant across the two sides is a superclass mismatch at boot.
-    #
-    # One switch: HOTCELL_ROOT registers the cell, and a registered cell carries every conversion.
-    # Only development and test may run without one — there Active Storage keeps its own analyzers
-    # and previewers and everything runs in the app. A deployed app has no in-app fallback any more,
-    # so a deployment without a cell is a misconfiguration caught at boot rather than a 500 on the
-    # first upload.
+    # One switch: HOTCELL_ROOT registers the cell, which then carries every conversion. Only development
+    # and test may run without one; everything then runs in the app.
     module Cell
       NAME = "active_storage"
 
-      # A cell may wait queue_wait in the queue and then run for deadline before it gets to say what
-      # happened. Below its answer_within, a saturated cell arrives here as a transport failure rather than
-      # as its own verdict, and the client warns about it at every boot.
+      # Must cover the cell's answer_within (queue_wait + deadline + reply), or a saturated cell arrives
+      # as a transport failure rather than its own verdict.
       TIMEOUT = 135
 
-      # An input this cell will never decode, which is a verdict about one file and may be recorded
-      # against it.
+      # A verdict about one file, which may be recorded against it.
       class UnprocessableAttachment < StandardError; end
 
       # Everything uncertain: a saturated cell, a restarting accessory, a deadline. Must not descend from
-      # UnprocessableAttachment — the gem raises ConfigurationError if it does, because the inheritance
-      # graph is the classification and every retryable failure would be written down as permanent.
+      # UnprocessableAttachment — the inheritance graph is the classification.
       class ProcessingUnavailable < StandardError; end
 
-      # A /hotcellz check that answered, but answered badly. Its message is already a sentence, so it is
-      # reported without an exception class in front of it.
+      # A /hotcellz check that answered, but answered badly.
       class CheckFailed < StandardError; end
 
       class << self
@@ -51,8 +41,8 @@ module Fizzy
           value
         end
 
-        # Unset in development, where the app and its cell run as one user and there is no group to share.
-        # The gem's setter coerces and raises ConfigurationError for a value that is not a numeric gid.
+        # Unset in development, where the app and its cell run as one user. The gem's setter coerces and
+        # raises for a value that is not a numeric gid.
         def group
           ENV["HOTCELL_GROUP"].presence
         end
@@ -61,8 +51,7 @@ module Fizzy
           root.present?
         end
 
-        # Registration happens even with no root, so a caller asking whether the cell is up gets an answer
-        # rather than an UnregisteredCell, and the metrics collector has one shape to iterate.
+        # Registration happens even with no root, so callers get an answer rather than an UnregisteredCell.
         def register!
           ::HotCell.root = root
           ::HotCell.group = group
@@ -74,11 +63,8 @@ module Fizzy
           ::HotCell.cell NAME
         end
 
-        # Everything Active Storage should be configured with, resolved here rather than in a constant
-        # because this file is required during Bundler.require, before Active Storage has defined its own
-        # classes. The image analyzer moves with the transformer whether or not you ask: Rails' image
-        # analyzers test `variant_processor == :vips`, so pointing the transformer at a class makes them
-        # decline and blobs get marked analyzed with no dimensions.
+        # Resolved at call time because this file is required during Bundler.require, before Active
+        # Storage has defined its own classes.
         def active_storage_configuration
           return {} unless enabled?
 
@@ -90,25 +76,11 @@ module Fizzy
                           ActiveStorage::HotCell::Client::Previewers::Video::FFmpeg ] }
         end
 
-        # What /hotcellz reports. Every check answers rather than raises, because the page's job is to be
-        # the last step of booting an accessory — the moment when a cell most likely cannot answer.
-        #
-        # describe and metrics ask the control socket, and a descriptor never crosses that, so both answer
-        # happily for a cell whose work socket the app cannot use at all. The echo round trip is the only
-        # one of the three that says anything about the socket real files travel over. The volume-ownership
-        # mistakes fail as EACCES on the first real request, and nothing else here would say so.
-        # Neither control call raises for itself: describe returns nil after warning, and metrics returns a
-        # response that is simply not ok. Reported as they come back, both say "ok" with an empty result
-        # for a cell that never answered — the same shape as a healthy one.
-        # `at` is spelled the way the cell spells it in its own log lines — same key, same UTC ISO8601 with
-        # milliseconds — so a reading taken here lines up mechanically against the cell's logs in Loki.
-        # `host` because every answer here is about one host's cell: a cell's sockets are host-local, a poll
-        # through the load balancer lands on whichever host it lands on, and an answer that does not say
-        # which one cannot be acted on. Kamal boots a container with the deploy host and a random suffix as
-        # its hostname, so this names the machine and the container on it.
-        # Control socket only by default, which the supervisor answers inline with no fork and no queue.
-        # `work: true` is opt-in because it puts a request on the cell's queue and forks a worker for each
-        # round trip: the caller that wants to spend that has to say so.
+        # What /hotcellz reports. Every check answers rather than raises: the page's job is to be the last
+        # step of booting an accessory, the moment a cell most likely cannot answer. Control socket only by
+        # default; `work: true` is opt-in because each round trip takes a queue slot and forks a worker.
+        # `at` and `host` are spelled the way the cell's own log lines spell them, so a reading lines up
+        # against Loki.
         def diagnostics(work: false)
           checks = { describe: reporting { cell.describe or raise CheckFailed, "the cell did not answer; see metrics" },
                      metrics: reporting { answered cell.metrics } }
@@ -123,22 +95,14 @@ module Fizzy
           round_trip Echo, message
         end
 
-        # The same payload through example.reopen, which reads the input by name. `/dev/fd/N` is a fresh
-        # open, rechecked against the cell's uid and the file's mode, so this succeeds only where the two
-        # sides share a group. Every operation that hands a tool a filename does exactly this, and echo
-        # never does — so a cell missing the group answers echo perfectly and fails every real conversion.
+        # The same payload through example.reopen, which re-opens the input by name as every operation that
+        # hands a tool a filename does — so a cell missing the shared group answers echo perfectly and
+        # fails only this.
         def reopen(message = "hotcell")
           round_trip Reopen, message
         end
 
         private
-          # The checks that cross the work socket. describe and metrics both answer on the control socket,
-          # and a descriptor never crosses that.
-          #
-          # Both verdicts raise rather than being reported beside an `ok`, because a caller reads the
-          # status and not the body: a cell that answers with the wrong bytes is not a healthy cell, and
-          # reporting `echoed: false` under `ok: true` is a 200 for a broken one.
-          #
           # The client verifies access modes, so the input must be "rb" and the output "wb";
           # Tempfile.create yields "r+", which it rejects.
           def round_trip(client, message)
@@ -155,8 +119,8 @@ module Fizzy
             end
           end
 
-          # Staged means the worker read a copy on its own scratch rather than the caller's file, so the
-          # round trip proved nothing about the descriptor it exists to prove.
+          # Staged means the worker read a copy rather than the caller's descriptor, so the round trip
+          # proved nothing about the thing it exists to prove.
           def verified(result, returned, message)
             raise CheckFailed, "the cell returned #{returned.bytesize} bytes, not the #{message.bytesize} " \
                                "sent" unless returned == message
@@ -166,8 +130,8 @@ module Fizzy
             result.merge(echoed: true)
           end
 
-          # The registered cell answers this rather than the module, because a cell registered with an
-          # explicit dir: is reachable whatever HOTCELL_ROOT says.
+          # The registered cell answers enabled? rather than the module: a cell registered with an explicit
+          # dir: is reachable whatever HOTCELL_ROOT says.
           def reporting
             if cell.enabled?
               { ok: true, result: yield }

--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -92,7 +92,7 @@ module Fizzy
 
       # Rails edge (actioncable 647ce6769c, 2026-05-28) extracted WebSocket handling
       # into ActionCable::Server::Socket, which now calls connection.handle_open /
-      # handle_close *publicly*. sentry-rails (through 6.6.2 and master as of 2026-07)
+      # handle_close *publicly*. sentry-rails (through 6.7.0 and master as of 2026-08)
       # still prepends these onto ActionCable::Connection::Base as `private`, matching
       # the old internal calling convention, so the external call raises NoMethodError
       # and every WebSocket connection dies. Restore public visibility on Sentry's

--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -3,6 +3,8 @@ require_relative "true_client_ip"
 require_relative "signup"
 require_relative "authorization"
 require_relative "gvl_instrumentation"
+require_relative "cell"
+require_relative "unprocessable_attachments"
 require_relative "../../rails_ext/active_record_tasks_database_tasks.rb"
 
 module Fizzy
@@ -45,6 +47,29 @@ module Fizzy
 
       initializer "fizzy_saas.gvl_instrumentation" do |app|
         app.config.middleware.insert_before(Rack::Runtime, GvlInstrumentation)
+      end
+
+      # Before active_storage.configs, which is where Active Storage reads these settings off config.
+      initializer "fizzy_saas.hotcell", before: "active_storage.configs" do |app|
+        Cell.register!
+
+        app.config.active_storage.merge! Cell.active_storage_configuration
+      end
+
+      # to_prepare rather than after_initialize, for the same reason the client gem's retry hook is: the
+      # job classes live in a reloadable engine and are redefined on every code reload, and a discard_on
+      # applied once at boot would silently vanish after the first file save in development.
+      initializer "fizzy_saas.unprocessable_attachments" do |app|
+        app.config.to_prepare do
+          UnprocessableAttachments.install!
+        end
+      end
+
+      # Warns when a client wants an operation the cell does not carry, and when the timeout is too tight
+      # for what the cell says it may take. Never fails boot: a cell that is restarting is a degraded
+      # deployment, not a broken one.
+      config.after_initialize do
+        ::HotCell.describe_cells
       end
 
       initializer "fizzy_saas.solid_queue" do
@@ -145,6 +170,9 @@ module Fizzy
 
         require "yabeda/solid_cache"
         Yabeda::SolidCache.install!
+
+        require "yabeda/hot_cell"
+        Yabeda::HotCell.install!
 
         require_relative "metrics"
       end

--- a/saas/lib/fizzy/saas/unprocessable_attachments.rb
+++ b/saas/lib/fizzy/saas/unprocessable_attachments.rb
@@ -1,24 +1,12 @@
 module Fizzy
   module Saas
-    # A permanent verdict from the cell is a fact about one variant of one blob. It must not fail the save of
-    # the record that attached the file: `process: :immediately` transforms inline inside the record's
-    # after_commit, so the record is already committed by then, and a raise there 500s a POST that succeeded.
-    #
-    # There are two immediate paths, and only one is a job. An already-uploaded blob (a direct-uploaded
-    # embed) is varied by `CreateVariantsJob.perform_now`, so `discard_on` catches it — the same mechanism
-    # the client gem uses to `retry_on` the transient class, and it fires under `perform_now`. A fresh io
-    # (a form-uploaded avatar) is varied by `Attachment#uploaded` straight from the io, before the blob is
-    # even stored, and no job is involved; a rescue there is what keeps the file uploaded and the save from
-    # raising.
-    #
-    # The transient class is deliberately caught by neither: a saturated cell says nothing about the file,
-    # and the client gem already retries it. Nothing is recorded against the blob either — one variant
-    # failing says nothing about the others, and Rails will attempt the failed one again on next request,
-    # which is the behaviour it had before the cell.
-    #
-    # Reported, because discarding is the one place a permanent verdict stops: elsewhere the raise reaches
-    # Sentry on its own, and the perform.hot_cell subscriber reports nothing so as not to double it. On the
-    # form path the rescue reports for the same reason.
+    # A permanent verdict on one variant must not fail the save that attached the file: immediate variants
+    # transform inside the record's after_commit, so a raise there 500s a POST that succeeded. There are
+    # two immediate paths, and only one is a job — a direct-uploaded embed runs under
+    # `CreateVariantsJob.perform_now`, which `discard_on` catches, while a form-uploaded io is varied
+    # before the blob is stored, so a rescue catches it there. Neither catches the transient class, which
+    # the client gem already retries. Both catches report, because they are where the raise stops;
+    # everywhere else it reaches Sentry on its own.
     module UnprocessableAttachments
       # Rails' own loop, with the rescue inside it rather than around it: one variant failing must not skip
       # the rest, and the loop's last line marks the variants as processed — miss it and Rails re-runs every

--- a/saas/lib/fizzy/saas/unprocessable_attachments.rb
+++ b/saas/lib/fizzy/saas/unprocessable_attachments.rb
@@ -1,0 +1,55 @@
+module Fizzy
+  module Saas
+    # A permanent verdict from the cell is a fact about one variant of one blob. It must not fail the save of
+    # the record that attached the file: `process: :immediately` transforms inline inside the record's
+    # after_commit, so the record is already committed by then, and a raise there 500s a POST that succeeded.
+    #
+    # There are two immediate paths, and only one is a job. An already-uploaded blob (a direct-uploaded
+    # embed) is varied by `CreateVariantsJob.perform_now`, so `discard_on` catches it — the same mechanism
+    # the client gem uses to `retry_on` the transient class, and it fires under `perform_now`. A fresh io
+    # (a form-uploaded avatar) is varied by `Attachment#uploaded` straight from the io, before the blob is
+    # even stored, and no job is involved; a rescue there is what keeps the file uploaded and the save from
+    # raising.
+    #
+    # The transient class is deliberately caught by neither: a saturated cell says nothing about the file,
+    # and the client gem already retries it. Nothing is recorded against the blob either — one variant
+    # failing says nothing about the others, and Rails will attempt the failed one again on next request,
+    # which is the behaviour it had before the cell.
+    #
+    # Reported, because discarding is the one place a permanent verdict stops: elsewhere the raise reaches
+    # Sentry on its own, and the perform.hot_cell subscriber reports nothing so as not to double it. On the
+    # form path the rescue reports for the same reason.
+    module UnprocessableAttachments
+      # Rails' own loop, with the rescue inside it rather than around it: one variant failing must not skip
+      # the rest, and the loop's last line marks the variants as processed — miss it and Rails re-runs every
+      # one of them as a job after commit.
+      module Attachment
+        private
+          def process_immediate_variants_from_io(io)
+            return unless blob.variable?
+
+            named_variants.each do |_variant_name, named_variant|
+              next unless named_variant.process(record) == :immediately
+
+              begin
+                blob.variant(named_variant.transformations).process_from_io(io)
+              rescue Cell::UnprocessableAttachment => error
+                Rails.error.report error, handled: true, severity: :info
+              end
+              io.rewind if io.respond_to?(:rewind)
+            end
+
+            self.immediate_variants_processed = true
+          end
+      end
+
+      def self.install!
+        ActiveSupport.on_load(:active_storage_attachment) { prepend Attachment }
+
+        %w[ ActiveStorage::CreateVariantsJob ActiveStorage::TransformJob ].each do |job|
+          job.constantize.discard_on Cell::UnprocessableAttachment, report: true
+        end
+      end
+    end
+  end
+end

--- a/saas/lib/yabeda/hot_cell.rb
+++ b/saas/lib/yabeda/hot_cell.rb
@@ -1,0 +1,113 @@
+module Yabeda
+  # A cell's control socket is host-local, so only a process on the same host can reach it. The collect
+  # block runs in every scraped process on every host, which matches the topology exactly.
+  #
+  # Two namespace traps live in this file, and both fail silently. Inside `module Yabeda`, `Rails` resolves
+  # to Yabeda::Rails, so error reporting has to say ::Rails or it raises inside the rescue that was meant
+  # to swallow it. And `hotcell` is a DSL method that exists only inside Yabeda.configure, so a method
+  # factored out of the collect block has to say Yabeda.hotcell or it records nothing at all. The tests
+  # assert gauge values for that reason: asserting the block ran would pass against both.
+  module HotCell
+    def self.install!
+      Yabeda.configure do
+        group :hotcell
+
+        counter :requests, comment: "Calls through perform_in_hotcell, by outcome",
+          tags: %i[ cell operation code cause ]
+        histogram :perform, comment: "Time the cell spent performing", unit: :seconds,
+          tags: %i[ cell operation ], buckets: [ 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 120 ]
+
+        gauge :up, comment: "1 when the local cell answers its control socket",
+          tags: %i[ cell ], aggregation: :most_recent
+        gauge :running, comment: "Workers busy right now", tags: %i[ cell ], aggregation: :most_recent
+        gauge :queued, comment: "Connections waiting for a worker", tags: %i[ cell ], aggregation: :most_recent
+        gauge :queue_high_water, comment: "Deepest the queue has been since boot",
+          tags: %i[ cell ], aggregation: :most_recent
+        gauge :cancelled, comment: "Callers that gave up before the cell answered (a floor)",
+          tags: %i[ cell ], aggregation: :most_recent
+        gauge :killed, comment: "Workers killed since boot, by cause",
+          tags: %i[ cell cause ], aggregation: :most_recent
+        gauge :uptime_seconds, comment: "Seconds since the supervisor booted",
+          tags: %i[ cell ], aggregation: :most_recent
+
+        collect { Yabeda::HotCell.collect_stats }
+      end
+
+      subscribe_to_performs
+    end
+
+    def self.collect_stats
+      ::HotCell.cells.each_value do |cell|
+        next unless cell.enabled?
+
+        response = cell.metrics
+        Yabeda.hotcell.up.set({ cell: cell.name }, response&.ok? ? 1 : 0)
+        next unless response&.ok?
+
+        set_counters cell, response.result
+      end
+    rescue => error
+      # A scrape must not fail because a cell is misbehaving.
+      ::Rails.error.report error, handled: true
+    end
+
+    # The subscriber raises into whoever called instrument, so an unguarded bug here would arrive as a
+    # failed conversion rather than as missing metrics.
+    def self.subscribe_to_performs
+      ActiveSupport::Notifications.subscribe "perform.hot_cell" do |event|
+        record_perform event
+      rescue => error
+        ::Rails.error.report error, handled: true
+      end
+    end
+
+    # Deliberately no Sentry report from here. The client raises the cell's verdict as the registered
+    # permanent or transient class, and that raise reaches Sentry with the right class wherever nothing
+    # rescues it; where something rescues it to keep a save from failing, that rescue reports. A report
+    # from this subscriber as well was a second copy of the same event under a second name.
+    def self.record_perform(event)
+      labels = { cell: event.payload[:cell], operation: event.payload[:operation] }
+      code = event.payload[:code]
+
+      # cause is empty rather than absent for every code but killed: a label that is sometimes missing is a
+      # separate series in Prometheus, and a query by code would silently split.
+      Yabeda.hotcell.requests.increment(labels.merge(code: code || "ok", cause: event.payload[:cause].to_s))
+      Yabeda.hotcell.perform.measure(labels, (event.payload[:perform_ms] || 0) / 1000.0)
+      log_perform event, labels, code
+    end
+
+    # One line per call, so an upload that ran a conversion inline shows what it paid. The histogram cannot
+    # say that: it knows how long transforms take on a host, not which request waited for one. Two clocks
+    # on purpose — `perform_ms` is what the cell measured inside the worker, `duration_ms` is what this
+    # process waited — because their difference is the queue and the socket, which is the number that says
+    # whether the cell or the plumbing was slow.
+    #
+    # `Rails.logger.info` rather than `logger.struct`, because `struct` is a method on the per-request
+    # proxy a controller or job holds, and a notification subscriber has neither. Structured logging still
+    # gathers every line written during a request onto that request's record, so this lands beside the
+    # request's own duration. Shaped like Active Storage's own `Storage (211.3ms) Downloaded file...`, with
+    # the duration up front where the eye expects it and the detail as JSON after.
+    private_class_method def self.log_perform(event, labels, code)
+      duration_ms = event.duration.round(1)
+
+      ::Rails.logger.info "  HotCell (#{duration_ms}ms) " + labels.merge(
+        code: code || "ok",
+        cause: event.payload[:cause],
+        perform_ms: event.payload[:perform_ms],
+        duration_ms: duration_ms,
+        bytes_in: event.payload[:bytes_in],
+        bytes_out: event.payload[:bytes_out]).to_json
+    end
+
+    private_class_method def self.set_counters(cell, counters)
+      tags = { cell: cell.name }
+
+      Yabeda.hotcell.running.set(tags, counters[:running])
+      Yabeda.hotcell.queued.set(tags, counters[:queued])
+      Yabeda.hotcell.queue_high_water.set(tags, counters[:queue_high_water])
+      Yabeda.hotcell.cancelled.set(tags, counters[:cancelled])
+      Yabeda.hotcell.uptime_seconds.set(tags, counters[:uptime_s])
+      counters[:killed_by].each { |cause, count| Yabeda.hotcell.killed.set(tags.merge(cause: cause), count) }
+    end
+  end
+end

--- a/saas/lib/yabeda/hot_cell.rb
+++ b/saas/lib/yabeda/hot_cell.rb
@@ -1,12 +1,7 @@
 module Yabeda
-  # A cell's control socket is host-local, so only a process on the same host can reach it. The collect
-  # block runs in every scraped process on every host, which matches the topology exactly.
-  #
-  # Two namespace traps live in this file, and both fail silently. Inside `module Yabeda`, `Rails` resolves
-  # to Yabeda::Rails, so error reporting has to say ::Rails or it raises inside the rescue that was meant
-  # to swallow it. And `hotcell` is a DSL method that exists only inside Yabeda.configure, so a method
-  # factored out of the collect block has to say Yabeda.hotcell or it records nothing at all. The tests
-  # assert gauge values for that reason: asserting the block ran would pass against both.
+  # Two namespace traps here fail silently: inside `module Yabeda`, `Rails` resolves to Yabeda::Rails, so
+  # error reporting must say ::Rails; and `hotcell` is a DSL method that exists only inside
+  # Yabeda.configure, so factored-out methods must say Yabeda.hotcell or they record nothing.
   module HotCell
     def self.install!
       Yabeda.configure do
@@ -61,32 +56,22 @@ module Yabeda
       end
     end
 
-    # Deliberately no Sentry report from here. The client raises the cell's verdict as the registered
-    # permanent or transient class, and that raise reaches Sentry with the right class wherever nothing
-    # rescues it; where something rescues it to keep a save from failing, that rescue reports. A report
-    # from this subscriber as well was a second copy of the same event under a second name.
+    # Deliberately no Sentry report from here: the raise the caller sees already reaches Sentry, so a
+    # report here was a second copy under a second name.
     def self.record_perform(event)
       labels = { cell: event.payload[:cell], operation: event.payload[:operation] }
       code = event.payload[:code]
 
-      # cause is empty rather than absent for every code but killed: a label that is sometimes missing is a
-      # separate series in Prometheus, and a query by code would silently split.
+      # cause is empty rather than absent: a sometimes-missing label is a separate Prometheus series.
       Yabeda.hotcell.requests.increment(labels.merge(code: code || "ok", cause: event.payload[:cause].to_s))
       Yabeda.hotcell.perform.measure(labels, (event.payload[:perform_ms] || 0) / 1000.0)
       log_perform event, labels, code
     end
 
-    # One line per call, so an upload that ran a conversion inline shows what it paid. The histogram cannot
-    # say that: it knows how long transforms take on a host, not which request waited for one. Two clocks
-    # on purpose — `perform_ms` is what the cell measured inside the worker, `duration_ms` is what this
-    # process waited — because their difference is the queue and the socket, which is the number that says
-    # whether the cell or the plumbing was slow.
-    #
-    # `Rails.logger.info` rather than `logger.struct`, because `struct` is a method on the per-request
-    # proxy a controller or job holds, and a notification subscriber has neither. Structured logging still
-    # gathers every line written during a request onto that request's record, so this lands beside the
-    # request's own duration. Shaped like Active Storage's own `Storage (211.3ms) Downloaded file...`, with
-    # the duration up front where the eye expects it and the detail as JSON after.
+    # The line carries two clocks on purpose: `perform_ms` is what the cell measured, `duration_ms` is
+    # what this process waited, and their difference is the queue and the socket. `Rails.logger.info`
+    # rather than `logger.struct`, because `struct` lives on the per-request proxy and a subscriber
+    # has none.
     private_class_method def self.log_perform(event, labels, code)
       duration_ms = event.duration.round(1)
 

--- a/saas/test/controllers/hotcellz_controller_test.rb
+++ b/saas/test/controllers/hotcellz_controller_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class HotcellzControllerTest < ActionDispatch::IntegrationTest
+  # The literal paths a monitor and a person are configured with, asserted as the strings they will hold.
+  HOTCELLZ = "/hotcellz"
+  HOTCELLZ_TEST = "/hotcellz/test"
+
+  # Unauthenticated so a monitor can poll it, and outside the account scope like the /up beside it.
+  test "answers without a session" do
+    get HOTCELLZ
+
+    assert_response :service_unavailable
+    assert_equal "text/plain", response.media_type
+    assert_equal "FAIL", response.body
+  end
+
+  # A monitor reads the status and a person reads the word. Neither should have to parse anything, and
+  # nothing about the cell's inventory, counters or configuration belongs in front of a stranger.
+  test "tells an unauthenticated caller nothing but whether the cell answered" do
+    get HOTCELLZ
+
+    assert_no_match(/hotcell|running|queued|uptime|HOTCELL_ROOT/i, response.body)
+  end
+
+  # describe and metrics ask the supervisor inline, with no fork and no queue. So an unauthenticated flood
+  # cannot make the cell do work, which is the whole reason the round trips moved to their own action.
+  test "runs no work-socket round trip" do
+    Fizzy::Saas::Cell.stubs(:echo).raises("echo must not run here")
+    Fizzy::Saas::Cell.stubs(:reopen).raises("reopen must not run here")
+
+    get HOTCELLZ
+
+    assert_response :service_unavailable
+  end
+
+  test "refuses the test action without a session" do
+    get HOTCELLZ_TEST
+
+    assert_response :forbidden
+  end
+
+  # Signups are open, so an authenticated identity is close to anyone. The round trips fork a worker, and
+  # the staff gate is the only thing bounding who may spend one.
+  test "refuses the test action to a signed-in identity that is not staff" do
+    sign_in_as :mike
+
+    untenanted { get HOTCELLZ_TEST }
+
+    assert_response :forbidden
+  end
+
+  test "reports every check to staff" do
+    sign_in_as :david
+
+    untenanted { get HOTCELLZ_TEST }
+
+    assert_equal "application/json", response.media_type
+    assert_equal %w[ at host root groups describe metrics echo reopen ], response.parsed_body.keys
+  end
+
+  # Spelled the way the cell spells `at` in its own log lines, so a reading lines up against them.
+  test "stamps the reading with subsecond resolution" do
+    sign_in_as :david
+
+    untenanted { get HOTCELLZ_TEST }
+
+    assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z/, response.parsed_body["at"])
+  end
+
+  # A poll lands on one of the web hosts and the answer is about that host's cell, so an answer that does
+  # not say which one cannot be acted on.
+  test "names the host that answered" do
+    sign_in_as :david
+
+    untenanted { get HOTCELLZ_TEST }
+
+    assert_equal Socket.gethostname, response.parsed_body["host"]
+  end
+
+  # The endpoint is the last step of booting an accessory, which is the moment a cell is least likely to
+  # answer. One that raises there is one nobody can use to find out why.
+  test "reports an unconfigured cell rather than raising" do
+    sign_in_as :david
+
+    untenanted { get HOTCELLZ_TEST }
+
+    assert_response :service_unavailable
+    assert_equal [ false, false, false, false ], checks.map { it["ok"] }
+    assert_match "HOTCELL_ROOT is unset", response.parsed_body["echo"]["error"]
+  end
+
+  test "reports a cell that will not answer rather than raising" do
+    HotCell.cell(Fizzy::Saas::Cell::NAME).stubs(:directory).returns("tmp/no-cell-here")
+    sign_in_as :david
+
+    untenanted { get HOTCELLZ_TEST }
+
+    assert_equal [ false, false, false, false ], checks.map { it["ok"] }
+    assert_match "Errno::ENOENT", response.parsed_body["echo"]["error"]
+  end
+
+  private
+    def checks
+      response.parsed_body.values_at("describe", "metrics", "echo", "reopen")
+    end
+end

--- a/saas/test/controllers/hotcellz_controller_test.rb
+++ b/saas/test/controllers/hotcellz_controller_test.rb
@@ -55,7 +55,7 @@ class HotcellzControllerTest < ActionDispatch::IntegrationTest
     untenanted { get HOTCELLZ_TEST }
 
     assert_equal "application/json", response.media_type
-    assert_equal %w[ at host root groups describe metrics echo reopen ], response.parsed_body.keys
+    assert_equal %w[ at host root describe metrics echo reopen ], response.parsed_body.keys
   end
 
   # Spelled the way the cell spells `at` in its own log lines, so a reading lines up against them.

--- a/saas/test/controllers/hotcellz_controller_test.rb
+++ b/saas/test/controllers/hotcellz_controller_test.rb
@@ -1,11 +1,9 @@
 require "test_helper"
 
 class HotcellzControllerTest < ActionDispatch::IntegrationTest
-  # The literal paths a monitor and a person are configured with, asserted as the strings they will hold.
   HOTCELLZ = "/hotcellz"
   HOTCELLZ_TEST = "/hotcellz/test"
 
-  # Unauthenticated so a monitor can poll it, and outside the account scope like the /up beside it.
   test "answers without a session" do
     get HOTCELLZ
 
@@ -14,16 +12,12 @@ class HotcellzControllerTest < ActionDispatch::IntegrationTest
     assert_equal "FAIL", response.body
   end
 
-  # A monitor reads the status and a person reads the word. Neither should have to parse anything, and
-  # nothing about the cell's inventory, counters or configuration belongs in front of a stranger.
   test "tells an unauthenticated caller nothing but whether the cell answered" do
     get HOTCELLZ
 
     assert_no_match(/hotcell|running|queued|uptime|HOTCELL_ROOT/i, response.body)
   end
 
-  # describe and metrics ask the supervisor inline, with no fork and no queue. So an unauthenticated flood
-  # cannot make the cell do work, which is the whole reason the round trips moved to their own action.
   test "runs no work-socket round trip" do
     Fizzy::Saas::Cell.stubs(:echo).raises("echo must not run here")
     Fizzy::Saas::Cell.stubs(:reopen).raises("reopen must not run here")
@@ -39,8 +33,6 @@ class HotcellzControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  # Signups are open, so an authenticated identity is close to anyone. The round trips fork a worker, and
-  # the staff gate is the only thing bounding who may spend one.
   test "refuses the test action to a signed-in identity that is not staff" do
     sign_in_as :mike
 
@@ -58,7 +50,6 @@ class HotcellzControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[ at host root describe metrics echo reopen ], response.parsed_body.keys
   end
 
-  # Spelled the way the cell spells `at` in its own log lines, so a reading lines up against them.
   test "stamps the reading with subsecond resolution" do
     sign_in_as :david
 
@@ -67,8 +58,6 @@ class HotcellzControllerTest < ActionDispatch::IntegrationTest
     assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z/, response.parsed_body["at"])
   end
 
-  # A poll lands on one of the web hosts and the answer is about that host's cell, so an answer that does
-  # not say which one cannot be acted on.
   test "names the host that answered" do
     sign_in_as :david
 
@@ -77,8 +66,6 @@ class HotcellzControllerTest < ActionDispatch::IntegrationTest
     assert_equal Socket.gethostname, response.parsed_body["host"]
   end
 
-  # The endpoint is the last step of booting an accessory, which is the moment a cell is least likely to
-  # answer. One that raises there is one nobody can use to find out why.
   test "reports an unconfigured cell rather than raising" do
     sign_in_as :david
 

--- a/saas/test/lib/cell_test.rb
+++ b/saas/test/lib/cell_test.rb
@@ -7,8 +7,6 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
   # or every later test in whatever order minitest chose runs without a registered cell.
   teardown { Cell.register! }
 
-  # Development runs the app and its cell as one user, so there is no group to share and chowning into one
-  # the app is not in would be EPERM on every conversion.
   test "no group is set when the environment names none" do
     with_env "HOTCELL_GROUP" => nil do
       Cell.register!
@@ -17,8 +15,6 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     end
   end
 
-  # A group name, or any typo, is `0` under to_i — root — and the client would chown every descriptor to
-  # it. A mistake in a deploy file must not look like a working configuration.
   test "a group that is not a number raises rather than meaning root" do
     with_env "HOTCELL_GROUP" => "hotcell" do
       error = assert_raises(HotCell::ConfigurationError) { Cell.register! }
@@ -27,8 +23,6 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     end
   end
 
-  # Anything that reaches the work socket forks a worker and takes a queue slot, so it is opt-in: a caller
-  # that only wants to know whether the cell is there must not be able to spend one by accident.
   test "diagnostics puts nothing on the cell's queue unless asked" do
     Cell.stubs(:echo).raises("echo must not run here")
     Cell.stubs(:reopen).raises("reopen must not run here")
@@ -40,14 +34,10 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     assert_equal %i[ at host root describe metrics echo reopen ], Cell.diagnostics(work: true).keys
   end
 
-  # The round trips report what they compared, and nothing above them looked at it — so a cell returning
-  # the wrong bytes answered /hotcellz with a 200.
   test "a round trip that returns different bytes is not ok" do
     assert_raises(Cell::CheckFailed) { Cell.send :round_trip, silent_client, "hotcell" }
   end
 
-  # Staged means the worker read a copy on its own scratch rather than the caller's file, so the check
-  # proved nothing about the descriptor it was written to prove.
   test "a round trip whose input was staged is not ok" do
     error = assert_raises(Cell::CheckFailed) { Cell.send :round_trip, staging_client, "hotcell" }
 
@@ -112,9 +102,6 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     assert_operator Cell::TIMEOUT, :>=, queue_wait + deadline + kill_and_reply
   end
 
-  # The gem's default, asserted rather than set, because nothing here should own the number — but a control
-  # call on the work timeout is what blanks a host's metrics instead of reporting its cell down. Yabeda
-  # collects inside the scrape request, so this has to answer well within one.
   test "control calls are bounded tighter than work calls and than a scrape" do
     scrape_timeout = 10
 
@@ -123,14 +110,12 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
   end
 
   private
-    # Answers without writing the output, so the bytes cannot match.
     def silent_client
       Class.new do
         def self.perform_in_hotcell(input, output) = { bytes: 0, staged: false }
       end
     end
 
-    # Returns the right bytes, having read a copy on its own scratch rather than the caller's file.
     def staging_client
       Class.new do
         def self.perform_in_hotcell(input, output)

--- a/saas/test/lib/cell_test.rb
+++ b/saas/test/lib/cell_test.rb
@@ -70,6 +70,30 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     end
   end
 
+  # Unstubbed by hand rather than left to mocha, whose automatic unstub runs after this class's
+  # teardown re-registers the cell — which would raise exactly the error this test is about.
+  test "a deployed app refuses to boot without a cell" do
+    Rails.env.stubs(:local?).returns(false)
+
+    with_env "HOTCELL_ROOT" => nil do
+      error = assert_raises(HotCell::ConfigurationError) { Cell.register! }
+
+      assert_match "HOTCELL_ROOT", error.message
+    end
+  ensure
+    Rails.env.unstub(:local?)
+  end
+
+  test "asset precompilation boots without a cell" do
+    Rails.env.stubs(:local?).returns(false)
+
+    with_env "HOTCELL_ROOT" => nil, "SECRET_KEY_BASE_DUMMY" => "1" do
+      assert_nothing_raised { Cell.register! }
+    end
+  ensure
+    Rails.env.unstub(:local?)
+  end
+
   test "a root moves every operation to the cell" do
     configuration = with_env("HOTCELL_ROOT" => "tmp/hotcell") { Cell.active_storage_configuration }
 

--- a/saas/test/lib/cell_test.rb
+++ b/saas/test/lib/cell_test.rb
@@ -1,0 +1,174 @@
+require "test_helper"
+
+class Fizzy::Saas::CellTest < ActiveSupport::TestCase
+  Cell = Fizzy::Saas::Cell
+
+  # Registration is global state, so a test that re-registers has to put the boot-time registration back
+  # or every later test in whatever order minitest chose runs without a registered cell.
+  teardown { Cell.register! }
+
+  # Development runs the app and its cell as one user, so there is no group to share and chowning into one
+  # the app is not in would be EPERM on every conversion.
+  test "no group is set when the environment names none" do
+    with_env "HOTCELL_GROUP" => nil do
+      Cell.register!
+
+      assert_nil HotCell.group
+    end
+  end
+
+  # A group name, or any typo, is `0` under to_i — root — and the client would chown every descriptor to
+  # it. Same reason HOTCELL_ACTIVE_STORAGE raises on a name it does not know: a mistake in a deploy file
+  # must not look like a working configuration.
+  test "a group that is not a number raises rather than meaning root" do
+    with_env "HOTCELL_GROUP" => "hotcell" do
+      error = assert_raises(HotCell::ConfigurationError) { Cell.register! }
+
+      assert_match "hotcell", error.message
+    end
+  end
+
+  # Anything that reaches the work socket forks a worker and takes a queue slot, so it is opt-in: a caller
+  # that only wants to know whether the cell is there must not be able to spend one by accident.
+  test "diagnostics puts nothing on the cell's queue unless asked" do
+    Cell.stubs(:echo).raises("echo must not run here")
+    Cell.stubs(:reopen).raises("reopen must not run here")
+
+    assert_equal %i[ at host root groups describe metrics ], Cell.diagnostics.keys
+  end
+
+  test "work asks for the round trips as well" do
+    assert_equal %i[ at host root groups describe metrics echo reopen ], Cell.diagnostics(work: true).keys
+  end
+
+  # The round trips report what they compared, and nothing above them looked at it — so a cell returning
+  # the wrong bytes answered /hotcellz with a 200.
+  test "a round trip that returns different bytes is not ok" do
+    assert_raises(Cell::CheckFailed) { Cell.send :round_trip, silent_client, "hotcell" }
+  end
+
+  # Staged means the worker read a copy on its own scratch rather than the caller's file, so the check
+  # proved nothing about the descriptor it was written to prove.
+  test "a round trip whose input was staged is not ok" do
+    error = assert_raises(Cell::CheckFailed) { Cell.send :round_trip, staging_client, "hotcell" }
+
+    assert_match "staged", error.message
+  end
+
+  test "the cell is registered even with no root, so callers get an answer rather than an UnregisteredCell" do
+    with_env "HOTCELL_ROOT" => nil do
+      Cell.register!
+
+      assert_not Cell.enabled?
+      assert_not Cell.cell.enabled?
+    end
+  end
+
+  test "a root registers the cell without moving any work" do
+    with_env "HOTCELL_ROOT" => "tmp/hotcell", "HOTCELL_ACTIVE_STORAGE" => nil do
+      assert Cell.enabled?
+      assert_not Cell.processing_attachments?
+      assert_empty Cell.active_storage_configuration
+    end
+  end
+
+  test "the work switch does nothing without a root" do
+    with_env "HOTCELL_ROOT" => nil, "HOTCELL_ACTIVE_STORAGE" => "all" do
+      assert_not Cell.processing_attachments?
+      assert_empty Cell.active_storage_configuration
+    end
+  end
+
+  test "images moves the transformer and the image analyzer together" do
+    configuration = configuration_for "images"
+
+    assert_equal ActiveStorage::HotCell::Client::Transformers::Image::Vips, configuration[:variant_processor]
+    assert_equal [ ActiveStorage::HotCell::Client::Analyzers::Image::Vips ],
+      configuration[:analyzers].grep(hotcell_classes)
+  end
+
+  test "a group that has not moved keeps Rails' own classes" do
+    configuration = configuration_for "images"
+
+    assert_equal [ ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ],
+      configuration[:analyzers] - configuration[:analyzers].grep(hotcell_classes)
+    assert_equal [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer,
+                   ActiveStorage::Previewer::VideoPreviewer ], configuration[:previewers]
+  end
+
+  test "pdfs moves the PDF previewer and leaves Rails' video previewer behind it" do
+    configuration = configuration_for "images,pdfs"
+
+    assert_equal [ ActiveStorage::HotCell::Client::Previewers::Pdf::Mutool,
+                   ActiveStorage::Previewer::VideoPreviewer ], configuration[:previewers]
+  end
+
+  test "all moves every operation" do
+    configuration = configuration_for "all"
+
+    assert_empty configuration[:analyzers] - configuration[:analyzers].grep(hotcell_classes)
+    assert_empty configuration[:previewers] - configuration[:previewers].grep(hotcell_classes)
+  end
+
+  test "an unknown group raises rather than meaning off" do
+    error = assert_raises(ArgumentError) { configuration_for "imgaes" }
+
+    assert_match "imgaes", error.message
+  end
+
+  test "the transient class does not descend from the permanent one" do
+    assert_not Cell::ProcessingUnavailable <= Cell::UnprocessableAttachment
+  end
+
+  test "the client waits at least as long as the cell may take to answer" do
+    queue_wait, deadline, kill_and_reply = 10, 120, 1
+
+    assert_operator Cell::TIMEOUT, :>=, queue_wait + deadline + kill_and_reply
+  end
+
+  # The gem's default, asserted rather than set, because nothing here should own the number — but a control
+  # call on the work timeout is what blanks a host's metrics instead of reporting its cell down. Yabeda
+  # collects inside the scrape request, so this has to answer well within one.
+  test "control calls are bounded tighter than work calls and than a scrape" do
+    scrape_timeout = 10
+
+    assert_operator Cell.cell.control_timeout, :<, scrape_timeout
+    assert_operator Cell.cell.control_timeout, :<, Cell::TIMEOUT
+  end
+
+  private
+    # Answers without writing the output, so the bytes cannot match.
+    def silent_client
+      Class.new do
+        def self.perform_in_hotcell(input, output) = { bytes: 0, staged: false }
+      end
+    end
+
+    # Returns the right bytes, having read a copy on its own scratch rather than the caller's file.
+    def staging_client
+      Class.new do
+        def self.perform_in_hotcell(input, output)
+          output.write File.read(input.path)
+          { bytes: 7, staged: true }
+        end
+      end
+    end
+
+    def configuration_for(groups)
+      with_env "HOTCELL_ROOT" => "tmp/hotcell", "HOTCELL_ACTIVE_STORAGE" => groups do
+        Cell.active_storage_configuration
+      end
+    end
+
+    def hotcell_classes
+      ->(klass) { klass.name.start_with?("ActiveStorage::HotCell::Client::") }
+    end
+
+    def with_env(vars)
+      originals = vars.keys.index_with { |key| ENV[key] }
+      vars.each { |key, value| ENV[key] = value }
+      yield
+    ensure
+      originals.each { |key, value| ENV[key] = value }
+    end
+end

--- a/saas/test/lib/cell_test.rb
+++ b/saas/test/lib/cell_test.rb
@@ -18,8 +18,7 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
   end
 
   # A group name, or any typo, is `0` under to_i — root — and the client would chown every descriptor to
-  # it. Same reason HOTCELL_ACTIVE_STORAGE raises on a name it does not know: a mistake in a deploy file
-  # must not look like a working configuration.
+  # it. A mistake in a deploy file must not look like a working configuration.
   test "a group that is not a number raises rather than meaning root" do
     with_env "HOTCELL_GROUP" => "hotcell" do
       error = assert_raises(HotCell::ConfigurationError) { Cell.register! }
@@ -34,11 +33,11 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     Cell.stubs(:echo).raises("echo must not run here")
     Cell.stubs(:reopen).raises("reopen must not run here")
 
-    assert_equal %i[ at host root groups describe metrics ], Cell.diagnostics.keys
+    assert_equal %i[ at host root describe metrics ], Cell.diagnostics.keys
   end
 
   test "work asks for the round trips as well" do
-    assert_equal %i[ at host root groups describe metrics echo reopen ], Cell.diagnostics(work: true).keys
+    assert_equal %i[ at host root describe metrics echo reopen ], Cell.diagnostics(work: true).keys
   end
 
   # The round trips report what they compared, and nothing above them looked at it — so a cell returning
@@ -64,56 +63,19 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
     end
   end
 
-  test "a root registers the cell without moving any work" do
-    with_env "HOTCELL_ROOT" => "tmp/hotcell", "HOTCELL_ACTIVE_STORAGE" => nil do
-      assert Cell.enabled?
-      assert_not Cell.processing_attachments?
+  test "no root moves no work" do
+    with_env "HOTCELL_ROOT" => nil do
+      assert_not Cell.enabled?
       assert_empty Cell.active_storage_configuration
     end
   end
 
-  test "the work switch does nothing without a root" do
-    with_env "HOTCELL_ROOT" => nil, "HOTCELL_ACTIVE_STORAGE" => "all" do
-      assert_not Cell.processing_attachments?
-      assert_empty Cell.active_storage_configuration
-    end
-  end
-
-  test "images moves the transformer and the image analyzer together" do
-    configuration = configuration_for "images"
+  test "a root moves every operation to the cell" do
+    configuration = with_env("HOTCELL_ROOT" => "tmp/hotcell") { Cell.active_storage_configuration }
 
     assert_equal ActiveStorage::HotCell::Client::Transformers::Image::Vips, configuration[:variant_processor]
-    assert_equal [ ActiveStorage::HotCell::Client::Analyzers::Image::Vips ],
-      configuration[:analyzers].grep(hotcell_classes)
-  end
-
-  test "a group that has not moved keeps Rails' own classes" do
-    configuration = configuration_for "images"
-
-    assert_equal [ ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ],
-      configuration[:analyzers] - configuration[:analyzers].grep(hotcell_classes)
-    assert_equal [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer,
-                   ActiveStorage::Previewer::VideoPreviewer ], configuration[:previewers]
-  end
-
-  test "pdfs moves the PDF previewer and leaves Rails' video previewer behind it" do
-    configuration = configuration_for "images,pdfs"
-
-    assert_equal [ ActiveStorage::HotCell::Client::Previewers::Pdf::Mutool,
-                   ActiveStorage::Previewer::VideoPreviewer ], configuration[:previewers]
-  end
-
-  test "all moves every operation" do
-    configuration = configuration_for "all"
-
     assert_empty configuration[:analyzers] - configuration[:analyzers].grep(hotcell_classes)
     assert_empty configuration[:previewers] - configuration[:previewers].grep(hotcell_classes)
-  end
-
-  test "an unknown group raises rather than meaning off" do
-    error = assert_raises(ArgumentError) { configuration_for "imgaes" }
-
-    assert_match "imgaes", error.message
   end
 
   test "the transient class does not descend from the permanent one" do
@@ -151,12 +113,6 @@ class Fizzy::Saas::CellTest < ActiveSupport::TestCase
           output.write File.read(input.path)
           { bytes: 7, staged: true }
         end
-      end
-    end
-
-    def configuration_for(groups)
-      with_env "HOTCELL_ROOT" => "tmp/hotcell", "HOTCELL_ACTIVE_STORAGE" => groups do
-        Cell.active_storage_configuration
       end
     end
 

--- a/saas/test/lib/hotcell_accessory_test.rb
+++ b/saas/test/lib/hotcell_accessory_test.rb
@@ -2,19 +2,12 @@ require "test_helper"
 require "erb"
 require "kamal"
 
-# Every one of these flags is what makes a cell a cell. Omit one and the protection is gone while the
-# cell goes on serving requests exactly as before, so nothing else would notice.
-#
-# Asserted against the `docker run` Kamal generates rather than against the YAML this repository wrote,
-# because the two are not the same document. Kamal contributes flags of its own, so a setting can be
-# present in the file and reach the daemon twice — which is a `docker: conflicting options` and a cell that
-# never starts, from a file that reads correctly.
-#
-# Every destination, because a destination file is deep-merged into the base and arrays are replaced rather
-# than merged.
+# Asserted against the `docker run` Kamal generates rather than the YAML, because Kamal contributes flags
+# of its own — a setting can be present in the file and reach the daemon twice, which is a
+# `docker: conflicting options` from a file that reads correctly. Every destination, because destination
+# files deep-merge into the base and arrays are replaced rather than merged.
 class HotcellAccessoryTest < ActiveSupport::TestCase
-  # Derived rather than listed, so a destination added later is covered the day it lands. `beta` is the
-  # shared template the numbered betas render, and it raises without BETA_NUMBER rather than deploying.
+  # `beta` is the shared template the numbered betas render; it raises without BETA_NUMBER.
   DESTINATIONS = Dir[Rails.root.join("saas/config/deploy.*.yml")]
     .map { File.basename(it, ".yml").delete_prefix("deploy.") } - %w[ beta ]
 
@@ -35,9 +28,8 @@ class HotcellAccessoryTest < ActiveSupport::TestCase
     end
   end
 
-  # The size cap and the nosuid,nodev,noexec flags ride the host mount, where this suite cannot see
-  # them — app_kamal's chef recipe owns those. From here we can only hold the mount itself: scratch is
-  # the provisioned filesystem and no tmpfs competes for /tmp.
+  # The size cap and the nosuid,nodev,noexec flags ride the host mount, which app_kamal's chef recipe
+  # owns; from here only the mount itself is visible.
   test "scratch is the provisioned loopback filesystem" do
     each_destination do |command|
       assert_match "--volume /var/lib/hotcell-scratch:/tmp", command
@@ -62,10 +54,8 @@ class HotcellAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "web", "jobs" ], accessory["roles"]
   end
 
-  # Three numbers in three places that must agree, and nothing else checks them. The cell's gid is what a
-  # descriptor's group is set to; the app must be in that group to set it, and must be told which group it
-  # is. Any one of them alone is a cell that answers echo and fails every operation that hands a tool a
-  # filename.
+  # Three numbers in three places that must agree, and nothing else checks them. Any one alone is a cell
+  # that answers echo and fails every operation that hands a tool a filename.
   test "the app shares the cell's group, and is told the same number" do
     DESTINATIONS.each do |destination|
       cell_gid = flag(run_command(destination), "--user")[/:(\d+)\z/, 1]
@@ -83,10 +73,8 @@ class HotcellAccessoryTest < ActiveSupport::TestCase
     assert_no_match(/:latest$/, accessory["image"])
   end
 
-  # A deploy never touches an accessory, so a pin left behind runs the old cell against the new app until
-  # somebody reboots it by hand — a client and server revision apart, which is a `protocol` failure on
-  # every request. The tag is a hash of exactly what the image is built from, so the two can only agree if
-  # the pin moved with the contents. Nothing else notices; this shipped once already.
+  # The tag is a hash of exactly what the image is built from, so the two can only agree if the pin moved
+  # with the contents. Nothing else notices a stale pin; this shipped once already.
   test "the pinned image is the one this tree builds" do
     built = `bash -c "source #{Rails.root}/saas/hotcell/bin/image && hotcell_image_tag #{Rails.root}"`.strip.split(":").last
 

--- a/saas/test/lib/hotcell_accessory_test.rb
+++ b/saas/test/lib/hotcell_accessory_test.rb
@@ -1,0 +1,160 @@
+require "test_helper"
+require "erb"
+require "kamal"
+
+# Every one of these flags is what makes a cell a cell. Omit one and the protection is gone while the
+# cell goes on serving requests exactly as before, so nothing else would notice.
+#
+# Asserted against the `docker run` Kamal generates rather than against the YAML this repository wrote,
+# because the two are not the same document. Kamal contributes flags of its own, so a setting can be
+# present in the file and reach the daemon twice — which is a `docker: conflicting options` and a cell that
+# never starts, from a file that reads correctly.
+#
+# Every destination, because a destination file is deep-merged into the base and arrays are replaced rather
+# than merged.
+class HotcellAccessoryTest < ActiveSupport::TestCase
+  # Derived rather than listed, so a destination added later is covered the day it lands. `beta` is the
+  # shared template the numbered betas render, and it raises without BETA_NUMBER rather than deploying.
+  DESTINATIONS = Dir[Rails.root.join("saas/config/deploy.*.yml")]
+    .map { File.basename(it, ".yml").delete_prefix("deploy.") } - %w[ beta ]
+
+  test "the cell has exactly one network, and it is none" do
+    each_destination do |command|
+      assert_equal 1, command.scan(/--network\b/).size, "Kamal supplies one of its own"
+      assert_match(/--network "?none"?/, command)
+    end
+  end
+
+  test "the cell has no capabilities and a read-only root" do
+    each_destination do |command|
+      assert_match "--read-only", command
+      assert_equal "ALL", flag(command, "--cap-drop")
+      assert_equal "no-new-privileges:true", flag(command, "--security-opt")
+      assert_equal "10001:10001", flag(command, "--user")
+      assert_equal "512", flag(command, "--pids-limit")
+    end
+  end
+
+  # The size cap and the nosuid,nodev,noexec flags ride the host mount, where this suite cannot see
+  # them — app_kamal's chef recipe owns those. From here we can only hold the mount itself: scratch is
+  # the provisioned filesystem and no tmpfs competes for /tmp.
+  test "scratch is the provisioned loopback filesystem" do
+    each_destination do |command|
+      assert_match "--volume /var/lib/hotcell-scratch:/tmp", command
+      assert_no_match(/--tmpfs/, command)
+    end
+  end
+
+  test "memory-swap matches memory, or the memory limit stops holding" do
+    each_destination do |command|
+      assert_equal flag(command, "--memory"), flag(command, "--memory-swap")
+    end
+  end
+
+  # Scratch no longer lives in the cgroup, so memory holds only processes.
+  test "the cgroup stays above the cell's own rlimit, so a breach is a verdict rather than a SIGKILL" do
+    each_destination do |command|
+      assert_operator megabytes(flag(command, "--memory")), :>, cell_memory_megabytes
+    end
+  end
+
+  test "the cell lands on the hosts that call it" do
+    assert_equal [ "web", "jobs" ], accessory["roles"]
+  end
+
+  # Three numbers in three places that must agree, and nothing else checks them. The cell's gid is what a
+  # descriptor's group is set to; the app must be in that group to set it, and must be told which group it
+  # is. Any one of them alone is a cell that answers echo and fails every operation that hands a tool a
+  # filename.
+  test "the app shares the cell's group, and is told the same number" do
+    DESTINATIONS.each do |destination|
+      cell_gid = flag(run_command(destination), "--user")[/:(\d+)\z/, 1]
+
+      configuration(destination).roles.each do |role|
+        assert_equal cell_gid, role.option_args.join(" ")[/--group-add "(\d+)"/, 1],
+          "#{destination} #{role.name} group-add"
+        assert_equal cell_gid, role.env(role.hosts.first).clear["HOTCELL_GROUP"].to_s,
+          "#{destination} #{role.name} HOTCELL_GROUP"
+      end
+    end
+  end
+
+  test "the image tag is immutable" do
+    assert_no_match(/:latest$/, accessory["image"])
+  end
+
+  # A deploy never touches an accessory, so a pin left behind runs the old cell against the new app until
+  # somebody reboots it by hand — a client and server revision apart, which is a `protocol` failure on
+  # every request. The tag is a hash of exactly what the image is built from, so the two can only agree if
+  # the pin moved with the contents. Nothing else notices; this shipped once already.
+  test "the pinned image is the one this tree builds" do
+    built = `bash -c "source #{Rails.root}/saas/hotcell/bin/image && hotcell_image_tag #{Rails.root}"`.strip.split(":").last
+
+    assert_equal built, accessory["image"][/:([^:]+)\z/, 1],
+      "saas/hotcell's contents changed since the accessory was pinned — run saas/hotcell/bin/build and re-pin"
+  end
+
+  test "the app mounts the same volume the cell writes its sockets to" do
+    app_mount = deploy_configuration["volumes"].find { it.start_with?("#{socket_volume}:") }
+
+    assert_equal "#{socket_volume}:/run/hotcell/#{Fizzy::Saas::Cell::NAME}", app_mount
+    assert_equal "/run/hotcell", deploy_configuration.dig("env", "clear", "HOTCELL_ROOT")
+  end
+
+  test "the app image creates the mount point owned by the cell's user" do
+    assert_match %r{mkdir -p /run/hotcell/#{Fizzy::Saas::Cell::NAME}.*chown -R 10001:10001 /run/hotcell}m,
+      Rails.root.join("saas/Dockerfile").read
+  end
+
+  private
+    def each_destination
+      DESTINATIONS.each do |destination|
+        yield run_command(destination)
+      rescue Minitest::Assertion => error
+        raise error.class, "#{destination}: #{error.message}"
+      end
+    end
+
+    def run_command(destination)
+      Kamal::Commands::Accessory.new(configuration(destination), name: :hotcell).run.flatten.join(" ")
+    end
+
+    def configuration(destination)
+      @configurations ||= {}
+      @configurations[destination] ||= Kamal::Configuration.create_from(
+        config_file: Rails.root.join("saas/config/deploy.yml"), destination: destination, version: "test")
+    end
+
+    # Kamal quotes what it argumentizes, so a flag's value ends at the closing quote.
+    def flag(command, name)
+      command[/#{Regexp.escape(name)} "([^"]+)"/, 1]
+    end
+
+    def deploy_configuration
+      @deploy_configuration ||= YAML.load(ERB.new(Rails.root.join("saas/config/deploy.yml").read).result)
+    end
+
+    def accessory
+      deploy_configuration.dig("accessories", "hotcell")
+    end
+
+    def socket_volume
+      accessory["volumes"].first.split(":").first
+    end
+
+    def cell_configuration
+      @cell_configuration ||= Rails.root.join("saas/hotcell/config.rb").read
+    end
+
+    def cell_memory_megabytes
+      cell_configuration[/memory:\s*(\d+) \* 1024\*\*2/, 1].to_i
+    end
+
+    def megabytes(size)
+      case size
+      when /\A(\d+)g\z/i then $1.to_i * 1024
+      when /\A(\d+)m\z/i then $1.to_i
+      else raise ArgumentError, "cannot read #{size.inspect} as a size"
+      end
+    end
+end

--- a/saas/test/lib/hotcell_lockfiles_test.rb
+++ b/saas/test/lib/hotcell_lockfiles_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "bundler"
+
+# The app and the cell resolve hotcell separately. A skew between the client the app loads and the
+# server the cell runs is a `protocol` failure at runtime, on every request. hotcell-core is the anchor
+# because both sides depend on it with an exact constraint.
+class HotcellLockfilesTest < ActiveSupport::TestCase
+  test "the app's lockfile and the cell's name the same hotcell version" do
+    assert_equal hotcell_version("Gemfile.saas.lock"), hotcell_version("saas/hotcell/Gemfile.lock")
+  end
+
+  test "neither lockfile resolves hotcell from a git source" do
+    %w[ Gemfile.saas.lock saas/hotcell/Gemfile.lock ].each do |lockfile|
+      source = parsed(lockfile).sources.find { it.to_s.include?("hotcell") }
+
+      assert_nil source, "#{lockfile} still resolves hotcell from #{source}"
+    end
+  end
+
+  private
+    def parsed(lockfile)
+      Bundler::LockfileParser.new(Rails.root.join(lockfile).read)
+    end
+
+    def hotcell_version(lockfile)
+      spec = parsed(lockfile).specs.find { it.name == "hotcell-core" }
+
+      assert_not_nil spec, "#{lockfile} names no hotcell-core"
+      spec.version
+    end
+end

--- a/saas/test/lib/yabeda/hot_cell_test.rb
+++ b/saas/test/lib/yabeda/hot_cell_test.rb
@@ -1,0 +1,179 @@
+require "test_helper"
+require "yabeda/testing"
+
+# Asserting values rather than that the block ran, because both of this file's namespace traps are silent:
+# a bare `Rails` raises inside the rescue, and a bare `hotcell` records nothing. assert_nothing_raised
+# would pass against either.
+class Yabeda::HotCellTest < ActiveSupport::TestCase
+  COUNTERS = { uptime_s: 41, running: 2, queued: 3, queue_high_water: 7, cancelled: 1,
+               requests: {}, killed_by: { memory: 5, deadline: 2 } }
+
+  setup do
+    Yabeda::TestAdapter.instance.reset!
+    @log = StringIO.new
+    Rails.logger.broadcast_to ActiveSupport::Logger.new(@log)
+  end
+
+  teardown { Fizzy::Saas::Cell.register! }
+
+  test "publishes the cell's counters" do
+    stub_cell_metrics COUNTERS
+
+    Yabeda::HotCell.collect_stats
+
+    assert_equal 1, gauge(:up)
+    assert_equal 2, gauge(:running)
+    assert_equal 3, gauge(:queued)
+    assert_equal 7, gauge(:queue_high_water)
+    assert_equal 1, gauge(:cancelled)
+    assert_equal 41, gauge(:uptime_seconds)
+  end
+
+  test "publishes kills by cause" do
+    stub_cell_metrics COUNTERS
+
+    Yabeda::HotCell.collect_stats
+
+    assert_equal 5, gauge(:killed, cause: :memory)
+    assert_equal 2, gauge(:killed, cause: :deadline)
+  end
+
+  test "a cell that does not answer is down rather than missing" do
+    cell = registered_cell
+    cell.stubs(:enabled?).returns(true)
+    cell.stubs(:metrics).returns(nil)
+
+    Yabeda::HotCell.collect_stats
+
+    assert_equal 0, gauge(:up)
+    assert_nil gauge(:running)
+  end
+
+  test "an unregistered cell publishes nothing rather than raising" do
+    registered_cell.stubs(:enabled?).returns(false)
+
+    Yabeda::HotCell.collect_stats
+
+    assert_nil gauge(:up)
+  end
+
+  test "a scrape does not fail because a cell is misbehaving" do
+    registered_cell.stubs(:enabled?).raises(StandardError.new("boom"))
+
+    assert_nothing_raised { Yabeda::HotCell.collect_stats }
+  end
+
+  test "counts a successful call as ok and measures what the cell spent" do
+    Yabeda::HotCell.record_perform perform_event(perform_ms: 250)
+
+    assert_equal 1, counter(:requests, code: "ok", cause: "")
+    assert_equal 0.25, histogram(:perform)
+  end
+
+  test "counts a failure under its own code" do
+    Yabeda::HotCell.record_perform perform_event(code: "capacity")
+
+    assert_equal 1, counter(:requests, code: "capacity", cause: "")
+  end
+
+  # `killed` is one code and several verdicts: which limit the worker hit decides whether the file did it.
+  # The counter carries the cause so a graph can stack kills by it, and every other code carries an empty
+  # one — a label that is sometimes absent is a separate series in Prometheus, not the same one.
+  test "counts a kill under its cause" do
+    Yabeda::HotCell.record_perform perform_event(code: "killed", cause: "fsize")
+
+    assert_equal 1, counter(:requests, code: "killed", cause: "fsize")
+  end
+
+  # The histogram says how long transforms take on a host; it cannot say what one upload paid. That is
+  # what a request's own log line is for, and it must carry both the cell's time and the caller's, because
+  # their difference is the queue and the socket — the number that says whether the cell or the plumbing
+  # was slow.
+  test "logs what each call cost" do
+    Yabeda::HotCell.record_perform perform_event(perform_ms: 250, duration_ms: 310, bytes_in: 4096, bytes_out: 512)
+
+    assert_match(/^  HotCell \(310\.0ms\) \{/, @log.string)
+    assert_equal "active_storage.transformers.image.vips", logged["operation"]
+    assert_equal "ok", logged["code"]
+    assert_equal 250, logged["perform_ms"]
+    assert_equal 310, logged["duration_ms"]
+    assert_equal 4096, logged["bytes_in"]
+    assert_equal 512, logged["bytes_out"]
+  end
+
+  test "logs a failure under its own code" do
+    Yabeda::HotCell.record_perform perform_event(code: "capacity")
+
+    assert_equal "capacity", logged["code"]
+  end
+
+  # `killed` alone says a worker died; the cause says whether the file did it. Both travel on the event.
+  test "logs why a worker was killed" do
+    Yabeda::HotCell.record_perform perform_event(code: "killed", cause: "fsize")
+
+    assert_equal "killed", logged["code"]
+    assert_equal "fsize", logged["cause"]
+  end
+
+  # The raise the caller sees already reaches Sentry with the right class. A report from here was a second
+  # copy of the same event under a second name — and a wrong one, because the payload carries `code` and
+  # not `cause`, so `killed` could not be told permanent from transient and every kill was filed as the
+  # transient class at warning.
+  test "does not report a failure to Sentry, because the raise already does" do
+    Rails.error.expects(:report).never
+
+    Yabeda::HotCell.record_perform perform_event(code: "killed", cause: "fsize")
+    Yabeda::HotCell.record_perform perform_event(code: "capacity")
+    Yabeda::HotCell.record_perform perform_event(code: "unreadable")
+  end
+
+  test "a metrics bug arrives as missing metrics rather than as a failed conversion" do
+    Yabeda.stubs(:hotcell).raises(StandardError.new("boom"))
+
+    assert_nothing_raised do
+      ActiveSupport::Notifications.instrument("perform.hot_cell") { }
+    end
+  end
+
+  private
+    def registered_cell
+      HotCell.cell Fizzy::Saas::Cell::NAME
+    end
+
+    def stub_cell_metrics(counters)
+      cell = registered_cell
+      cell.stubs(:enabled?).returns(true)
+      cell.stubs(:metrics).returns(stub(ok?: true, result: counters))
+    end
+
+    # `duration_ms` is what the caller waited, which the event measures itself; the payload only carries
+    # what the cell reported. Faking it takes the same start/finish the real event has.
+    def perform_event(code: nil, perform_ms: 0, cause: nil, duration_ms: 0, bytes_in: nil, bytes_out: nil)
+      start = Time.now
+      ActiveSupport::Notifications::Event.new("perform.hot_cell", start, start + duration_ms / 1000.0, nil,
+        { cell: Fizzy::Saas::Cell::NAME, operation: "active_storage.transformers.image.vips",
+          code: code, cause: cause, perform_ms: perform_ms, bytes_in: bytes_in, bytes_out: bytes_out })
+    end
+
+    # The line reads like Active Storage's own — `Storage (211.3ms) Downloaded file...` — with the duration
+    # up front where the eye expects it, and the detail as JSON after.
+    def logged
+      JSON.parse @log.string[/^  HotCell \([\d.]+ms\) (\{.*\})$/, 1]
+    end
+
+    def gauge(metric, **tags)
+      Yabeda::TestAdapter.instance.gauges[Yabeda.hotcell.public_send(metric)][tags.merge(cell: Fizzy::Saas::Cell::NAME)]
+    end
+
+    def counter(metric, **tags)
+      Yabeda::TestAdapter.instance.counters[Yabeda.hotcell.public_send(metric)][default_labels.merge(tags)]
+    end
+
+    def histogram(metric)
+      Yabeda::TestAdapter.instance.histograms[Yabeda.hotcell.public_send(metric)][default_labels]
+    end
+
+    def default_labels
+      { cell: Fizzy::Saas::Cell::NAME, operation: "active_storage.transformers.image.vips" }
+    end
+end

--- a/saas/test/lib/yabeda/hot_cell_test.rb
+++ b/saas/test/lib/yabeda/hot_cell_test.rb
@@ -76,19 +76,12 @@ class Yabeda::HotCellTest < ActiveSupport::TestCase
     assert_equal 1, counter(:requests, code: "capacity", cause: "")
   end
 
-  # `killed` is one code and several verdicts: which limit the worker hit decides whether the file did it.
-  # The counter carries the cause so a graph can stack kills by it, and every other code carries an empty
-  # one — a label that is sometimes absent is a separate series in Prometheus, not the same one.
   test "counts a kill under its cause" do
     Yabeda::HotCell.record_perform perform_event(code: "killed", cause: "fsize")
 
     assert_equal 1, counter(:requests, code: "killed", cause: "fsize")
   end
 
-  # The histogram says how long transforms take on a host; it cannot say what one upload paid. That is
-  # what a request's own log line is for, and it must carry both the cell's time and the caller's, because
-  # their difference is the queue and the socket — the number that says whether the cell or the plumbing
-  # was slow.
   test "logs what each call cost" do
     Yabeda::HotCell.record_perform perform_event(perform_ms: 250, duration_ms: 310, bytes_in: 4096, bytes_out: 512)
 
@@ -107,7 +100,6 @@ class Yabeda::HotCellTest < ActiveSupport::TestCase
     assert_equal "capacity", logged["code"]
   end
 
-  # `killed` alone says a worker died; the cause says whether the file did it. Both travel on the event.
   test "logs why a worker was killed" do
     Yabeda::HotCell.record_perform perform_event(code: "killed", cause: "fsize")
 
@@ -115,10 +107,6 @@ class Yabeda::HotCellTest < ActiveSupport::TestCase
     assert_equal "fsize", logged["cause"]
   end
 
-  # The raise the caller sees already reaches Sentry with the right class. A report from here was a second
-  # copy of the same event under a second name — and a wrong one, because the payload carries `code` and
-  # not `cause`, so `killed` could not be told permanent from transient and every kill was filed as the
-  # transient class at warning.
   test "does not report a failure to Sentry, because the raise already does" do
     Rails.error.expects(:report).never
 
@@ -146,8 +134,8 @@ class Yabeda::HotCellTest < ActiveSupport::TestCase
       cell.stubs(:metrics).returns(stub(ok?: true, result: counters))
     end
 
-    # `duration_ms` is what the caller waited, which the event measures itself; the payload only carries
-    # what the cell reported. Faking it takes the same start/finish the real event has.
+    # duration_ms is measured by the event itself, not carried in the payload, so faking it takes the
+    # same start/finish the real event has.
     def perform_event(code: nil, perform_ms: 0, cause: nil, duration_ms: 0, bytes_in: nil, bytes_out: nil)
       start = Time.now
       ActiveSupport::Notifications::Event.new("perform.hot_cell", start, start + duration_ms / 1000.0, nil,
@@ -155,8 +143,6 @@ class Yabeda::HotCellTest < ActiveSupport::TestCase
           code: code, cause: cause, perform_ms: perform_ms, bytes_in: bytes_in, bytes_out: bytes_out })
     end
 
-    # The line reads like Active Storage's own — `Storage (211.3ms) Downloaded file...` — with the duration
-    # up front where the eye expects it, and the detail as JSON after.
     def logged
       JSON.parse @log.string[/^  HotCell \([\d.]+ms\) (\{.*\})$/, 1]
     end

--- a/saas/test/models/unprocessable_attachment_test.rb
+++ b/saas/test/models/unprocessable_attachment_test.rb
@@ -1,8 +1,5 @@
 require "test_helper"
 
-# A permanent verdict from the cell is a fact about one variant of one blob. It must not fail the save of
-# the record that attached the file: `process: :immediately` transforms inline inside the record's
-# after_commit, so the record is already committed by then, and a raise there 500s a POST that succeeded.
 class Fizzy::Saas::UnprocessableAttachmentTest < ActiveSupport::TestCase
   setup { Current.session = sessions(:david) }
 
@@ -16,9 +13,6 @@ class Fizzy::Saas::UnprocessableAttachmentTest < ActiveSupport::TestCase
     assert_equal 1, comment.body.embeds.count
   end
 
-  # A form upload takes a different path from an embed: Rails transforms the immediate variants straight
-  # from the uploaded io, before the blob is stored, and no job is involved. Left alone the save raised, the
-  # attachment row existed, and the file was never uploaded.
   test "an avatar uploads when its variant cannot be made" do
     transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
     user = users(:david)
@@ -29,8 +23,6 @@ class Fizzy::Saas::UnprocessableAttachmentTest < ActiveSupport::TestCase
     assert blob.service.exist?(blob.key), "the original must still be uploaded"
   end
 
-  # One variant failing says nothing about the others: a large animated GIF can outgrow the cell's output
-  # limit at 1024×768 and fit at 800×600. Every variant gets its own attempt.
   test "the remaining variants are still attempted after one cannot be made" do
     attempted = []
     ActiveStorage::Variation.any_instance.stubs(:transform).with do |*|
@@ -43,9 +35,7 @@ class Fizzy::Saas::UnprocessableAttachmentTest < ActiveSupport::TestCase
     assert_equal Attachments::VARIANTS.size, attempted.size
   end
 
-  # The form path runs its own loop over the variants, and the rescue has to sit inside it: around it, the
-  # first failure would skip the rest and leave the variants unmarked as processed, so Rails would run every
-  # one again as a job after commit. This holds a copy of a private Rails method to its reason for existing.
+  # Holds a copy of a private Rails method to its reason for existing.
   test "the form path still attempts every immediate variant, and does not enqueue them again" do
     attempted = []
     ActiveStorage::Variation.any_instance.stubs(:transform).with do |*|
@@ -61,17 +51,12 @@ class Fizzy::Saas::UnprocessableAttachmentTest < ActiveSupport::TestCase
     assert_equal 1, attempted.size, "the avatar declares one immediate variant"
   end
 
-  # A cell that is saturated or restarting says nothing about the file. The client gem retries the transient
-  # class on these jobs, and nothing here may get in the way of that.
   test "a transient failure is left to the retry" do
     transforms_raise Fizzy::Saas::Cell::ProcessingUnavailable.new("capacity")
 
     assert_nothing_raised { comment_with_embed }
   end
 
-  # Rescuing is where the raise stops, so it is the one place a permanent verdict has to be reported from —
-  # elsewhere the raise reaches Sentry on its own. Once per variant, not twice: the perform.hot_cell
-  # subscriber reports nothing.
   test "a permanent verdict on the job path is reported once" do
     transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
     Rails.error.expects(:report).with { |error, **| error.is_a?(Fizzy::Saas::Cell::UnprocessableAttachment) }

--- a/saas/test/models/unprocessable_attachment_test.rb
+++ b/saas/test/models/unprocessable_attachment_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+# A permanent verdict from the cell is a fact about one variant of one blob. It must not fail the save of
+# the record that attached the file: `process: :immediately` transforms inline inside the record's
+# after_commit, so the record is already committed by then, and a raise there 500s a POST that succeeded.
+class Fizzy::Saas::UnprocessableAttachmentTest < ActiveSupport::TestCase
+  setup { Current.session = sessions(:david) }
+
+  test "a comment posts when an embed's variant cannot be made" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
+
+    comment = nil
+    assert_nothing_raised { comment = comment_with_embed }
+
+    assert comment.persisted?
+    assert_equal 1, comment.body.embeds.count
+  end
+
+  # A form upload takes a different path from an embed: Rails transforms the immediate variants straight
+  # from the uploaded io, before the blob is stored, and no job is involved. Left alone the save raised, the
+  # attachment row existed, and the file was never uploaded.
+  test "an avatar uploads when its variant cannot be made" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
+    user = users(:david)
+
+    assert_nothing_raised { user.update!(avatar: Rack::Test::UploadedFile.new(file_fixture("moon.jpg"), "image/jpeg")) }
+
+    blob = user.reload.avatar.blob
+    assert blob.service.exist?(blob.key), "the original must still be uploaded"
+  end
+
+  # One variant failing says nothing about the others: a large animated GIF can outgrow the cell's output
+  # limit at 1024×768 and fit at 800×600. Every variant gets its own attempt.
+  test "the remaining variants are still attempted after one cannot be made" do
+    attempted = []
+    ActiveStorage::Variation.any_instance.stubs(:transform).with do |*|
+      attempted << true
+      true
+    end.raises(Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize"))
+
+    comment_with_embed
+
+    assert_equal Attachments::VARIANTS.size, attempted.size
+  end
+
+  # The form path runs its own loop over the variants, and the rescue has to sit inside it: around it, the
+  # first failure would skip the rest and leave the variants unmarked as processed, so Rails would run every
+  # one again as a job after commit. This holds a copy of a private Rails method to its reason for existing.
+  test "the form path still attempts every immediate variant, and does not enqueue them again" do
+    attempted = []
+    ActiveStorage::Variation.any_instance.stubs(:transform).with do |*|
+      attempted << true
+      true
+    end.raises(Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize"))
+    user = users(:david)
+
+    assert_no_enqueued_jobs(only: [ ActiveStorage::CreateVariantsJob, ActiveStorage::TransformJob ]) do
+      user.update!(avatar: Rack::Test::UploadedFile.new(file_fixture("moon.jpg"), "image/jpeg"))
+    end
+
+    assert_equal 1, attempted.size, "the avatar declares one immediate variant"
+  end
+
+  # A cell that is saturated or restarting says nothing about the file. The client gem retries the transient
+  # class on these jobs, and nothing here may get in the way of that.
+  test "a transient failure is left to the retry" do
+    transforms_raise Fizzy::Saas::Cell::ProcessingUnavailable.new("capacity")
+
+    assert_nothing_raised { comment_with_embed }
+  end
+
+  # Rescuing is where the raise stops, so it is the one place a permanent verdict has to be reported from —
+  # elsewhere the raise reaches Sentry on its own. Once per variant, not twice: the perform.hot_cell
+  # subscriber reports nothing.
+  test "a permanent verdict on the job path is reported once" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
+    Rails.error.expects(:report).with { |error, **| error.is_a?(Fizzy::Saas::Cell::UnprocessableAttachment) }
+      .times(Attachments::VARIANTS.size)
+
+    comment_with_embed
+  end
+
+  test "a permanent verdict on the form path is reported once" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
+    Rails.error.expects(:report).with { |error, **| error.is_a?(Fizzy::Saas::Cell::UnprocessableAttachment) }.once
+
+    users(:david).update!(avatar: Rack::Test::UploadedFile.new(file_fixture("moon.jpg"), "image/jpeg"))
+  end
+
+  private
+    def transforms_raise(error)
+      ActiveStorage::Variation.any_instance.stubs(:transform).raises(error)
+    end
+
+    def comment_with_embed
+      comment = cards(:logo).comments.create!(body: "Check this out")
+      comment.body.body.attachables
+
+      blob = ActiveStorage::Blob.create_and_upload!(io: File.open(file_fixture("moon.jpg")), filename: "moon.jpg",
+        content_type: "image/jpeg")
+
+      comment.body.body = ActionText::Content.new(comment.body.body.to_html).append_attachables(blob)
+      comment.save!
+      comment
+    end
+end

--- a/test/fixtures/setup_phases/saas-minio/commands.txt
+++ b/test/fixtures/setup_phases/saas-minio/commands.txt
@@ -4,6 +4,7 @@ bundle install
 docker-dev/setup minio
 minio-setup [SAAS=1 BUNDLE_GEMFILE=Gemfile.saas]
 docker-dev/setup mysql84
+bundle install
 rails db:prepare
 rails runner pp Account.all.any?
 rails log:clear tmp:clear

--- a/test/fixtures/setup_phases/saas-minio/output.txt
+++ b/test/fixtures/setup_phases/saas-minio/output.txt
@@ -37,6 +37,11 @@ bin/minio-setup
 ▸ Starting mysql
 $HOME/Work/basecamp/docker-dev/setup mysql84
 
+▸ Installing the cell's RubyGems
+env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE BUNDLE_GEMFILE=$APP/saas/hotcell/Gemfile bundle install
+
+▸ Skipping the cell's image (saas/hotcell/bin/build is not here)
+
 ▸ Preparing the database
 rails db:prepare
 

--- a/test/fixtures/setup_phases/saas-no-minio/commands.txt
+++ b/test/fixtures/setup_phases/saas-no-minio/commands.txt
@@ -2,6 +2,7 @@ brew bundle --file=$APP/Brewfile
 bundle config set --local auto_install true
 bundle install
 docker-dev/setup mysql84
+bundle install
 rails db:prepare
 rails runner pp Account.all.any?
 rails log:clear tmp:clear

--- a/test/fixtures/setup_phases/saas-no-minio/output.txt
+++ b/test/fixtures/setup_phases/saas-no-minio/output.txt
@@ -31,6 +31,11 @@ env MISE_ENV=saas mise bootstrap --only repos --yes
 ▸ Starting mysql
 $HOME/Work/basecamp/docker-dev/setup mysql84
 
+▸ Installing the cell's RubyGems
+env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE BUNDLE_GEMFILE=$APP/saas/hotcell/Gemfile bundle install
+
+▸ Skipping the cell's image (saas/hotcell/bin/build is not here)
+
 ▸ Preparing the database
 rails db:prepare
 


### PR DESCRIPTION
Move Active Storage's image, PDF, and video processing out of the app container and into a sidecar, so potential decoder bugs/vulnerabilities land in an unprivileged container with no network that holds nothing worth stealing.

What a cell is and how it works: https://github.com/basecamp/hotcell (Note: hotcell is private for now, hopefully will be publicly released soon as open source.)

This is saas-only for the time being. Once it's been open-sourced and has been burned in a bit, we'll figure out how to work this into the open-source ONCE-deployed or kamal-deployed apps.

## Observability

- active monitoring
  - public hotcell status, `/hotcellz`, returns just an "OK" and a status code
  - staff-only hotcell details, `/hotcellz/test` which also does two round-trip requests with files through the cell, and returns full metrics
- Yabeda metrics are recorded on each request, and in a periodic collector. 
- Log line is emitted after each cell request with request metrics
- Sentry errors are reported for failed cell calls

## Other changes

The Rails bump is a prerequisite rather than housekeeping: `config.active_storage.variant_processor` only began accepting a transformer class in rails/rails#58384.
