### PR TITLE
Suppress phantom parent routes for columns/cards

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
   end
 
   namespace :columns do
-    resources :cards do
+    resources :cards, only: [] do
       scope module: :cards do
         namespace :drops do
           resource :not_now

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -12,4 +12,17 @@ class RouteTest < ActionDispatch::IntegrationTest
   test "account/entropy" do
     assert_recognizes({ controller: "account/entropies", action: "show" }, "/account/entropy")
   end
+
+  test "columns/cards exposes no parent routes" do
+    assert_empty Rails.application.routes.routes.select { |route| route.defaults[:controller] == "columns/cards" }
+
+    error = assert_raises ActionController::RoutingError do
+      Rails.application.routes.recognize_path("/columns/cards/123", method: :get)
+    end
+    assert_match /No route matches/, error.message
+  end
+
+  test "columns/cards/drops routes remain nested under cards" do
+    assert_recognizes({ controller: "columns/cards/drops/columns", action: "create", card_id: "123" }, { path: "/columns/cards/123/drops/column", method: :post })
+  end
 end


### PR DESCRIPTION
## Symptom

`GET /:slug/columns/cards/:id` returns 500 instead of 404. Probers id-fuzzing these paths trip it regularly (Sentry FIZZY-SN, 16 events since June).

## Root cause

The `columns` namespace declares `resources :cards` solely to nest the four `Columns::Cards::Drops::*` controllers, but without `only: []` Rails also generates the seven parent RESTful routes targeting `Columns::CardsController` — a constant that has never existed. Requests matching those routes dispatch to the missing constant and raise at controller resolution, surfacing as a 500 where a routing 404 is correct. Introduced already-broken in aa9d7664e (#1174); day-one defect, not a regression.

## Fix

`resources :cards, only: []` — suppresses the seven phantom parent routes while leaving the nested `/columns/cards/:card_id/drops/*` routes and their helpers unchanged. No call sites use the parent `columns_card(s)_*` helpers; the drops controllers and board views use only the nested `columns_card_drops_*` helpers.

## Tests

- New routing test asserting no route targets `columns/cards` and that `/columns/cards/123` raises a genuine "No route matches" `RoutingError` (pre-fix it raised the missing-controller variant, so the assertion fails without the fix — verified).
- Positive companion asserting the nested drops routes still recognize.
- `test/controllers/columns` + `boards_controller_test.rb`: 45 tests, 275 assertions, green.