### PR TITLE
dep: update rails to 28e3e642

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: ce95deb79b0402a21cf2fe854f47179427af98c7
+  revision: 28e3e6426b6926b46047d4141207d704483c540e
   branch: main
   specs:
     actioncable (8.2.0.alpha)

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -69,7 +69,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: ce95deb79b0402a21cf2fe854f47179427af98c7
+  revision: 28e3e6426b6926b46047d4141207d704483c540e
   branch: main
   specs:
     actioncable (8.2.0.alpha)

--- a/config/initializers/uuid_primary_keys.rb
+++ b/config/initializers/uuid_primary_keys.rb
@@ -1,7 +1,10 @@
 # Automatically use UUID type for all binary(16) columns and generate defaults
 
 module UuidPrimaryKeyDefault
-  def load_schema!
+  # Rails builds the schema context's attribute set (applying pending attribute
+  # modifications) inside `load_schema`, before the model's own `load_schema!`
+  # hook runs, so the default has to be registered as the context is built.
+  def build_schema_context
     define_uuid_primary_key_pending_default
     super
   end

--- a/test/controllers/controller_authentication_test.rb
+++ b/test/controllers/controller_authentication_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ControllerAuthenticationTest < ActionDispatch::IntegrationTest
   test "access without an account slug redirects to menu" do
     sign_in_as :kevin
-    integration_session.default_url_options[:script_name] = "" # no tenant
+    integration_session.default_url_options = integration_session.default_url_options.merge(script_name: "") # no tenant
 
     get cards_path
 

--- a/test/models/uuid_primary_key_test.rb
+++ b/test/models/uuid_primary_key_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class UuidPrimaryKeyTest < ActiveSupport::TestCase
+  test "new record is assigned a generated uuid primary key" do
+    assert_match(/\A[0-9a-z]{25}\z/, Identity.new.id)
+  end
+
+  test "created record persists its generated uuid primary key" do
+    identity = Identity.create!(email_address: "uuid-default@example.com")
+
+    assert_equal identity.id, Identity.find_by(email_address: "uuid-default@example.com").id
+  end
+end

--- a/test/system/code_block_styling_test.rb
+++ b/test/system/code_block_styling_test.rb
@@ -17,6 +17,7 @@ class CodeBlockStylingTest < ApplicationSystemTestCase
 
     sign_in_as(users(:david))
     visit card_url(cards(:layout))
+    force_light_theme
 
     within "#comment_#{comments(:layout_overflowing_david).id}" do
       assert_equal "oklch(1 0 0)", background_color_of(find("code"))
@@ -24,6 +25,12 @@ class CodeBlockStylingTest < ApplicationSystemTestCase
   end
 
   private
+    # Without an explicit theme the chip colour follows the browser's
+    # prefers-color-scheme, so this asserts light-mode values on a dark desktop.
+    def force_light_theme
+      page.execute_script("document.documentElement.setAttribute('data-theme', 'light')")
+    end
+
     def background_color_of(element)
       page.evaluate_script("getComputedStyle(arguments[0]).backgroundColor", element)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,7 +75,7 @@ end
 
 class ActionDispatch::IntegrationTest
   setup do
-    integration_session.default_url_options[:script_name] = "/#{ActiveRecord::FixtureSet.identify("37signals")}"
+    integration_session.default_url_options = integration_session.default_url_options.merge(script_name: "/#{ActiveRecord::FixtureSet.identify("37signals")}")
   end
 
   private
@@ -92,7 +92,7 @@ end
 
 class ActionDispatch::SystemTestCase
   setup do
-    self.default_url_options[:script_name] = "/#{ActiveRecord::FixtureSet.identify("37signals")}"
+    self.default_url_options = default_url_options.merge(script_name: "/#{ActiveRecord::FixtureSet.identify("37signals")}")
   end
 end
 

--- a/test/test_helpers/session_test_helper.rb
+++ b/test/test_helpers/session_test_helper.rb
@@ -52,11 +52,11 @@ module SessionTestHelper
   end
 
   def untenanted(&block)
-    original_script_name = integration_session.default_url_options[:script_name]
-    integration_session.default_url_options[:script_name] = ""
+    original_options = integration_session.default_url_options
+    integration_session.default_url_options = original_options.merge(script_name: "")
     yield
   ensure
-    integration_session.default_url_options[:script_name] = original_script_name
+    integration_session.default_url_options = original_options
   end
 
   def with_multi_tenant_mode(enabled)


### PR DESCRIPTION
Moves the `rails` git dep from `ce95deb` to [`28e3e642`](https://github.com/rails/rails/commit/28e3e6426b6926b46047d4141207d704483c540e), 118 commits. Both `Gemfile.lock` and `Gemfile.saas.lock` move; no transitive gems change.

Two behaviour changes in the range needed mitigation.

**[`ae739c38`](https://github.com/rails/rails/commit/ae739c38) broke UUID primary keys.** Rails moved model schema state into a new `SchemaContext` and inverted an ordering: the context builds the attribute set, applying pending attribute modifications, before the model's own `load_schema!` hook runs. `config/initializers/uuid_primary_keys.rb` registered its `PendingUuidDefault` from `load_schema!`, so the generator went silently inert — no boot error, just `nil` primary keys on `INSERT`, surfacing as `NOT NULL` violations. `bin/rails db:seed` failed on the first `Identity.find_or_create_by!`:

    ActiveRecord::NotNullViolation: Trilogy::ProtocolError: 1364: Field 'id' doesn't have a default value

Registering from `build_schema_context` puts it back in front of the attribute set. `test/models/uuid_primary_key_test.rb` covers it.

**[`baa1ca5f`](https://github.com/rails/rails/commit/baa1ca5f) freezes `default_url_options`.** Every integration and system test sets `script_name` for the account-slug prefix by mutating that hash in place, so the whole suite raised `FrozenError`. Five call sites now merge and reassign. `untenanted` restores the whole hash rather than the one key, so anything else set inside the block is also reverted.

One unrelated fix rides along: `CodeBlockStylingTest#test_inline_code_keeps_its_chip_background` hardcodes `--color-canvas`'s light-mode value without pinning a theme, so it follows the browser's `prefers-color-scheme` and fails on a dark desktop. It reproduces on `main` at 488192c1 with the old rails — not caused by this branch. Pinned to `data-theme="light"`.

Verified on both adapters: full suite and system tests green under SQLite/OSS and MySQL 8.4/SaaS, `db:schema:load` + `db:seed` green, and `db:schema:dump` byte-identical on both.

Two security fixes in the range shipped without a CVE or GHSA — `2191ca0d` (Action Text stored XSS) and `38efca8d` (a cross-tenant `Relation#update(id, attrs)` write hole). Fizzy has no call sites for either, but it's worth factoring into how urgently this ships.

Full analysis: [`fizzy-20260824-rails_ce95deb..28e3e64.md`](https://github.com/basecamp/37signals-hq/blob/main/upgrade-analysis/fizzy-20260824-rails_ce95deb..28e3e64.md)
