### PR TITLE
Vendor the pacman-packages block

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -165,15 +165,22 @@ pacman_package_satisfied() {
 }
 
 install_pacman_packages() {
-  local declared manager package rest status missing=()
+  local declared rows manager package rest status missing=()
 
   # Captured here rather than read through a process substitution: neither set -e nor pipefail
   # propagates a failure out of one, so a broken status run would yield no rows and report every
   # declared package installed — silently skipping the phase that the plain apply used to abort.
-  declared="$(mise bootstrap packages status)" || {
-    echo "mise bootstrap packages status failed — refusing to report declared packages as installed." >&2
+  status=0
+  declared="$(mise bootstrap packages status)" || status=$?
+  rows="$(printf '%s\n' "$declared" | awk '$1 == "pacman"')"
+
+  # status takes no --manager, so it reports every manager and another manager's failure must not
+  # abort this phase — the manager-scoped apply it replaced could not fail that way. Abort only
+  # when pacman rows are missing too, which is when we cannot tell what needs installing.
+  if [ "$status" -ne 0 ] && [ -z "$rows" ]; then
+    echo "mise bootstrap packages status failed and reported no pacman packages." >&2
     return 1
-  }
+  fi
 
   while read -r manager package rest; do
     [ "$manager" = pacman ] && [ -n "$package" ] || continue
@@ -186,7 +193,7 @@ install_pacman_packages() {
     127) missing+=("pacman:$package") ;;
     *) return 1 ;;
     esac
-  done <<< "$declared"
+  done <<< "$rows"
 
   if [ "${#missing[@]}" -gt 0 ]; then
     mise bootstrap packages apply --yes "${missing[@]}"

--- a/bin/setup
+++ b/bin/setup
@@ -185,6 +185,21 @@ install_pacman_packages() {
   while read -r manager package rest; do
     [ "$manager" = pacman ] && [ -n "$package" ] || continue
 
+    # status renders a pinned declaration as name@version — a display token, not the
+    # dependency syntax pacman -T reads — and pacman cannot install a pinned version at all.
+    # Take mise's own verdict for those rather than deriving one: testing the token would
+    # read a satisfied pin as missing and then hand pacman an operand it cannot resolve.
+    case "$package" in
+    *@*)
+      case "$rest" in
+      *installed) continue ;;
+      esac
+
+      echo "pacman cannot install the pinned declaration $package." >&2
+      return 1
+      ;;
+    esac
+
     status=0
     pacman_package_satisfied "$package" || status=$?
 

--- a/bin/setup
+++ b/bin/setup
@@ -165,22 +165,20 @@ pacman_package_satisfied() {
 }
 
 install_pacman_packages() {
-  local declared rows manager package rest status missing=()
+  local declared manager package rest status missing=()
 
   # Captured here rather than read through a process substitution: neither set -e nor pipefail
   # propagates a failure out of one, so a broken status run would yield no rows and report every
   # declared package installed — silently skipping the phase that the plain apply used to abort.
-  status=0
-  declared="$(mise bootstrap packages status)" || status=$?
-  rows="$(printf '%s\n' "$declared" | awk '$1 == "pacman"')"
-
-  # status takes no --manager, so it reports every manager and another manager's failure must not
-  # abort this phase — the manager-scoped apply it replaced could not fail that way. Abort only
-  # when pacman rows are missing too, which is when we cannot tell what needs installing.
-  if [ "$status" -ne 0 ] && [ -z "$rows" ]; then
-    echo "mise bootstrap packages status failed and reported no pacman packages." >&2
+  #
+  # status takes no --manager, and it queries managers in turn and gives up on the first one that
+  # errors, so an unrelated manager could abort a pacman run — something the manager-scoped apply
+  # it replaced could not do. Scope it with the setting's own env var; excluded managers are
+  # reported as skipped and never queried. A mise without the setting ignores the variable.
+  declared="$(MISE_SYSTEM_PACKAGES_MANAGERS=pacman mise bootstrap packages status)" || {
+    echo "mise bootstrap packages status failed — refusing to report declared packages as installed." >&2
     return 1
-  fi
+  }
 
   while read -r manager package rest; do
     [ "$manager" = pacman ] && [ -n "$package" ] || continue
@@ -208,7 +206,7 @@ install_pacman_packages() {
     127) missing+=("pacman:$package") ;;
     *) return 1 ;;
     esac
-  done <<< "$rows"
+  done <<< "$declared"
 
   if [ "${#missing[@]}" -gt 0 ]; then
     mise bootstrap packages apply --yes "${missing[@]}"

--- a/bin/setup
+++ b/bin/setup
@@ -146,29 +146,47 @@ fi
 # asymmetric — percona provides mariadb-clients, but nothing provides percona's own name, so a
 # machine already carrying another provider would otherwise be handed a conflicting install.
 pacman_package_satisfied() {
-  local requirement="$1"
+  local requirement="$1" status
 
   if [ "$requirement" = percona-server-clients ]; then
     requirement=mysql-clients
   fi
 
   pacman -T -- "$requirement" > /dev/null
-}
+  status=$?
 
-unsatisfied_pacman_packages() {
-  local package
+  # 0 satisfied, 127 unsatisfied — any other status is pacman failing rather than answering,
+  # and must not read as "missing" and send us on to install something
+  if [ "$status" -ne 0 ] && [ "$status" -ne 127 ]; then
+    echo "pacman -T $requirement failed (status $status)" >&2
+  fi
 
-  while read -r package; do
-    pacman_package_satisfied "$package" || echo "$package"
-  done < <(mise bootstrap packages status | awk '$1 == "pacman" { print $2 }')
+  return $status
 }
 
 install_pacman_packages() {
-  local package missing=()
+  local declared manager package rest status missing=()
 
-  while read -r package; do
-    missing+=("pacman:$package")
-  done < <(unsatisfied_pacman_packages)
+  # Captured here rather than read through a process substitution: neither set -e nor pipefail
+  # propagates a failure out of one, so a broken status run would yield no rows and report every
+  # declared package installed — silently skipping the phase that the plain apply used to abort.
+  declared="$(mise bootstrap packages status)" || {
+    echo "mise bootstrap packages status failed — refusing to report declared packages as installed." >&2
+    return 1
+  }
+
+  while read -r manager package rest; do
+    [ "$manager" = pacman ] && [ -n "$package" ] || continue
+
+    status=0
+    pacman_package_satisfied "$package" || status=$?
+
+    case $status in
+    0) ;;
+    127) missing+=("pacman:$package") ;;
+    *) return 1 ;;
+    esac
+  done <<< "$declared"
 
   if [ "${#missing[@]}" -gt 0 ]; then
     mise bootstrap packages apply --yes "${missing[@]}"

--- a/bin/setup
+++ b/bin/setup
@@ -132,6 +132,52 @@ else
   exit 1
 fi
 
+# shipyard-block: pacman-packages v1
+# mise matches declared package names exactly against what pacman reports installed, but pacman
+# satisfies a name from any installed provider and answers under the provider's name. A
+# provider-satisfied declaration therefore reads as missing, and mise hands pacman a package
+# that conflicts with the provider already installed (jdx/mise#12181, fixed upstream by #12183 —
+# this block still carries every machine below that floor).
+#
+# The mysql client is the one declaration with interchangeable providers: mariadb-clients,
+# mariadb-lts-clients and percona-server-clients all provide mysql-clients and all own
+# /usr/bin/mysql, so pacman refuses to add a second. The fleet declares percona-server-clients
+# so fresh machines get it; test the virtual rather than that name, because the provides are
+# asymmetric — percona provides mariadb-clients, but nothing provides percona's own name, so a
+# machine already carrying another provider would otherwise be handed a conflicting install.
+pacman_package_satisfied() {
+  local requirement="$1"
+
+  if [ "$requirement" = percona-server-clients ]; then
+    requirement=mysql-clients
+  fi
+
+  pacman -T -- "$requirement" > /dev/null
+}
+
+unsatisfied_pacman_packages() {
+  local package
+
+  while read -r package; do
+    pacman_package_satisfied "$package" || echo "$package"
+  done < <(mise bootstrap packages status | awk '$1 == "pacman" { print $2 }')
+}
+
+install_pacman_packages() {
+  local package missing=()
+
+  while read -r package; do
+    missing+=("pacman:$package")
+  done < <(unsatisfied_pacman_packages)
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    mise bootstrap packages apply --yes "${missing[@]}"
+  else
+    echo "All declared pacman packages are already installed."
+  fi
+}
+# shipyard-block-end: pacman-packages
+
 # Native packages before tools: Bundler builds native extensions against them.
 if [ "$manager" = "brew" ]; then
   step "Installing system packages" brew bundle --file="$app_root/Brewfile"
@@ -140,7 +186,7 @@ else
   # forced `pacman -Sy` before a targeted -S, Arch's unsupported partial upgrade.
   # Install against the existing synchronized database instead.
   if [ "$manager" = pacman ]; then
-    step "Installing system packages" mise bootstrap packages apply --manager "$manager" --yes
+    step "Installing system packages" install_pacman_packages
   else
     step "Installing system packages" mise bootstrap packages apply --manager "$manager" --yes --update
   fi


### PR DESCRIPTION
Vendors the shared `pacman-packages` block so any already-installed provider is accepted.

## Why

`pacman` satisfies a declared name from any installed **provider**, and answers under the provider's name. mise matches names exactly, so a provider-satisfied declaration reads as missing and mise hands pacman a package that conflicts with the provider already installed — `mariadb-clients`, `mariadb-lts-clients` and `percona-server-clients` all provide `mysql-clients` and all own `/usr/bin/mysql`, so pacman refuses to add a second and `bin/setup` aborts.

Reported upstream as jdx/mise#12181 and fixed by jdx/mise#12183, which is merged to mise master but **not in any release yet** (latest is v2026.8.8, from before the merge).

## Why the block is still needed after that lands

The provides are asymmetric. `percona-server-clients` provides `mariadb-clients`, but **nothing** provides percona's own name:

```
$ expac -Ss '%n provides: %S' percona-server-clients
mariadb-clients        provides: mysql-clients
mariadb-lts-clients    provides: mariadb-clients  mysql-clients
percona-server-clients provides: mysql-clients  mariadb-clients
```

So declaring percona is unsatisfiable for anyone already running mariadb-clients, no matter how well mise resolves provides. The block tests the `mysql-clients` virtual instead, which every provider satisfies.

Declaring the virtual directly instead was considered and rejected: on a fresh box `pacman -S --noconfirm mysql-clients` resolves to **mariadb-clients**, so it would silently stop being percona on new machines.

## Shape

The block is canonical in shipyard (`share/setup-blocks/pacman-packages` v1) and vendored here byte-for-byte, per the standalone constraint — app setups run on fresh machines before any shipyard checkout exists. It defines functions only, at column 0, so the same bytes vendor into every app regardless of how each one indents its call site. `bin/audit-fleet-setup` covers it.

## Verified

- `audit_block` reports `clean` against the canonical copy.
- `bash -n bin/setup` passes.
- The normalized pacman split matches `test/mise-floor-test`'s `expected_split`, and `mise bootstrap packages apply` still appears exactly twice (one in the block, one in the else arm).
- Block behavior is covered by `test/pacman-packages-test` in shipyard, which runs the extracted canonical bytes against pacman/mise shims — including the asymmetry case. That test was mutation-checked: deleting the `mysql-clients` rewrite makes it fail.

`bin/setup` was not run end to end.

fizzy declares no mysql client, so the block is inert here today — `pacman:mariadb-libs` is the connector library, which percona neither provides nor conflicts with. It is vendored for shape parity: `test/mise-floor-test` asserts every app's pacman split is identical, so fizzy has to move with the fleet.

Depends on basecamp/shipyard#175, which carries the canonical block and its test.