### PR TITLE
dep: update sentry-ruby and sentry-rails to 6.7.0

### DIFF
--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -611,12 +611,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.2.0)
+    sentry-rails (6.7.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.2.0)
-    sentry-ruby (6.2.0)
+      sentry-ruby (~> 6.7.0)
+    sentry-ruby (6.7.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     signet (0.21.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -976,8 +977,8 @@ CHECKSUMS
   rubyzip (3.3.0) sha256=a372fc67892a4f8c0bc8ec906b720353d8e48807a64b2e63adf99b1e3583a034
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
-  sentry-rails (6.2.0) sha256=e1a1977e58099231774b85ca40ce9e1d185326cee814bed4f59bc3192f1f77e6
-  sentry-ruby (6.2.0) sha256=d7b8a358a3a0d0536bd194b19cc282c85f295b6d242731e9b4a934ccdb71ac17
+  sentry-rails (6.7.0) sha256=d295dc5aa239eb91d4fb123c55d9ff2d3c40e7c29921539c5b4ae684b1490293
+  sentry-ruby (6.7.0) sha256=b4b915d79a0395ad02106d4012aa1914641456e042ce36393f15bd1630d8db42
   signet (0.21.0) sha256=d617e9fbf24928280d39dcfefba9a0372d1c38187ffffd0a9283957a10a8cd5b
   sniffer (0.5.0) sha256=cd040cc51929c04749b20baa4dd8f5985174210e13437491f4923b8de27e1359
   solid_cable (4.0.0)

--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -92,7 +92,7 @@ module Fizzy
 
       # Rails edge (actioncable 647ce6769c, 2026-05-28) extracted WebSocket handling
       # into ActionCable::Server::Socket, which now calls connection.handle_open /
-      # handle_close *publicly*. sentry-rails (through 6.6.2 and master as of 2026-07)
+      # handle_close *publicly*. sentry-rails (through 6.7.0 and master as of 2026-08)
       # still prepends these onto ActionCable::Connection::Base as `private`, matching
       # the old internal calling convention, so the external call raises NoMethodError
       # and every WebSocket connection dies. Restore public visibility on Sentry's


### PR DESCRIPTION
Every error from the Rails error reporter reached Sentry badged
unhandled, whatever `handled:` said. `ErrorSubscriber#report` wrote the
flag into tags and then left `hint[:mechanism]` unset, so the client fell
back to a mechanism that contradicted it. Measured on both lockfiles,
6.2.0 reports `handled=false` for `handled: true`, `handled: false`, and
the Rails default alike, where 6.7.0 reports `true`, `false`, `true`.
Introduced in getsentry/sentry-ruby#2280, fixed in
getsentry/sentry-ruby#2892, first released in 6.5.0.

Two new upstream defaults come with the bump, both accepted. Solid Queue
payloads gain a `_sentry` trace-propagation key, written even though we
enable no tracing. And `ActionController::TooManyRequests` joins the
default `excluded_exceptions` on Rails >= 8.1.1, so rate-limit hits on
`Users::EmailAddressesController#create` and its confirmations stop
reaching Sentry.

Expect the crash-free rate to rise, since Sentry counts unhandled errors
as crashed sessions, and alerts keyed on `is:unhandled` to stop matching
these events.

ref: https://github.com/getsentry/sentry-ruby/pull/2892

