### PR TITLE
Guard the my/access_tokens back link against untenanted renders

### DIFF
--- a/app/views/my/access_tokens/index.html.erb
+++ b/app/views/my/access_tokens/index.html.erb
@@ -2,7 +2,11 @@
 
 <% content_for :header do %>
   <div class="header__actions header__actions--start">
-    <%= back_link_to "My profile", user_path(Current.user), "keydown.left@document->hotkey#click keydown.esc@document->hotkey#click" %>
+    <% if Current.user %>
+      <%= back_link_to "My profile", user_path(Current.user), "keydown.left@document->hotkey#click keydown.esc@document->hotkey#click" %>
+    <% else %>
+      <%= back_link_to "Menu", session_menu_path, "keydown.left@document->hotkey#click keydown.esc@document->hotkey#click" %>
+    <% end %>
   </div>
 
   <h1 class="header__title" data-bridge--title-target="header"><%= @page_title %></h1>

--- a/app/views/my/passkeys/index.html.erb
+++ b/app/views/my/passkeys/index.html.erb
@@ -2,7 +2,11 @@
 
 <% content_for :header do %>
   <div class="header__actions header__actions--start">
-    <%= back_link_to "My profile", user_path(Current.user), "keydown.left@document->hotkey#click keydown.esc@document->hotkey#click" %>
+    <% if Current.user %>
+      <%= back_link_to "My profile", user_path(Current.user), "keydown.left@document->hotkey#click keydown.esc@document->hotkey#click" %>
+    <% else %>
+      <%= back_link_to "Menu", session_menu_path, "keydown.left@document->hotkey#click keydown.esc@document->hotkey#click" %>
+    <% end %>
   </div>
 
   <h1 class="header__title" data-bridge--title-target="header"><%= @page_title %></h1>

--- a/test/controllers/my/access_tokens_controller_test.rb
+++ b/test/controllers/my/access_tokens_controller_test.rb
@@ -5,9 +5,22 @@ class My::AccessTokensControllerTest < ActionDispatch::IntegrationTest
     sign_in_as :kevin
   end
 
+  test "index renders untenanted" do
+    identities(:kevin).access_tokens.create!(description: "Fizzy CLI", permission: "read")
+
+    untenanted do
+      get my_access_tokens_path
+
+      assert_response :success
+      assert_in_body session_menu_path
+      assert_not_in_body user_path(users(:kevin))
+    end
+  end
+
   test "create new token" do
     get my_access_tokens_path
     assert_response :success
+    assert_in_body user_path(users(:kevin))
 
     get new_my_access_token_path
     assert_response :success


### PR DESCRIPTION
### Symptom

A bare browser GET to `https://app.fizzy.do/my/access_tokens` (no account slug) 500s with `ActionController::UrlGenerationError` — Sentry [FIZZY-PN](https://37signals.sentry.io/issues/FIZZY-PN/), firing since 2026-05-30.

### Root cause

723c8180b (#2675) added `skip_before_action :require_account` to `My::AccessTokensController` so identity-level bearer-token JSON calls could reach `/my/access_tokens` without an account slug. The skip is format-blind: a bare browser GET, which `require_account` previously redirected to the session menu, now renders `index.html.erb` inside `Current.without_account`. There `Current.user` derives to `nil` (`identity.users.find_by(account: nil)`), and the header's `back_link_to "My profile", user_path(Current.user)` raises `UrlGenerationError` (id: nil).

The untenanted path is the *only* path to this error: `Authorization#ensure_can_access_account` redirects any tenanted request whose `Current.user` isn't active, so a tenanted render always has a user. Every FIZZY-PN event is the bare URL; data is healthy.

### Fix

Guard the back link: with a user, the existing "My profile" link; without one, fall back to a "Menu" link to `session_menu_path` — the same destination `require_account` and `ensure_can_access_account` already redirect to, i.e. the canonical untenanted landing. The page is otherwise fully functional untenanted (tokens are identity-scoped).

`my/passkeys/index.html.erb` has the identical back link. It's unreachable untenanted today (`My::PasskeysController` doesn't skip `require_account`), so this is latent hardening: one copied `skip_before_action` would otherwise reproduce this exact bug. Untestable end-to-end for the same reason.

### Tests

- New `index renders untenanted`: signed-in HTML GET with no account prefix, with a token so the populated table renders; asserts 200, the menu fallback link, and no user link. Verified to fail without the fix with the exact production error (`UrlGenerationError` at `index.html.erb:5`).
- Existing tenanted index test now also asserts the "My profile" back link still renders.

`bin/rails test test/controllers/my/access_tokens_controller_test.rb test/controllers/my/passkeys_controller_test.rb`: 11 tests, 72 assertions, 0 failures.
