### PR TITLE
Block the libvips TIFF loader

### DIFF
--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -7,8 +7,10 @@ raise LoadError, "Please install libvips" unless defined?(Vips::LIBRARY_VERSION)
 ActiveStorage::Transformers::Vips
 Vips.block_untrusted(true)
 Vips.block("VipsForeignLoadOpenslide", true) # prevent sqlite segfault in forked parallel workers
+Vips.block("VipsForeignLoadTiff", true) # unused; list below only gates variants, not parsing
+
 Rails.application.config.active_storage.variable_content_types -=
-    %w[ image/bmp image/vnd.microsoft.icon image/vnd.adobe.photoshop ]
+    %w[ image/bmp image/tiff image/vnd.microsoft.icon image/vnd.adobe.photoshop ]
 
 # Limit libvips to 4 threads for each thread pool. Default is #CPUs.
 Vips.concurrency_set 4

--- a/test/lib/vips_loader_policy_test.rb
+++ b/test/lib/vips_loader_policy_test.rb
@@ -27,8 +27,12 @@ class VipsLoaderPolicyTest < ActiveSupport::TestCase
     assert_equal "VipsForeignLoadJpegFile", loader_for(encode("jpg"))
   end
 
-  test "loads TIFF" do
-    assert_equal "VipsForeignLoadTiffFile", loader_for(encode("tif"))
+  test "denies TIFF through tiffload" do
+    assert_nil loader_for(encode("tif"))
+  end
+
+  test "denies TIFF loader operations" do
+    assert_loader_blocked :tiffload, ".tif"
   end
 
   test "loads WebP" do


### PR DESCRIPTION
## Why

No fizzy surface accepts or advertises TIFF:

- Avatars enforce a server-side allowlist: `ALLOWED_AVATAR_CONTENT_TYPES = %w[ image/jpeg image/png image/gif image/webp ]` (`app/models/user/avatar.rb`).
- Card covers accept `image/png, image/jpeg, image/jpg, image/webp` (`app/views/cards/container/_image.html.erb`).
- No doc, fixture, UI copy, or API example mentions TIFF anywhere in the repo.

TIFF reached libvips only because `image/tiff` is in Rails' default `variable_content_types` and rich-text embed uploads are unrestricted — and a TIFF embed would be transcoded to PNG for display anyway, since `web_image_content_types` excludes it. That keeps a complex native parser exposed to untrusted bytes for zero product value. `tiffload` is a "trusted" loader upstream, so the existing `Vips.block_untrusted(true)` does not cover it.

## What

- `Vips.block("VipsForeignLoadTiff", true)` — blocks the whole loader family (file/buffer/source). This is the load-bearing control: ActiveStorage's image analyzer runs `Vips::Image.new_from_file` on **every** `image/*` upload regardless of `variable_content_types`, so the content-type edit alone would not stop parsing.
- `image/tiff` removed from `variable_content_types` — belt-and-braces, stops variant jobs from ever being enqueued for TIFFs, matching the existing bmp/ico/psd treatment.
- The `loads TIFF` characterization test flips to two denial assertions: `vips_foreign_find_load` finds no loader for real TIFF bytes, and `tiffload` raises `operation is blocked`.

Applies identically to the OSS and SaaS images at any libvips version — no package or infra dependency.

## Verification

`bin/rails test test/lib/vips_loader_policy_test.rb`: 18 tests, 30 assertions, 0 failures (1 pre-existing skip for a loader absent from the local libvips). The two new tests assert non-vacuously: the prior test proved `encode("tif")` produces bytes that selected `VipsForeignLoadTiffFile`; the same bytes now resolve to no loader.

## Noted, not addressed here

The SaaS image also installs `libreoffice-writer/impress/calc` and `groff`, which no code path or Rails previewer invokes (`mupdf-tools` and `ffmpeg` are live via ActiveStorage previewers/analyzers). Removing the unused ones is a separate cleanup.