### PR TITLE
Authorize the destination board's ACL mutation on card moves

### DIFF
--- a/app/models/card/accessible.rb
+++ b/app/models/card/accessible.rb
@@ -17,7 +17,7 @@ module Card::Accessible
 
   private
     def grant_access_to_assignees
-      board.accesses.grant_to(assignees)
+      board.accesses.grant_to(assignees) if Current.user&.can_administer_board?(board)
     end
 
     def clean_inaccessible_data_later

--- a/test/models/card_test.rb
+++ b/test/models/card_test.rb
@@ -114,16 +114,34 @@ class CardTest < ActiveSupport::TestCase
     end
   end
 
-  test "grants access to assignees when moved to a new board" do
+  test "grants access to assignees when an authorized mover moves the card to a new board" do
+    Current.session = sessions(:kevin) # kevin can administer the private board (its creator)
     card = cards(:logo)
-    assignee = users(:david)
-    card.toggle_assignment(assignee)
-
+    assignee = users(:jz) # already assigned to the card via fixtures, no access to the private board
     board = boards(:private)
-    assert_not_includes board.users, assignee
+
+    assert Current.user.can_administer_board?(board)
+    assert_includes card.assignees, assignee
+    assert_not board.accessible_to?(assignee)
 
     card.update!(board: board)
     assert_includes board.users.reload, assignee
+  end
+
+  test "does not grant board access to assignees when the mover cannot administer the destination board" do
+    Current.session = sessions(:david) # david is a plain member: not an admin and not the private board's creator
+    card = cards(:logo)
+    assignee = users(:jz) # already assigned to the card via fixtures, no access to the private board
+    board = boards(:private)
+
+    assert_not Current.user.can_administer_board?(board)
+    assert_includes card.assignees, assignee
+    assert_not board.accessible_to?(assignee)
+
+    card.update!(board: board)
+
+    assert_not_includes board.users.reload, assignee,
+      "a non-administering mover must not grant a user access to a private board via a card move"
   end
 
   test "move cards to a different board" do

--- a/test/models/card_test.rb
+++ b/test/models/card_test.rb
@@ -114,13 +114,16 @@ class CardTest < ActiveSupport::TestCase
     end
   end
 
-  test "grants access to assignees when an authorized mover moves the card to a new board" do
-    Current.session = sessions(:kevin) # kevin can administer the private board (its creator)
+  test "an admin mover grants access to assignees when moving the card to a new board" do
+    board = accounts("37s").boards.create!(name: "David's board", creator: users(:david), all_access: false)
+    board.accesses.grant_to(users(:kevin)) # kevin can reach the board, but did not create it
+    Current.session = sessions(:kevin) # admin, and a member of both the source and destination boards
     card = cards(:logo)
-    assignee = users(:jz) # already assigned to the card via fixtures, no access to the private board
-    board = boards(:private)
+    assignee = users(:jz) # already assigned to the card via fixtures, no access to the destination board
 
-    assert Current.user.can_administer_board?(board)
+    assert Current.user.admin?
+    assert_not_equal Current.user, board.creator # authorized through the admin role, not the creator path
+    assert board.accessible_to?(users(:kevin))
     assert_includes card.assignees, assignee
     assert_not board.accessible_to?(assignee)
 
@@ -128,12 +131,29 @@ class CardTest < ActiveSupport::TestCase
     assert_includes board.users.reload, assignee
   end
 
-  test "does not grant board access to assignees when the mover cannot administer the destination board" do
-    Current.session = sessions(:david) # david is a plain member: not an admin and not the private board's creator
+  test "a non-admin board creator grants access to assignees when moving the card to a new board" do
+    Current.session = sessions(:david) # plain member, but the creator of the destination board
+    board = accounts("37s").boards.create!(name: "David's board", creator: users(:david), all_access: false)
+    card = cards(:logo)
+    assignee = users(:jz) # already assigned to the card via fixtures, no access to the new board
+
+    assert_not Current.user.admin?
+    assert Current.user.can_administer_board?(board) # authorized through the creator path, not the admin role
+    assert_includes card.assignees, assignee
+    assert_not board.accessible_to?(assignee)
+
+    card.update!(board: board)
+    assert_includes board.users.reload, assignee
+  end
+
+  test "a member with mere board access does not grant assignees access when moving the card" do
+    Current.session = sessions(:david) # plain member: not an admin and not the private board's creator
+    board = boards(:private)
+    board.accesses.grant_to(users(:david)) # david holds mere access to the private board, not administration rights
     card = cards(:logo)
     assignee = users(:jz) # already assigned to the card via fixtures, no access to the private board
-    board = boards(:private)
 
+    assert board.accessible_to?(users(:david))
     assert_not Current.user.can_administer_board?(board)
     assert_includes card.assignees, assignee
     assert_not board.accessible_to?(assignee)
@@ -141,7 +161,7 @@ class CardTest < ActiveSupport::TestCase
     card.update!(board: board)
 
     assert_not_includes board.users.reload, assignee,
-      "a non-administering mover must not grant a user access to a private board via a card move"
+      "a member with mere board access must not grant others access to a private board via a card move"
   end
 
   test "move cards to a different board" do


### PR DESCRIPTION
## Problem

Moving a card to a private board silently grants the card's assignees access to that board. `Card#handle_board_change` fires on a board change and runs:

```ruby
grant_access_to_assignees unless board.all_access?
# => board.accesses.grant_to(assignees)
```

This mutated the destination board's access list **unconditionally** — with no check on whether the person moving the card is allowed to manage that board's membership. Any user with mere *access* to a private board (not administration rights) could therefore add arbitrary users to it: assign users to a card, move the card onto the board, and those users receive an `Access` row.

The assignable set is not naturally narrow, so this cannot be bounded by "you can only assign people you already share a board with": any user can create an `all_access` board (`BoardsController#create` has no authorization gate and defaults `all_access: true`), which grants every active account user an `Access` row and makes the whole account assignable. The effective reach is account-wide.

This bypasses the authorization that the dedicated access-management path enforces: `BoardsController#update` gates `accesses.revise` behind `ensure_permission_to_admin_board` (`can_administer_board?`). The card-move path reached the same ACL mutation without that gate.

## Root cause

The implicit grant was introduced in `fdc90eb5386e42e96f5723aaf123a0573d243b8a` ("Grant access to assignees when changing collections"), which added the assignee grant to the board-change callback without an authorization check on the actor.

## Fix

Gate the grant on the acting user's authority over the destination board, using the same predicate the sanctioned ACL path uses:

```ruby
def grant_access_to_assignees
  board.accesses.grant_to(assignees) if Current.user&.can_administer_board?(board)
end
```

`can_administer_board?` is `admin? || board.creator == self` — identical to `ensure_permission_to_admin_board`. An administering mover (account admin/owner, or the board's creator) still brings assignees along, exactly as before. A non-administering mover no longer expands a private board's membership. The `Current.user&.` guard fails closed in any context without a current user (import already skips this callback; no background/system flow moves cards expecting an implicit grant).

This is the only non-admin-reachable ACL mutation targeting an *existing* private board — every other `Access`-writing sink is admin-gated (`accesses.revise`), creation-scoped (`grant_access_to_creator`), or restricted to `all_access` boards (`grant_access_to_everyone`, new-user provisioning).

## Test

`test/models/card_test.rb`:

- **Regression** — a plain member moving an assigned card onto a private board they cannot administer does **not** grant the assignee access. Fails before this change (assignee is granted), passes after.
- **Preserved behavior** — an authorized mover (the board's creator) moving the same card still grants the assignee access.

The pre-existing "grants access to assignees when moved to a new board" test was rewritten as the authorized case; it had been asserting the vulnerable behavior (a non-administering actor performing the grant).

## Verification

- Regression test confirmed red on the unpatched method, green after.
- Related model + controller suites (cards, boards, access, assignments) green: 80 tests, 455 assertions, 0 failures.
- Adversarial review (external) found no bypass, missed sink, fail-open path, or vacuous test.
- Scanned for credentials/PII before posting — none.

## Out of scope (separate design question)

`BoardsController#create` has no authorization gate and defaults `all_access: true`, so any unprivileged user can mint an account-wide board. That is the enabling primitive for widening the assignable set, but it is a product/design question (should members create account-wide containers?) claimed by neither report and independent of this ACL-bypass fix. Flagged for a separate decision rather than folded in here.