### PR TITLE
Flush pending auto-saves before publishing a card

### DIFF
--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -5,6 +5,7 @@ const AUTOSAVE_INTERVAL = 3000
 
 export default class extends Controller {
   #timer
+  #saving
 
   // Lifecycle
 
@@ -16,8 +17,10 @@ export default class extends Controller {
 
   async submit() {
     if (this.#dirty) {
-      await this.#save()
+      this.#save()
     }
+
+    await this.#saving
   }
 
   change(event) {
@@ -32,9 +35,9 @@ export default class extends Controller {
     this.#timer = setTimeout(() => this.#save(), AUTOSAVE_INTERVAL)
   }
 
-  async #save() {
+  #save() {
     this.#resetTimer()
-    await submitForm(this.element)
+    this.#saving = submitForm(this.element)
   }
 
   #resetTimer() {

--- a/app/javascript/controllers/clicker_controller.js
+++ b/app/javascript/controllers/clicker_controller.js
@@ -3,8 +3,13 @@ import { nextFrame } from "helpers/timing_helpers";
 
 export default class extends Controller {
   static targets = [ "clickable" ]
+  static outlets = [ "auto-save" ]
 
   async click() {
+    if (this.hasAutoSaveOutlet) {
+      await this.autoSaveOutlet.submit()
+    }
+
     await nextFrame()
     this.#clickable.click()
   }

--- a/app/views/cards/container/footer/_create.html.erb
+++ b/app/views/cards/container/footer/_create.html.erb
@@ -3,13 +3,15 @@
     <%= button_to card_publish_path(card), name: "creation_type", value: "add", class: "btn",
           title: "Create card (#{ hotkey_label(["ctrl", "enter"]) })",
           form: { data: { controller: "form bridge--form" } },
-          data: { form_target: "submit", bridge__form_target: "submit", controller: "clicker", action: "keydown.ctrl+enter@document->clicker#click keydown.meta+enter@document->clicker#click" } do %>
+          data: { form_target: "submit", bridge__form_target: "submit", controller: "clicker", clicker_auto_save_outlet: "#card_form",
+                  action: "keydown.ctrl+enter@document->clicker#click keydown.meta+enter@document->clicker#click" } do %>
       <span>Create card</span>
     <% end %>
 
     <%= button_to card_publish_path(card), method: :post, class: "btn btn--reversed", name: "creation_type", value: "add_another",
           title: "Create and add another (#{ hotkey_label(["ctrl", "shift", "enter"]) })", form: { data: { controller: "form" } },
-          data: { form_target: "submit", controller: "clicker", action: "keydown.ctrl+shift+enter@document->clicker#click keydown.meta+shift+enter@document->clicker#click" } do %>
+          data: { form_target: "submit", controller: "clicker", clicker_auto_save_outlet: "#card_form",
+                  action: "keydown.ctrl+shift+enter@document->clicker#click keydown.meta+shift+enter@document->clicker#click" } do %>
       <span>Create and add another</span>
     <% end %>
   </div>

--- a/test/system/card_creation_test.rb
+++ b/test/system/card_creation_test.rb
@@ -1,0 +1,19 @@
+require "application_system_test_case"
+
+class CardCreationTest < ApplicationSystemTestCase
+  test "creating a card with the keyboard shortcut publishes the title typed last" do
+    sign_in_as(users(:david))
+
+    visit board_url(boards(:writebook))
+    click_on "Add a card"
+    fill_in "card_title", with: "Published with a shortcut"
+    find("#card_title").send_keys [ :control, :enter ]
+
+    assert_selector "h3", text: "Published with a shortcut"
+
+    card = boards(:writebook).cards.order(:created_at).last
+    assert_equal "Published with a shortcut", card.title
+    assert_empty card.events.where(action: "card_title_changed"),
+      "Publishing an untitled card and renaming it afterwards leaks a title change"
+  end
+end


### PR DESCRIPTION
Fixes #2778.

Creating a card with Cmd/Ctrl+Enter right after typing the title publishes it as "Untitled" on the board. Reloading shows the real title.

### Root cause

Two things combine.

The title textarea has `keydown.enter->auto-save#submit:prevent`, but Stimulus keyboard filters require an exact modifier match:

```js
keyFilterDissatisfied(e,t){const[s,r,n,i]=u.map((e=>t.includes(e)));return e.metaKey!==s||e.ctrlKey!==r||e.altKey!==n||e.shiftKey!==i}
```

So `keydown.enter` is skipped whenever meta or ctrl is held. No blur fires either, because focus stays in the textarea, and the 3s `AUTOSAVE_INTERVAL` timer has not elapsed yet.

Meanwhile `clicker#click` publishes immediately, and the publish `button_to` is a separate form that carries only `creation_type`. The title lives in `#card_form` and is never part of that request.

The title therefore only reaches the server from `auto_save_controller#disconnect`, which runs while Turbo is already swapping in the board page. The card is published with `title == nil`, `Card#set_default_title` writes "Untitled", and the board renders that. The late PATCH then renames the card, which also leaves debris: `Card::Eventable#track_title_change` records a `card_title_changed` event plus its system comment and webhook delivery.

### Fix

`clicker` awaits the auto-save controller through an outlet before clicking publish.

`auto_save_controller#submit` now resolves once any in-flight save has landed, not only one it started itself. Previously it returned immediately when `#dirty` was false, so if the 3s timer had already fired and a PATCH was in flight, an external "flush now" caller would not actually wait. Storing the promise in `#saving` unconditionally means `submit()` has one code path whether it just started a save, one was already running, or nothing ever ran, since `await undefined` resolves immediately.

### Relationship to #2812 and #2895

Same outlet wiring, which is the only place the two async handlers can be sequenced. Two deliberate differences:

- #2812 resets its saved promise in a `finally`. That is wrong when two saves overlap: the first save's `finally` nulls out the second save's promise, so a subsequent `submit()` returns without waiting. Storing `#saving` unconditionally with no reset avoids that.
- #2895's test aliases `CardsController#update` to insert a `sleep 0.5`. That is not needed. On main the PATCH is only sent from `disconnect()`, which by construction runs after the publish request, so the failure is already deterministic. Dropping the alias also avoids leaking a patched controller if teardown is skipped.

### Testing

New system test, written first and confirmed failing on unmodified code:

```
FAIL CardCreationTest#test_creating_a_card_with_the_keyboard_shortcut_publishes_the_title_typed_last
  expected to find css "h3" but there were no matches
```

The failure screenshot showed the board card titled "Untitled", confirming the mechanism rather than a selector problem. The test also asserts no `card_title_changed` event is left behind, which pins the phantom-event half of the bug.

After the fix:

```
bin/rails test test/system/card_creation_test.rb   1 test, 5 assertions, 0 failures
PARALLEL_WORKERS=1 bin/rails test:system           17 tests, 72 assertions, 0 failures
bin/rails test                                     1549 tests, 5849 assertions, 0 failures, 1 skip
```

### Known gaps

- Clicking "Create card" with the pointer still races. Blur starts the PATCH but does not block the click, so the same lost update is possible through a narrower window. Closing that properly means intercepting the publish form submission or sending the title with the publish request, which seemed beyond this issue.
- Overlapping saves still have no ordering guarantee. Serializing them looked like scope creep here.
- Only `ctrl+enter` is exercised. The `meta+enter` and `ctrl/meta+shift+enter` variants share identical wiring but have no coverage.
- The Hotwire Native bridge submit path was not tested, and only the SQLite/OSS half of the suite was run.
