### PR TITLE
Answer 422 when a permanent cell verdict fails an on-demand representation

### DIFF
--- a/saas/lib/fizzy/saas/unprocessable_attachments.rb
+++ b/saas/lib/fizzy/saas/unprocessable_attachments.rb
@@ -4,9 +4,12 @@ module Fizzy
     # transform inside the record's after_commit, so a raise there 500s a POST that succeeded. There are
     # two immediate paths, and only one is a job — a direct-uploaded embed runs under
     # `CreateVariantsJob.perform_now`, which `discard_on` catches, while a form-uploaded io is varied
-    # before the blob is stored, so a rescue catches it there. Neither catches the transient class, which
-    # the client gem already retries. Both catches report, because they are where the raise stops;
-    # everywhere else it reaches Sentry on its own.
+    # before the blob is stored, so a rescue catches it there. A third path is a request of its own:
+    # the representation controllers process on demand, synchronously in `#show`, so a permanent verdict
+    # there 500s a GET for a file the cell will never convert — `rescue_from` on their shared base class
+    # (Redirect and Proxy both inherit it) answers 422 instead. None of the three catches the transient
+    # class, which the client gem already retries. Every catch reports, because it is where the raise
+    # stops; everywhere else it reaches Sentry on its own.
     module UnprocessableAttachments
       # Rails' own loop, with the rescue inside it rather than around it: one variant failing must not skip
       # the rest, and the loop's last line marks the variants as processed — miss it and Rails re-runs every
@@ -36,6 +39,11 @@ module Fizzy
 
         %w[ ActiveStorage::CreateVariantsJob ActiveStorage::TransformJob ].each do |job|
           job.constantize.discard_on Cell::UnprocessableAttachment, report: true
+        end
+
+        ActiveStorage::Representations::BaseController.rescue_from Cell::UnprocessableAttachment do |error|
+          Rails.error.report error, handled: true, severity: :info
+          head :unprocessable_entity
         end
       end
     end

--- a/saas/test/integration/unprocessable_representation_test.rb
+++ b/saas/test/integration/unprocessable_representation_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class Fizzy::Saas::UnprocessableRepresentationTest < ActionDispatch::IntegrationTest
+  setup do
+    Current.session = sessions(:david)
+    @blob = attach_blob_to_card(cards(:logo))
+    sign_in_as :david
+  end
+
+  test "a permanent verdict answers 422 rather than 500" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
+
+    get rails_representation_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+
+    assert_response :unprocessable_entity
+  end
+
+  test "the proxy route answers 422 too" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("unreadable")
+
+    get rails_storage_proxy_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+
+    assert_response :unprocessable_entity
+  end
+
+  test "a permanent verdict is reported once, as handled" do
+    transforms_raise Fizzy::Saas::Cell::UnprocessableAttachment.new("killed: fsize")
+    Rails.error.expects(:report)
+      .with { |error, handled:, severity:, **| error.is_a?(Fizzy::Saas::Cell::UnprocessableAttachment) && handled && severity == :info }.once
+
+    get rails_representation_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+  end
+
+  test "a transient failure is left to raise for the retry" do
+    transforms_raise Fizzy::Saas::Cell::ProcessingUnavailable.new("capacity")
+
+    assert_raises Fizzy::Saas::Cell::ProcessingUnavailable do
+      get rails_representation_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+    end
+  end
+
+  private
+    def transforms_raise(error)
+      ActiveStorage::Variation.any_instance.stubs(:transform).raises(error)
+    end
+
+    def attach_blob_to_card(card)
+      Current.with(session: sessions(:david)) do
+        card.image.attach io: file_fixture("moon.jpg").open, filename: "test.jpg", content_type: "image/jpeg"
+        card.image.blob
+      end
+    end
+end


### PR DESCRIPTION
## Symptom

Previews of certain PDFs 500 on every request (Sentry FIZZY-TY, 86 events since 08-14, transaction `ActiveStorage::Representations::RedirectController#show`): 68 are `killed: fsize` (PDFs over the cell's 256MB `RLIMIT_FSIZE` ceiling), 18 are `unreadable` (password-protected PDFs, which also 500'd pre-HotCell as `ActiveStorage::PreviewError`).

## Root cause

The HotCell rollout (#3034, fb0d146f5e41bfbe2a059685aa26013c59f92482) rescued `Cell::UnprocessableAttachment` on both save paths — the rescue inside `Attachment#process_immediate_variants_from_io` and `discard_on` for `CreateVariantsJob`/`TransformJob` — but the on-demand path is a request of its own: `ActiveStorage::Representations::BaseController#set_representation` calls `@blob.representation(...).processed` synchronously in-request and rescues only `InvalidSignature`, so a permanent verdict raised straight through to a 500.

## Fix

Extend `UnprocessableAttachments.install!` (already invoked from the engine's `to_prepare` initializer) with a `rescue_from` on `ActiveStorage::Representations::BaseController` — Redirect and Proxy both inherit it — answering `head :unprocessable_entity` and reporting the error as handled. This completes #3034's handling matrix: every place the raise stops, it reports. The transient class (`ProcessingUnavailable`) deliberately stays a raise: the client gem retries it, and a 5xx is the honest answer while the cell is unavailable.

## Tests

New `saas/test/integration/unprocessable_representation_test.rb`:
- permanent verdict → 422 on the redirect route (errors with the uncaught raise without the fix)
- permanent verdict → 422 on the proxy route (backs the BaseController-inheritance claim)
- exactly one `handled: true, severity: :info` report (reports `handled: false` without the fix — matching the Sentry evidence)
- transient verdict still raises, proving the rescue is scoped to the permanent class

Ran together with `saas/test/models/unprocessable_attachment_test.rb` and `test/integration/active_storage_authorization_test.rb`: 36 tests, 0 failures.

## Out of scope, on purpose

- A permanently doomed representation is still re-attempted per request (nothing negative-caches the 422, same as the 500 before it). The durable remedy is persisting the verdict against the blob, anticipated by the comment in `saas/lib/fizzy/saas/cell.rb` — left as a follow-up.
- Fizzy's authorization patch runs after `set_representation`, so the 422 (like the 500 before it) precedes the access check; reordering that layer is its own change.