### PR TITLE
Bump brakeman to 8.0.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+      exclude:
+        - "brakeman"
   - package-ecosystem: github-actions
     directory: "/"
     groups:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -602,7 +602,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.5) sha256=36b677448524d279b470469aabd5dff4a980e3fa4931a0df68da4a500eb1b6c4
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -273,7 +273,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -828,7 +828,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.5) sha256=36b677448524d279b470469aabd5dff4a980e3fa4931a0df68da4a500eb1b6c4
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9


### PR DESCRIPTION
brakeman here is at 8.0.4; 8.0.6 shipped on 2026-08-12. This repo's `bin/brakeman` does **not** pass `--ensure-latest`, so CI is green and this is a staleness fix rather than a red-build fix.

Two commits:

1. **Lockfile bump to 8.0.6** in both `Gemfile.lock` and `Gemfile.saas.lock`. brakeman's only runtime dependency is `racc` and its required ruby is `>= 3.2.0`, both unchanged since 7.1.2, so nothing else in the graph moves.
2. **brakeman exempted from the dependabot cooldown**, so the next release is proposed the week it ships instead of 7–14 days later.

Deliberately *not* done: adding `--ensure-latest` to `bin/brakeman`. Sibling repos in this sweep have it and it is exactly what turned their builds red; introducing that failure mode here would be a regression, not an improvement.

### A bug in `bin/bundle-drift forward`

The plan was to bump `Gemfile.lock` and run `bin/bundle-drift forward` — the same script `.github/workflows/dependabot-sync-saas-lockfile.yml` runs. It produces a **wrong `Gemfile.saas.lock`**:

```
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.6) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
```

`patch_saas` rewrites every `name (version)` occurrence textually, including inside the `CHECKSUMS` section, and leaves the `sha256=` untouched — so the entry claims 8.0.4's digest for 8.0.6. `bin/bundle-drift check` still passes, because it only compares versions. `bundle install` against `Gemfile.saas` would fail checksum verification.

So this PR regenerates the saas lockfile with bundler instead:

```
BUNDLE_GEMFILE=Gemfile.saas bundle lock --update brakeman
```

which writes the correct `sha256=759cc693…`, and `bin/bundle-drift check` then reports the two files in sync.

I checked whether this had already bitten: on `main`, all 173 shared checksummed gems agree between the two lockfiles, so no stale digest is in the tree today. But the workflow runs `forward` on every dependabot bundler PR, so the next version-drift gem it forwards will carry a stale digest. Fixing `bundle-drift` is out of scope here — flagging it rather than folding an unrelated fix into a version bump.

### Verified locally

- Both lockfile diffs are the brakeman line plus its checksum, nothing else.
- brakeman 8.0.6 scans this repo clean: 0 warnings, 0 errors, 0 obsolete ignore entries.

One of twelve repos in a fleet-wide sweep to 8.0.6.
