### PR TITLE
Fix store_accessor on MariaDB by declaring the JSON attribute type

### DIFF
--- a/app/models/event/particulars.rb
+++ b/app/models/event/particulars.rb
@@ -2,6 +2,9 @@ module Event::Particulars
   extend ActiveSupport::Concern
 
   included do
+    # MariaDB reports JSON columns as LONGTEXT, so declare the type store_accessor needs.
+    attribute :particulars, :json
+
     store_accessor :particulars, :assignee_ids
   end
 

--- a/app/models/filter/fields.rb
+++ b/app/models/filter/fields.rb
@@ -30,6 +30,9 @@ module Filter::Fields
   end
 
   included do
+    # MariaDB reports JSON columns as LONGTEXT, so declare the type store_accessor needs.
+    attribute :fields, :json
+
     store_accessor :fields, :assignment_status, :indexed_by, :sorted_by, :terms,
       :card_ids, :creation, :closure, :column_ids
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -50,4 +50,21 @@ class EventTest < ActiveSupport::TestCase
     assert_equal({ "old_title" => "", "new_title" => "" }, title_event.api_particulars)
     assert_equal({ "column" => "" }, triage_event.api_particulars)
   end
+
+  test "particulars is a JSON attribute however the adapter reports the column" do
+    assert_instance_of ActiveRecord::Type::Json, Event.type_for_attribute(:particulars)
+  end
+
+  test "store accessors round-trip through the database" do
+    event = boards(:writebook).events.create!(
+      action: "card_assigned",
+      creator: users(:david),
+      eventable: cards(:logo),
+      account: accounts("37s"),
+      assignee_ids: [ users(:jz).id ]
+    )
+
+    assert_equal({ "assignee_ids" => [ users(:jz).id ] }, event.reload.particulars)
+    assert_equal [ users(:jz) ], event.assignees.to_a
+  end
 end

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -203,4 +203,16 @@ class FilterTest < ActiveSupport::TestCase
     assert_not_includes filter.board_titles, "Writebook"
     assert_not_includes filter.board_titles, "Private board"
   end
+
+  test "fields is a JSON attribute however the adapter reports the column" do
+    assert_instance_of ActiveRecord::Type::Json, Filter.type_for_attribute(:fields)
+  end
+
+  test "store accessors round-trip through the database" do
+    filter = users(:david).filters.create! indexed_by: "closed", terms: [ "haggis" ]
+
+    assert_equal({ "indexed_by" => "closed", "terms" => [ "haggis" ] }, filter.reload.fields)
+    assert_equal "closed", filter.indexed_by
+    assert_equal [ "haggis" ], filter.terms
+  end
 end


### PR DESCRIPTION
Fixes #2402.

MariaDB implements `JSON` as an alias for `LONGTEXT` with a `CHECK (json_valid(...))` constraint, so ActiveRecord introspects `filters.fields` and `events.particulars` as `Type::Text`. `store_accessor` rejects that type and `Filter.from_params` raises `ActiveRecord::ConfigurationError` on every request.

Verified against MariaDB 11.8.8, where the column comes back as:

```
`fields` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
  DEFAULT json_object() CHECK (json_valid(`fields`))
```

Declaring `attribute :fields, :json` overrides the introspected type on MariaDB and is a no-op on MySQL and SQLite, where the column already resolves to `Type::Json`. Unlike `store ..., coder: JSON` it adds no `Type::Serialized` layer and keeps `StringKeyedHashAccessor`, so the existing string-keyed hash semantics are unchanged.

These are the only two JSON columns in the schema. The other serialized columns (`webhooks.subscribed_actions`, `webhook_deliveries.request`/`response`, `passkeys.transports`) are text columns with explicit coders and resolve to `Type::Serialized` on every adapter, so they are unaffected.

### Why this does not also quote the fixtures

#2769 fixes the same bug with the same `attribute` declaration, but it additionally quotes the JSON fixture values. That part is a silent data-loss regression on MySQL and SQLite, so this PR leaves fixtures untouched.

`build_fixture_sql` serializes through the **database column type**, not the model's declared attribute type, so `attribute :fields, :json` never reaches fixtures at all:

```
fixture value as YAML Hash (current main, unquoted):
  Type::Json (MySQL/SQLite) -> "{\"assignee_ids\":[\"abc\"]}"        correct
  Type::Text (MariaDB)      -> {"assignee_ids" => ["abc"]}           violates json_valid

fixture value as YAML String (quoted, per #2769):
  Type::Json (MySQL/SQLite) -> "\"{\\\"assignee_ids\\\":[\\\"abc\\\"]}\""   double encoded
  Type::Text (MariaDB)      -> "{\"assignee_ids\":[\"abc\"]}"                correct
```

The double-encoded value deserializes back to a `String` rather than a `Hash`, so the store accessors find no keys and the data quietly disappears. On SQLite with #2769's quoting applied, `bin/rails test test/models/event/description_test.rb` gives 5 failures of the form:

```
Expected "David assigned  to ..." to include "Tom & Jerry"
```

Reverting only the quoting: 18 tests, 62 assertions, 0 failures.

Neither a YAML String nor a YAML Hash is correct on all three adapters, so there is no stock-Rails fixture value that works everywhere. That means this PR unblocks MariaDB at runtime but does not make the test suite runnable on MariaDB, and it deliberately does not add MariaDB to CI. Closing that gap needs either an upstream Rails change or an adapter-level patch mapping MariaDB's `json_valid` longtext columns to `Type::Json`, which seemed out of scope here.

### Testing

| Adapter | Result |
|---|---|
| SQLite 3.53.2 | full suite: 1553 tests, 5856 assertions, 0 failures |
| MySQL 8.4.11 (Trilogy) | full suite: 1553 tests, 5851 assertions, 0 failures |
| MariaDB 11.8.8 (Trilogy) | error reproduced pre-fix, confirmed fixed post-fix on the same connection |

Added four tests: a type assertion per model that fails on MariaDB before this change, and a create/reload round trip through the store accessors.

Not verified: `bin/rails test:system` on any adapter, and the full suite on MariaDB, which is blocked by the pre-existing fixture issue described above rather than by this change.
