### PR TITLE
Drop vestigial office parsers from the SaaS app image

### DIFF
--- a/saas/Dockerfile
+++ b/saas/Dockerfile
@@ -54,7 +54,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips build-essential ffmpeg groff libreoffice-writer libreoffice-impress libreoffice-calc mupdf-tools sqlite3 libjemalloc-dev && \
+    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips build-essential ffmpeg mupdf-tools sqlite3 libjemalloc-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application


### PR DESCRIPTION
**Stacked on #3034 (hotcell) — do not merge to `main` independently.** Base is `hotcell`; if #3034 merges first, this rebases onto `main`.

## What

Drops `groff libreoffice-writer libreoffice-impress libreoffice-calc` from the final-stage install in `saas/Dockerfile`. Nothing else changes.

## Why

Fizzy never previews office documents: no `office` group in `Cell#configuration_for`, no Active Storage office previewer, and zero invokers of `soffice`/`groff` across `app/ lib/ config/ saas/ test/ Rakefile` (the install line is the only hit). The cell image deliberately omits LibreOffice for the same reason. These packages sat in the secret-bearing app image — the process holding `RAILS_MASTER_KEY` — as pure attack surface, the exact class hotcell exists to shrink.

**Deliberately kept:** `ffmpeg` and `mupdf-tools` back the in-process fallback `Cell#configuration_for(group, moved: false)` runs if a group is un-moved (hotcell disabled or cell outage). `libvips` is a boot-time `ruby-vips` dependency and the `images` fallback; the in-process TIFF loader is already blocked in `config/initializers/vips.rb`. The OSS root `Dockerfile` never installed any of these, so it needs no edit.

## Verification

- Built both images on amd64: `hotcell` baseline **2.17GB** → this branch **1.74GB** (**−430MB**)
- `soffice`, `libreoffice`, `groff` absent from the built image; `ffmpeg`, `mutool`, and the libvips shared libraries present
- Production-mode boot smoke in the built image: `bin/rails runner` boots clean
- Test suite: 1550 tests, 5852 assertions, 0 failures, 0 errors, 1 skip