### PR TITLE
dep: update lexxy to 0.9.31.beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "geared_pagination", "~> 1.2"
 gem "rqrcode"
 gem "rouge"
 gem "jbuilder"
-gem "lexxy", "0.9.23"
+gem "lexxy", "0.9.31.beta"
 gem "image_processing", "~> 1.14"
 gem "platform_agent"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,7 +278,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.9.23)
+    lexxy (0.9.31.beta)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -541,7 +541,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  lexxy (= 0.9.23)
+  lexxy (= 0.9.31.beta)
   minitest-reporters
   mission_control-jobs
   mittens
@@ -647,7 +647,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
-  lexxy (0.9.23) sha256=a2ba4bffb56d414cd9fd3f338cc6226c6d312821b0d9a64e2094c7a69d0555b3
+  lexxy (0.9.31.beta) sha256=97b1774d597b9b9e2e857e3d69318d4f6b1eac62cdccbe35b80d533771ac7c76
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -390,7 +390,7 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    lexxy (0.9.23)
+    lexxy (0.9.31.beta)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -747,7 +747,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  lexxy (= 0.9.23)
+  lexxy (= 0.9.31.beta)
   minitest-reporters
   mission_control-jobs
   mittens
@@ -884,7 +884,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
-  lexxy (0.9.23) sha256=a2ba4bffb56d414cd9fd3f338cc6226c6d312821b0d9a64e2094c7a69d0555b3
+  lexxy (0.9.31.beta) sha256=97b1774d597b9b9e2e857e3d69318d4f6b1eac62cdccbe35b80d533771ac7c76
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918


### PR DESCRIPTION
Fizzy has been pinned to Lexxy 0.9.23 since early July, so it misses the editor's sanitization rework — and, because it also lagged behind bc3 in the meantime, seven further releases of paste, selection and mounting fixes. This is a jump of eight versions, not a routine bump, and the diff carries a good deal more than the sanitization stack.

Originally tracked in [Lexxy sanitization](https://app.basecamp.com/2914079/buckets/48540453/card_tables/cards/10213802488).

### The sanitization work

Landed across 0.9.30 and 0.9.31.beta. Lexxy now runs its own DOMPurify instance with a per-editor allowlist instead of configuring the shared one, strips Stimulus behaviour attributes during sanitization, applies mXSS-safe `SAFE_FOR_XML` when re-inflating attachment content, validates attachment URLs itself on DOMPurify 3.4.13, and claims a `lexxy` Trusted Types policy rather than racing the host application for `dompurify`.

Fizzy consumes Lexxy as a gem only — there is no `package.json`, no JS lockfile, and no DOMPurify pin anywhere in the tree. The importmap pins `lexxy` straight at the gem's prebuilt bundle, so the DOMPurify version and the Trusted Types policy arrive with the gem and nothing here can override them. Worth stating explicitly because bc3 carries a tree-wide `resolutions.dompurify` override that has to be handled separately; Fizzy has no equivalent.

### Worth an eye from the intervening releases

These change editor behaviour rather than fix crashes, so they are the parts of the jump that merit a look:

- Pasting is substantially reworked — foreign `<style>` blocks are stripped from pasted content with some rules inlined first, Word and Outlook lists arrive as lists, Gmail emoji `<img>` tags become emoji text, and plain text from Notepad no longer turns into a code block.
- macOS text replacements no longer lose their line breaks on submit.
- The editor no longer shifts layout as it mounts, which is visible on the card and comment forms.
- Focus stays in other form fields when a stale selection is reconciled.
- Headings became configurable, and dedicated heading commands were restored for the native apps.

Two test helpers moved onto the editor handle in 0.9.25 (`dispatchToolbarCommand`, `placeCaretInside`) — Fizzy uses neither. The CSS custom properties and class names Fizzy overrides are all still present in 0.9.31.beta.

### Lockfiles

Both are updated. `Gemfile.saas.lock` is relocked rather than patched, so the checksum entry matches the new gem and `bin/bundle-drift` stays in sync.

Full suite and the audit steps pass locally: 1549 unit tests and 16 system tests green, plus drift, gem audit and importmap audit.

Related upstream work: [Apply mXSS-safe SAFE_FOR_XML on attachment content re-inflation](https://github.com/basecamp/lexxy/pull/1226), [Build dist on install so a branch or SHA can be depended on](https://github.com/basecamp/lexxy/pull/1228), [Move to dompurify 3.4.13, and validate attachment URLs ourselves](https://github.com/basecamp/lexxy/pull/1229), [Keep an image's alternative text and intrinsic size in attachment content](https://github.com/basecamp/lexxy/pull/1230), [Give Lexxy its own DOMPurify instance, and an allowlist per editor](https://github.com/basecamp/lexxy/pull/1231), [Claim a "lexxy" Trusted Types policy instead of racing the host for "dompurify"](https://github.com/basecamp/lexxy/pull/1232).
