### PR TITLE
Fail account imports cleanly on duplicate unique keys

### DIFF
--- a/app/jobs/account/data_import_job.rb
+++ b/app/jobs/account/data_import_job.rb
@@ -1,14 +1,14 @@
 class Account::DataImportJob < ApplicationJob
   include ActiveJob::Continuable
 
-  # Let errors reach the discard_on/failure handlers instead of resuming the
-  # continuation, which would re-run the import against terminal errors like
-  # conflicts. Deploy interruptions still resume via Continuation::Interrupt.
-  self.resume_errors_after_advancing = false
+  # Errors that must reach the discard_on handlers instead of resuming the
+  # continuation, which would re-run the import against them. Transient errors
+  # (network, database) still resume from the step cursor as usual.
+  TERMINAL_ERRORS = [ Account::DataTransfer::RecordSet::IntegrityError, ZipFile::InvalidFileError,
+    Account::Import::InsufficientStorageSpaceError ].freeze
 
   queue_as :backend
-  discard_on Account::DataTransfer::RecordSet::IntegrityError, ZipFile::InvalidFileError,
-    Account::Import::InsufficientStorageSpaceError
+  discard_on(*TERMINAL_ERRORS)
 
   def perform(import)
     step :check do |step|
@@ -23,4 +23,9 @@ class Account::DataImportJob < ApplicationJob
         callback: ->(record_set:, files:) { step.set!([ record_set.model.name, files.last ]) }
     end
   end
+
+  private
+    def resume_job(exception)
+      TERMINAL_ERRORS.any? { |terminal| exception.is_a?(terminal) } ? raise(exception) : super
+    end
 end

--- a/app/jobs/account/data_import_job.rb
+++ b/app/jobs/account/data_import_job.rb
@@ -1,6 +1,11 @@
 class Account::DataImportJob < ApplicationJob
   include ActiveJob::Continuable
 
+  # Let errors reach the discard_on/failure handlers instead of resuming the
+  # continuation, which would re-run the import against terminal errors like
+  # conflicts. Deploy interruptions still resume via Continuation::Interrupt.
+  self.resume_errors_after_advancing = false
+
   queue_as :backend
   discard_on Account::DataTransfer::RecordSet::IntegrityError, ZipFile::InvalidFileError,
     Account::Import::InsufficientStorageSpaceError

--- a/app/models/account/data_transfer/manifest.rb
+++ b/app/models/account/data_transfer/manifest.rb
@@ -33,8 +33,8 @@ class Account::DataTransfer::Manifest
           ::Column
         ),
         Account::DataTransfer::EntropyRecordSet.new(account),
+        record_set_for(::Board::Publication, unique_keys: %w[ key ]),
         *record_sets_for(
-          ::Board::Publication,
           ::Webhook,
           ::Access,
           ::Card,
@@ -71,8 +71,8 @@ class Account::DataTransfer::Manifest
       end
     end
 
-    def record_set_for(model)
-      Account::DataTransfer::RecordSet.new(account: account, model: model)
+    def record_set_for(model, **options)
+      Account::DataTransfer::RecordSet.new(account: account, model: model, **options)
     end
 
     def set_importable_model_names(record_sets)

--- a/app/models/account/data_transfer/record_set.rb
+++ b/app/models/account/data_transfer/record_set.rb
@@ -6,13 +6,14 @@ class Account::DataTransfer::RecordSet
   INTERNAL_RECORD_TYPES = %w[Export Account::Import].freeze
 
   attr_accessor :importable_model_names
-  attr_reader :account, :model, :attributes
+  attr_reader :account, :model, :attributes, :unique_keys
 
-  def initialize(account:, model:, attributes: nil, importable_model_names: nil)
+  def initialize(account:, model:, attributes: nil, importable_model_names: nil, unique_keys: nil)
     @account = account
     @model = model
     @attributes = (attributes || model.column_names).map(&:to_s)
     @importable_model_names = importable_model_names || [ model.name ]
+    @unique_keys = (unique_keys || []).map(&:to_s)
   end
 
   def export(to:, start: nil)
@@ -101,6 +102,7 @@ class Account::DataTransfer::RecordSet
       end
 
       check_associations_dont_exist(data)
+      check_unique_keys_available(data)
     end
 
     def check_associations_dont_exist(data)
@@ -124,6 +126,28 @@ class Account::DataTransfer::RecordSet
       if associated_class.exists?(id: associated_id)
         raise ConflictError, "#{model} record references existing #{association.name} (#{associated_class}) with ID #{associated_id}"
       end
+    end
+
+    def check_unique_keys_available(data)
+      unique_keys.each do |column|
+        if value = data[column]
+          check_unique_key_available(column, value)
+        end
+      end
+    end
+
+    def check_unique_key_available(column, value)
+      if seen_unique_key_values[column].include?(value)
+        raise ConflictError, "#{model} #{column} appears more than once in the export"
+      elsif model.exists?(column => value)
+        raise ConflictError, "#{model} record with #{column} #{value.inspect} already exists"
+      else
+        seen_unique_key_values[column] << value
+      end
+    end
+
+    def seen_unique_key_values
+      @seen_unique_key_values ||= Hash.new { |values, column| values[column] = Set.new }
     end
 
     def verify_model_type(type_name)

--- a/app/models/account/data_transfer/record_set.rb
+++ b/app/models/account/data_transfer/record_set.rb
@@ -82,6 +82,8 @@ class Account::DataTransfer::RecordSet
       end
 
       model.insert_all!(batch_data)
+    rescue ActiveRecord::RecordNotUnique => e
+      raise ConflictError, "#{model} import violated a uniqueness constraint: #{e.message}"
     end
 
     def check_record(file_path)

--- a/app/models/account/data_transfer/record_set.rb
+++ b/app/models/account/data_transfer/record_set.rb
@@ -132,7 +132,11 @@ class Account::DataTransfer::RecordSet
 
     def check_unique_keys_available(data)
       unique_keys.each do |column|
-        if value = data[column]
+        value = data[column]
+
+        if value.blank?
+          raise IntegrityError, "#{model} #{column} must be present"
+        else
           check_unique_key_available(column, value)
         end
       end

--- a/app/models/account/data_transfer/record_set.rb
+++ b/app/models/account/data_transfer/record_set.rb
@@ -36,6 +36,8 @@ class Account::DataTransfer::RecordSet
         callback&.call(record_set: self, files: file_batch)
       end
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    raise ConflictError, "#{model} import violated a uniqueness constraint: #{e.message}"
   end
 
   def check(from:, start: nil, callback: nil)
@@ -82,8 +84,6 @@ class Account::DataTransfer::RecordSet
       end
 
       model.insert_all!(batch_data)
-    rescue ActiveRecord::RecordNotUnique => e
-      raise ConflictError, "#{model} import violated a uniqueness constraint: #{e.message}"
     end
 
     def check_record(file_path)

--- a/test/jobs/account/data_import_job_test.rb
+++ b/test/jobs/account/data_import_job_test.rb
@@ -27,4 +27,66 @@ class Account::DataImportJobTest < ActiveJob::TestCase
     export_tempfile&.close
     export_tempfile&.unlink
   end
+
+  test "discards the job and marks the import failed_due_to_conflict when a crafted export duplicates a unique key" do
+    source_account = accounts("37s")
+    exporter = users(:david)
+    identity = exporter.identity
+
+    boards(:writebook).publish
+
+    export = Account::Export.create!(account: source_account, user: exporter)
+    export.build
+
+    export_tempfile = Tempfile.new([ "export", ".zip" ])
+    export.file.open { |f| FileUtils.cp(f.path, export_tempfile.path) }
+
+    source_account.destroy!
+
+    tampered_tempfile = duplicate_publication_key_in(export_tempfile)
+
+    target_account = Account.create_with_owner(account: { name: "Import Test" }, owner: { identity: identity, name: exporter.name })
+    import = Account::Import.create!(identity: identity, account: target_account)
+    Current.set(account: target_account) do
+      import.file.attach(io: File.open(tampered_tempfile.path), filename: "export.zip", content_type: "application/zip")
+    end
+
+    assert_nothing_raised do
+      Account::DataImportJob.perform_now(import)
+    end
+
+    assert import.reload.failed_due_to_conflict?
+  ensure
+    export_tempfile&.close
+    export_tempfile&.unlink
+    tampered_tempfile&.close
+    tampered_tempfile&.unlink
+  end
+
+  private
+    # Simulates a hand-edited export: an extra board_publications record with a
+    # fresh id but a key copied from another record in the same export.
+    def duplicate_publication_key_in(export_tempfile)
+      tampered = Tempfile.new([ "tampered_export", ".zip" ])
+      tampered.binmode
+
+      File.open(export_tempfile.path, "rb") do |file|
+        reader = ZipFile::Reader.new(file)
+        writer = ZipFile::Writer.new(tampered)
+
+        reader.glob("*").reject { |name| name.end_with?("/") }.each do |entry|
+          writer.add_file(entry, reader.read(entry))
+        end
+
+        publication_file = reader.glob("data/board_publications/*.json").first
+        publication_data = JSON.parse(reader.read(publication_file))
+        publication_data["id"] = ActiveRecord::Type::Uuid.generate
+        writer.add_file("data/board_publications/#{publication_data['id']}.json", publication_data.to_json)
+
+        writer.close
+      end
+
+      tampered.rewind
+      tampered
+    end
 end

--- a/test/jobs/account/data_import_job_test.rb
+++ b/test/jobs/account/data_import_job_test.rb
@@ -28,6 +28,35 @@ class Account::DataImportJobTest < ActiveJob::TestCase
     export_tempfile&.unlink
   end
 
+  test "resumes the continuation when a transient error is raised after advancing" do
+    source_account = accounts("37s")
+    exporter = users(:david)
+    identity = exporter.identity
+
+    export = Account::Export.create!(account: source_account, user: exporter)
+    export.build
+
+    export_tempfile = Tempfile.new([ "export", ".zip" ])
+    export.file.open { |f| FileUtils.cp(f.path, export_tempfile.path) }
+
+    source_account.destroy!
+
+    target_account = Account.create_with_owner(account: { name: "Import Test" }, owner: { identity: identity, name: exporter.name })
+    import = Account::Import.create!(identity: identity, account: target_account)
+    Current.set(account: target_account) do
+      import.file.attach(io: File.open(export_tempfile.path), filename: "export.zip", content_type: "application/zip")
+    end
+
+    Account::Import.any_instance.stubs(:process).raises(Errno::ECONNRESET)
+
+    assert_enqueued_with(job: Account::DataImportJob) do
+      Account::DataImportJob.perform_now(import)
+    end
+  ensure
+    export_tempfile&.close
+    export_tempfile&.unlink
+  end
+
   test "discards the job and marks the import failed_due_to_conflict when a crafted export duplicates a unique key" do
     source_account = accounts("37s")
     exporter = users(:david)

--- a/test/jobs/account/data_import_job_test.rb
+++ b/test/jobs/account/data_import_job_test.rb
@@ -52,7 +52,9 @@ class Account::DataImportJobTest < ActiveJob::TestCase
     end
 
     assert_nothing_raised do
-      Account::DataImportJob.perform_now(import)
+      assert_no_enqueued_jobs only: Account::DataImportJob do
+        Account::DataImportJob.perform_now(import)
+      end
     end
 
     assert import.reload.failed_due_to_conflict?

--- a/test/models/account/data_transfer/record_set_test.rb
+++ b/test/models/account/data_transfer/record_set_test.rb
@@ -73,6 +73,17 @@ class Account::DataTransfer::RecordSetTest < ActiveSupport::TestCase
     assert_match(/appears more than once/i, error.message)
   end
 
+  test "check rejects a blank unique key" do
+    publication_data = build_publication_data(key: nil)
+
+    error = assert_raises(Account::DataTransfer::RecordSet::IntegrityError) do
+      publication_record_set.check(from: build_reader(dir: "board_publications", data: publication_data))
+    end
+
+    assert_match(/key must be present/i, error.message)
+    assert_not error.is_a?(Account::DataTransfer::RecordSet::ConflictError)
+  end
+
   test "check accepts a fresh unique key" do
     boards(:writebook).create_publication!
     publication_data = build_publication_data(key: SecureRandom.base58(24))

--- a/test/models/account/data_transfer/record_set_test.rb
+++ b/test/models/account/data_transfer/record_set_test.rb
@@ -51,6 +51,37 @@ class Account::DataTransfer::RecordSetTest < ActiveSupport::TestCase
     end
   end
 
+  test "check rejects a unique key that already exists in the destination database" do
+    existing = boards(:writebook).create_publication!
+    publication_data = build_publication_data(key: existing.key)
+
+    error = assert_raises(Account::DataTransfer::RecordSet::ConflictError) do
+      publication_record_set.check(from: build_reader(dir: "board_publications", data: publication_data))
+    end
+
+    assert_match(/key .* already exists/i, error.message)
+  end
+
+  test "check rejects a unique key that repeats within the export" do
+    key = SecureRandom.base58(24)
+    publication_data = [ build_publication_data(key: key), build_publication_data(key: key) ]
+
+    error = assert_raises(Account::DataTransfer::RecordSet::ConflictError) do
+      publication_record_set.check(from: build_reader(dir: "board_publications", data: publication_data))
+    end
+
+    assert_match(/appears more than once/i, error.message)
+  end
+
+  test "check accepts a fresh unique key" do
+    boards(:writebook).create_publication!
+    publication_data = build_publication_data(key: SecureRandom.base58(24))
+
+    assert_nothing_raised do
+      publication_record_set.check(from: build_reader(dir: "board_publications", data: publication_data))
+    end
+  end
+
   private
     def importing_account
       @importing_account ||= Account.create!(name: "Importing Account", external_account_id: 99999999)
@@ -71,12 +102,29 @@ class Account::DataTransfer::RecordSetTest < ActiveSupport::TestCase
       }
     end
 
+    def publication_record_set
+      Account::DataTransfer::RecordSet.new(account: importing_account, model: Board::Publication, unique_keys: %w[ key ])
+    end
+
+    def build_publication_data(key:)
+      {
+        "id" => ActiveRecord::Type::Uuid.generate,
+        "account_id" => ActiveRecord::Type::Uuid.generate,
+        "board_id" => ActiveRecord::Type::Uuid.generate,
+        "key" => key,
+        "created_at" => Time.current.iso8601,
+        "updated_at" => Time.current.iso8601
+      }
+    end
+
     def build_reader(dir:, data:)
       tempfile = Tempfile.new([ "import_test", ".zip" ])
       tempfile.binmode
 
       writer = ZipFile::Writer.new(tempfile)
-      writer.add_file("data/#{dir}/#{data['id']}.json", data.to_json)
+      Array.wrap(data).each do |record_data|
+        writer.add_file("data/#{dir}/#{record_data['id']}.json", record_data.to_json)
+      end
       writer.close
       tempfile.rewind
 

--- a/test/models/account/data_transfer/record_set_test.rb
+++ b/test/models/account/data_transfer/record_set_test.rb
@@ -105,6 +105,26 @@ class Account::DataTransfer::RecordSetTest < ActiveSupport::TestCase
     assert_not Board::Publication.exists?(id: publication_data["id"])
   end
 
+  test "import converts a constraint violation raised by an overridden import_batch to a conflict error" do
+    existing = boards(:writebook).create_publication!
+    publication_data = build_publication_data(key: existing.key)
+
+    subclass = Class.new(Account::DataTransfer::RecordSet) do
+      private
+        def import_batch(files)
+          batch_data = files.map { |file| load(file).merge("account_id" => account.id) }
+          model.insert_all!(batch_data)
+        end
+    end
+    record_set = subclass.new(account: importing_account, model: Board::Publication, unique_keys: %w[ key ])
+
+    error = assert_raises(Account::DataTransfer::RecordSet::ConflictError) do
+      record_set.import(from: build_reader(dir: "board_publications", data: publication_data))
+    end
+
+    assert_match(/uniqueness constraint/i, error.message)
+  end
+
   test "import inserts a publication when its key is unique" do
     publication_data = build_publication_data(key: SecureRandom.base58(24))
 

--- a/test/models/account/data_transfer/record_set_test.rb
+++ b/test/models/account/data_transfer/record_set_test.rb
@@ -82,6 +82,26 @@ class Account::DataTransfer::RecordSetTest < ActiveSupport::TestCase
     end
   end
 
+  test "import converts a duplicate-key constraint violation to a conflict error" do
+    existing = boards(:writebook).create_publication!
+    publication_data = build_publication_data(key: existing.key)
+
+    error = assert_raises(Account::DataTransfer::RecordSet::ConflictError) do
+      publication_record_set.import(from: build_reader(dir: "board_publications", data: publication_data))
+    end
+
+    assert_match(/uniqueness constraint/i, error.message)
+    assert_not Board::Publication.exists?(id: publication_data["id"])
+  end
+
+  test "import inserts a publication when its key is unique" do
+    publication_data = build_publication_data(key: SecureRandom.base58(24))
+
+    publication_record_set.import(from: build_reader(dir: "board_publications", data: publication_data))
+
+    assert Board::Publication.exists?(id: publication_data["id"], key: publication_data["key"])
+  end
+
   private
     def importing_account
       @importing_account ||= Account.create!(name: "Importing Account", external_account_id: 99999999)


### PR DESCRIPTION
## Context

Second occurrence of a crafted account-import probe: an edited export zip carrying a `board_publications` record with a fresh id but a `key` that already exists under the global unique index ([on-call card](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10238722333), [July precedent](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10098281769), Sentry [FIZZY-VA](https://37signals.sentry.io/issues/?query=FIZZY-VA)).

The import pre-flight validates record ids and `belongs_to` ids, but never secondary unique keys — and `RecordSet#import_batch` preserves `key` verbatim via `insert_all!`. So the probe sailed through `check`, blew up mid-`process` with an unhandled `ActiveRecord::RecordNotUnique` (Trilogy 1062), and left a failed job in the queue plus an auto-filed card — even though the constraint correctly protected the data. The two Sentry events for the single job are the original failure plus an `ActiveJob::Continuable` resumption re-raising the same error.

## Change

Four legs, one per commit:

1. **Pre-flight** ([`725236a33`](https://github.com/basecamp/fizzy/commit/725236a33)): record sets can declare `unique_keys` columns. The `check` step raises `ConflictError` when a declared key already exists in the destination database or repeats within the export — so crafted imports fail as `failed_due_to_conflict`, the established graceful path (user emailed, job discarded via `discard_on IntegrityError`). Declared for `Board::Publication#key`, the only import-preserved secondary unique key.
2. **Rescue belt** ([`58e37c0b4`](https://github.com/basecamp/fizzy/commit/58e37c0b4)): `import_batch` converts `ActiveRecord::RecordNotUnique` into `ConflictError`, covering anything the pre-flight can't see — e.g. an undeclared unique key, or a check pass resumed from a cursor that no longer remembers the first in-zip occurrence.
3. **Terminal failure** ([`859fba292`](https://github.com/basecamp/fizzy/commit/859fba292)): `Continuable` resumes any `StandardError` raised after the step cursor advanced (`resume_errors_after_advancing` defaults to true), so conflict errors were re-enqueued instead of reaching `discard_on` — re-marking the failed import as processing and re-emailing the user per resumption. Import errors are terminal; they now propagate to the failure handlers. Deploy interruptions still resume via `Continuation::Interrupt`, which bypasses this setting.

4. **Blank keys** ([`1b8df1070`](https://github.com/basecamp/fizzy/commit/1b8df1070), from review): a null key evades both guards — the pre-flight skipped absent values and MySQL unique indexes admit multiple NULLs — while `insert_all!` bypasses `has_secure_token`. A declared unique key must now be present; blank fails as `invalid_export`.

Deliberately not mirrored in the pre-flight: MySQL's `utf8mb4_0900_ai_ci` collation is case/accent-insensitive while the in-zip seen-set compares exact bytes. Ruby can't replicate the collation faithfully, so a collation-variant duplicate falls through to the rescue belt, which handles it identically (single clean conflict failure).

## Tests

- Pre-flight: destination-DB key collision and in-zip key repetition each raise `ConflictError`; a fresh key passes (non-vacuity).
- Rescue: a forced duplicate-key `insert_all!` converts to `ConflictError`; a clean publication import inserts.
- End-to-end: a real export tampered with a duplicated publication key runs through `Account::DataImportJob.perform_now` without raising, marks the import `failed_due_to_conflict`, and enqueues no continuation job. Mutation-checked: with `resume_errors_after_advancing = false` removed, the test fails on the enqueued continuation.

`bin/ci` green: 48 checks including SQLite + system suites, Brakeman, RuboCop, signoff.
