### PR TITLE
Stop painting inline-code chips inside `<pre>` blocks

### DIFF
--- a/app/assets/stylesheets/lexxy.css
+++ b/app/assets/stylesheets/lexxy.css
@@ -173,7 +173,7 @@
       padding-block: 0;
     }
 
-    code {
+    code:not(pre code) {
       background: var(--color-canvas);
       border: 1px solid var(--color-ink-lighter);
     }

--- a/test/system/code_block_styling_test.rb
+++ b/test/system/code_block_styling_test.rb
@@ -1,0 +1,30 @@
+require "application_system_test_case"
+
+class CodeBlockStylingTest < ApplicationSystemTestCase
+  test "a code block and its nested code element share one background" do
+    comments(:layout_overflowing_david).update! body: "<pre><code>puts :hello</code></pre>"
+
+    sign_in_as(users(:david))
+    visit card_url(cards(:layout))
+
+    within "#comment_#{comments(:layout_overflowing_david).id}" do
+      assert_equal background_color_of(find("pre")), background_color_of(find("pre code"))
+    end
+  end
+
+  test "inline code keeps its chip background" do
+    comments(:layout_overflowing_david).update! body: "<p>Run <code>puts :hello</code> now.</p>"
+
+    sign_in_as(users(:david))
+    visit card_url(cards(:layout))
+
+    within "#comment_#{comments(:layout_overflowing_david).id}" do
+      assert_equal "oklch(1 0 0)", background_color_of(find("code"))
+    end
+  end
+
+  private
+    def background_color_of(element)
+      page.evaluate_script("getComputedStyle(arguments[0]).backgroundColor", element)
+    end
+end


### PR DESCRIPTION
A `<pre><code>` block in a card description or comment rendered with the inline-code chip painted on the inner `<code>`: a `--color-canvas` background and a border, one ragged box per line, sitting on the block's `--color-ink-lighter`.

Lexxy's editor and Fizzy's markdown renderer emit different markup for the same block. Lexxy emits `<pre data-language="…">…<br>…</pre>` with no `<code>` child; the markdown renderer emits `<pre><code>…</code></pre>`. `app/assets/stylesheets/lexxy.css:176` styled a bare `code`:

    .lexxy-content {
      code {
        background: var(--color-canvas);
        border: 1px solid var(--color-ink-lighter);
      }
    }

That is the inline chip, and the bare selector was safe only because Lexxy never nests `code` inside `pre`. On the markdown path it lands on the inner `<code>`, which is `display: inline` inheriting `white-space: pre` from the block — hence one chip per line box. Both themes break: light is `--lch-canvas: var(--lch-white)` against `--lch-ink-lighter: 92%`, dark is `20%` against `30%`.

<table>
<tr><th>before<th>after
<tr><td><img width="785" height="239" alt="1-before-light" src="https://github.com/user-attachments/assets/ecc3eb9f-e748-4371-8d66-3407a603c8ec" /><td><img width="785" height="239" alt="2-after-light" src="https://github.com/user-attachments/assets/7e157fd1-8a76-4358-ba31-58db9d7cdad9" />

<tr><td><img width="785" height="239" alt="3-before-dark" src="https://github.com/user-attachments/assets/1a7bfcb2-d620-4f63-84de-8957abd7c04b" /><td><img width="785" height="239" alt="4-after-dark" src="https://github.com/user-attachments/assets/9037ce76-2d24-489e-b940-b2364aae8114" />
</table>

## Detail

Scope the rule to `code:not(pre code)`. The nested `code` then falls back to the Lexxy gem's own `code, pre` rule (`lexxy-content.css:108` in 0.9.31), which paints `--lexxy-color-ink-lightest`; `lexxy.css:10` maps that to `--color-ink-lighter`, the same value the block already uses. Backgrounds match in both themes, and a bare inline `<code>` keeps its chip.

The rule sits in `@layer components` while the gem's stylesheets are imported into `layer(base)`, so the override wins by cascade layer rather than specificity. Narrowing the selector is what removes it from the nested case; specificity is not in play.

`test/system/code_block_styling_test.rb` covers both halves — the block and its nested `code` resolve to one computed `background-color`, and an inline `<code>` still resolves to the canvas chip. Against the old rule the first fails with `Expected: "oklch(0.92 0.003 254)"` / `Actual: "oklch(1 0 0)"`.

## Additional information

`app/assets/stylesheets/cards.css:228` has the same bare-`code` shape. It is scoped to `.card__title`, which is plain text and never contains a `<pre>`, so there is no path to the defect. Left alone.

One residue remains: the gem rule also gives the inner `code` `padding: 0.25ch 0.5ch`, nudging the first character of each line. Invisible once the backgrounds match. Fixing it is an upstream `code:not(pre code), pre` change in Lexxy, not a Fizzy one.

Before/after screenshots in light and dark exist but are not embedded — there is no `gh` or API path to upload an image into a PR body, so @flavorjones will drag them in.

ref: https://app.fizzy.do/6097036/cards/391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPp9kjB67z8k27f9uv4dq7
