### PR TITLE
Harden passkey/WebAuthn registration against malformed input

### DIFF
--- a/app/controllers/my/passkeys_controller.rb
+++ b/app/controllers/my/passkeys_controller.rb
@@ -12,6 +12,10 @@ class My::PasskeysController < ApplicationController
     passkey = Current.identity.passkeys.register(passkey_registration_params)
 
     redirect_to edit_my_passkey_path(passkey, created: true)
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to my_passkeys_path, alert: "That passkey is already registered."
+  rescue ActionPack::WebAuthn::Error
+    redirect_to my_passkeys_path, alert: "We couldn't register that passkey. Please try again."
   end
 
   def edit

--- a/db/migrate/20260825120000_widen_action_pack_passkeys_sign_count_to_bigint.rb
+++ b/db/migrate/20260825120000_widen_action_pack_passkeys_sign_count_to_bigint.rb
@@ -1,0 +1,10 @@
+class WidenActionPackPasskeysSignCountToBigint < ActiveRecord::Migration[8.2]
+  # WebAuthn signature counters are unsigned 32-bit integers (max 4294967295),
+  # but the column was created as a signed 4-byte INT (max 2147483647). A
+  # spec-legal high counter from a genuine authenticator overflows the column
+  # and raises ActiveModel::RangeError. Widen to bigint so the full uint32
+  # range persists and the replay/clone check compares real values.
+  def change
+    change_column :action_pack_passkeys, :sign_count, :bigint, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_28_120000) do
     t.string "holder_type", null: false
     t.string "name"
     t.binary "public_key", null: false
-    t.integer "sign_count", default: 0, null: false
+    t.bigint "sign_count", default: 0, null: false
     t.text "transports"
     t.datetime "updated_at", null: false
     t.index ["credential_id"], name: "index_action_pack_passkeys_on_credential_id", unique: true

--- a/db/schema_sqlite.rb
+++ b/db/schema_sqlite.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_28_120000) do
     t.string "holder_type", limit: 255, null: false
     t.string "name", limit: 255
     t.binary "public_key", null: false
-    t.integer "sign_count", default: 0, null: false
+    t.bigint "sign_count", default: 0, null: false
     t.text "transports", limit: 65535
     t.datetime "updated_at", null: false
     t.index ["credential_id"], name: "index_action_pack_passkeys_on_credential_id", unique: true

--- a/lib/action_pack/passkey.rb
+++ b/lib/action_pack/passkey.rb
@@ -86,7 +86,7 @@ class ActionPack::Passkey < Rails.configuration.action_pack.passkey.parent_class
     credential.authenticate(passkey)
     update!(sign_count: credential.sign_count, backed_up: credential.backed_up)
     self
-  rescue ActionPack::WebAuthn::InvalidResponseError
+  rescue ActionPack::WebAuthn::Error
     nil
   end
 

--- a/lib/action_pack/web_authn.rb
+++ b/lib/action_pack/web_authn.rb
@@ -30,11 +30,17 @@
 #   ActionPack::WebAuthn.register_attestation_verifier("packed", MyPackedVerifier.new)
 #
 module ActionPack::WebAuthn
-  class InvalidResponseError < StandardError; end
-  class InvalidCborError < StandardError; end
-  class InvalidKeyError < StandardError; end
-  class UnsupportedKeyTypeError < StandardError; end
-  class InvalidOptionsError < StandardError; end
+  # Base class for every error raised while parsing or verifying a WebAuthn
+  # ceremony response. Callers can rescue this single class to turn any
+  # malformed, unsupported, or failed-verification input into a 4xx response
+  # instead of letting it surface as an unhandled 500.
+  class Error < StandardError; end
+
+  class InvalidResponseError < Error; end
+  class InvalidCborError < Error; end
+  class InvalidKeyError < Error; end
+  class UnsupportedKeyTypeError < Error; end
+  class InvalidOptionsError < Error; end
 
   class << self
     # Returns a new RelyingParty configured from the current request context.

--- a/lib/action_pack/web_authn/authenticator/assertion_response.rb
+++ b/lib/action_pack/web_authn/authenticator/assertion_response.rb
@@ -39,7 +39,12 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponse < ActionPack::WebAu
   def initialize(credential:, authenticator_data:, signature:, **attributes)
     super(**attributes)
 
-    unless signature.is_a?(String) && authenticator_data.is_a?(String)
+    # A request delivers signature and authenticator_data as serialized Strings;
+    # reject scalars that would crash on #encoding before decoding. But
+    # Data.wrap also accepts an already-decoded Authenticator::Data (returned
+    # as-is), which library callers pass — keep that documented branch reachable.
+    unless signature.is_a?(String) &&
+        (authenticator_data.is_a?(String) || authenticator_data.is_a?(ActionPack::WebAuthn::Authenticator::Data))
       raise ActionPack::WebAuthn::InvalidResponseError, "Assertion response is missing or malformed"
     end
 

--- a/lib/action_pack/web_authn/authenticator/assertion_response.rb
+++ b/lib/action_pack/web_authn/authenticator/assertion_response.rb
@@ -38,6 +38,11 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponse < ActionPack::WebAu
 
   def initialize(credential:, authenticator_data:, signature:, **attributes)
     super(**attributes)
+
+    unless signature.is_a?(String) && authenticator_data.is_a?(String)
+      raise ActionPack::WebAuthn::InvalidResponseError, "Assertion response is missing or malformed"
+    end
+
     @credential = credential
     @signature = signature
     @signature = Base64.urlsafe_decode64(@signature) unless @signature.encoding == Encoding::BINARY

--- a/lib/action_pack/web_authn/authenticator/attestation.rb
+++ b/lib/action_pack/web_authn/authenticator/attestation.rb
@@ -47,7 +47,18 @@ class ActionPack::WebAuthn::Authenticator::Attestation
     if data.is_a?(self)
       data
     else
-      data = Base64.urlsafe_decode64(data) unless data.encoding == Encoding::BINARY
+      unless data.encoding == Encoding::BINARY
+        # Base64URL expands 3 bytes into 4 characters, so an encoded value whose
+        # decoded size would exceed the CBOR byte limit is rejected before
+        # Base64.urlsafe_decode64 allocates the decoded copy.
+        max_encoded = ActionPack::WebAuthn::CborDecoder::MAX_SIZE / 3 * 4 + 4
+        if data.bytesize > max_encoded
+          raise ActionPack::WebAuthn::InvalidResponseError, "Attestation object is too large"
+        end
+
+        data = Base64.urlsafe_decode64(data)
+      end
+
       decode(data)
     end
   rescue ArgumentError

--- a/lib/action_pack/web_authn/authenticator/attestation.rb
+++ b/lib/action_pack/web_authn/authenticator/attestation.rb
@@ -58,6 +58,10 @@ class ActionPack::WebAuthn::Authenticator::Attestation
   def self.decode(bytes)
     cbor = ActionPack::WebAuthn::CborDecoder.decode(bytes)
 
+    unless cbor.is_a?(Hash) && cbor["authData"].is_a?(String)
+      raise ActionPack::WebAuthn::InvalidResponseError, "Malformed attestation object"
+    end
+
     new(
       authenticator_data: ActionPack::WebAuthn::Authenticator::Data.decode(cbor["authData"]),
       format: cbor["fmt"],

--- a/lib/action_pack/web_authn/authenticator/attestation_response.rb
+++ b/lib/action_pack/web_authn/authenticator/attestation_response.rb
@@ -36,7 +36,13 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponse < ActionPack::Web
   def initialize(attestation_object:, **attributes)
     super(**attributes)
 
-    unless attestation_object.is_a?(String)
+    # A request-supplied attestation object arrives as a serialized String, and
+    # strong parameters may deliver a scalar (e.g. a number) that would crash on
+    # #encoding before decoding — reject those here. But Attestation.wrap also
+    # accepts an already-decoded Attestation (returned as-is), which library
+    # callers pass when constructing a response for a custom verifier; keep that
+    # documented branch reachable.
+    unless attestation_object.is_a?(String) || attestation_object.is_a?(ActionPack::WebAuthn::Authenticator::Attestation)
       raise ActionPack::WebAuthn::InvalidResponseError, "Attestation object is missing or malformed"
     end
 

--- a/lib/action_pack/web_authn/authenticator/attestation_response.rb
+++ b/lib/action_pack/web_authn/authenticator/attestation_response.rb
@@ -30,10 +30,16 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponse < ActionPack::Web
   attr_reader :attestation_object
 
   validate :client_data_type_must_be_create
+  validate :attested_credential_data_must_be_present
   validate :attestation_must_be_valid
 
   def initialize(attestation_object:, **attributes)
     super(**attributes)
+
+    unless attestation_object.is_a?(String)
+      raise ActionPack::WebAuthn::InvalidResponseError, "Attestation object is missing or malformed"
+    end
+
     @attestation_object = attestation_object
   end
 
@@ -56,6 +62,15 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponse < ActionPack::Web
     def client_data_type_must_be_create
       unless client_data["type"] == "webauthn.create"
         errors.add(:base, "Client data type is not webauthn.create")
+      end
+    end
+
+    def attested_credential_data_must_be_present
+      # A registration attestation must carry attested credential data (the AT
+      # flag). Without it credential_id/public_key are nil and persistence would
+      # crash; treat it as a malformed registration response.
+      if attestation.credential_id.nil? || attestation.public_key_bytes.nil?
+        errors.add(:base, "Attested credential data is missing")
       end
     end
 

--- a/lib/action_pack/web_authn/authenticator/data.rb
+++ b/lib/action_pack/web_authn/authenticator/data.rb
@@ -66,7 +66,19 @@ class ActionPack::WebAuthn::Authenticator::Data
       if data.is_a?(self)
         data
       else
-        data = Base64.urlsafe_decode64(data) unless data.encoding == Encoding::BINARY
+        unless data.encoding == Encoding::BINARY
+          # Reject before Base64.urlsafe_decode64 allocates the decoded copy: an
+          # encoded value larger than the byte ceiling can only decode to an
+          # oversized blob. Authenticator data is small, so this only bounds the
+          # allocation an attacker-controlled string would otherwise force.
+          max_encoded = ActionPack::WebAuthn::CborDecoder::MAX_SIZE / 3 * 4 + 4
+          if data.bytesize > max_encoded
+            raise ActionPack::WebAuthn::InvalidResponseError, "Authenticator data is too large"
+          end
+
+          data = Base64.urlsafe_decode64(data)
+        end
+
         decode(data)
       end
     rescue ArgumentError

--- a/lib/action_pack/web_authn/authenticator/response.rb
+++ b/lib/action_pack/web_authn/authenticator/response.rb
@@ -62,9 +62,15 @@ class ActionPack::WebAuthn::Authenticator::Response
   end
 
   # Parses the client data JSON string into a Hash. Raises
-  # +InvalidResponseError+ if the JSON is malformed.
+  # +InvalidResponseError+ if the JSON is malformed or is not a JSON object
+  # (anything other than an object would break the field lookups below with an
+  # uncaught TypeError).
   def client_data
-    @client_data ||= JSON.parse(client_data_json)
+    @client_data ||= JSON.parse(client_data_json).tap do |parsed|
+      unless parsed.is_a?(Hash)
+        raise ActionPack::WebAuthn::InvalidResponseError, "Client data is not a JSON object"
+      end
+    end
   rescue JSON::ParserError
     raise ActionPack::WebAuthn::InvalidResponseError, "Client data is not valid JSON"
   end
@@ -83,7 +89,16 @@ class ActionPack::WebAuthn::Authenticator::Response
     def challenge_must_not_be_expired
       return if errors.any?
 
-      signed_message = Base64.urlsafe_decode64(client_data["challenge"])
+      challenge = client_data["challenge"]
+
+      # A non-string challenge (object/array/number) would blow up Base64
+      # decoding with an uncaught error; reject it as invalid.
+      unless challenge.is_a?(String)
+        errors.add(:base, "Challenge is invalid")
+        return
+      end
+
+      signed_message = Base64.urlsafe_decode64(challenge)
 
       unless ActionPack::WebAuthn.challenge_verifier.verified(signed_message, purpose: challenge_purpose)
         errors.add(:base, "Challenge has expired")
@@ -113,7 +128,9 @@ class ActionPack::WebAuthn::Authenticator::Response
     end
 
     def must_not_have_token_binding
-      if client_data.dig("tokenBinding", "status") == "present"
+      token_binding = client_data["tokenBinding"]
+
+      if token_binding.is_a?(Hash) && token_binding["status"] == "present"
         errors.add(:base, "Token binding is not supported")
       end
     end

--- a/lib/action_pack/web_authn/authenticator/response.rb
+++ b/lib/action_pack/web_authn/authenticator/response.rb
@@ -45,6 +45,13 @@ class ActionPack::WebAuthn::Authenticator::Response
   validate :user_must_be_verified_when_required
 
   def initialize(client_data_json:, origin: nil, user_verification: :preferred)
+    # Strong parameters permit scalars, so a JSON request body can deliver a
+    # non-string here (e.g. a number or object). Reject it at the boundary
+    # rather than crashing later on JSON.parse/#encoding with an uncaught error.
+    unless client_data_json.is_a?(String)
+      raise ActionPack::WebAuthn::InvalidResponseError, "Client data is missing or malformed"
+    end
+
     @client_data_json = client_data_json
     @origin = origin
     @user_verification = user_verification.to_sym

--- a/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/lib/action_pack/web_authn/cbor_decoder.rb
@@ -101,9 +101,16 @@ class ActionPack::WebAuthn::CborDecoder
     #
     #   ActionPack::WebAuthn::CborDecoder.decode("\xa2\x61a\x01\x61b\x02")
     #   # => {"a" => 1, "b" => 2}
-    def decode(bytes, **args)
+    def decode(bytes, max_size: MAX_SIZE, **args)
+      # Enforce the size limit before String#bytes materializes an array with
+      # one slot per byte (~8x the input on a 64-bit VM). Otherwise a huge
+      # string balloons memory before the initializer's length check rejects it.
+      if bytes.respond_to?(:bytesize) && bytes.bytesize > max_size
+        raise ActionPack::WebAuthn::InvalidCborError, "Input exceeds maximum size"
+      end
+
       bytes = bytes.bytes if bytes.respond_to?(:bytes)
-      new(bytes, **args).decode
+      new(bytes, max_size: max_size, **args).decode
     end
   end
 

--- a/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/lib/action_pack/web_authn/cbor_decoder.rb
@@ -159,15 +159,7 @@ class ActionPack::WebAuthn::CborDecoder
 
     def decode_byte_string
       if indefinite_length?
-        # Charge each chunk: an indefinite byte string is a stream of chunks,
-        # so a flood of empty 0x40 chunks would otherwise iterate and allocate
-        # without touching the array/map budget.
-        String.new(encoding: Encoding::ASCII_8BIT).tap do |str|
-          until break_code?
-            charge_element
-            str << decode_byte_string
-          end
-        end
+        read_indefinite_string(BYTE_STRING_TYPE, Encoding::ASCII_8BIT)
       else
         read_bytes(read_argument).pack("C*")
       end
@@ -175,14 +167,29 @@ class ActionPack::WebAuthn::CborDecoder
 
     def decode_text_string
       if indefinite_length?
-        String.new(encoding: Encoding::UTF_8).tap do |str|
-          until break_code?
-            charge_element
-            str << decode_text_string
-          end
-        end
+        read_indefinite_string(TEXT_STRING_TYPE, Encoding::UTF_8)
       else
         read_bytes(read_argument).pack("C*").force_encoding(Encoding::UTF_8)
+      end
+    end
+
+    # Assembles an indefinite-length string from its chunks. RFC 8949 requires
+    # every chunk to be a definite-length string of the same major type, so read
+    # each one inline rather than recursing: a nested indefinite marker (or any
+    # other item) is rejected, which also removes the unbounded recursion that
+    # would otherwise overflow the stack before MAX_DEPTH or the element budget
+    # could intervene. Each chunk is charged so a flood of empty chunks is bound.
+    def read_indefinite_string(major, encoding)
+      String.new(encoding: encoding).tap do |str|
+        until break_code?
+          charge_element
+
+          unless major_type == major && additional_info(consume: false) != INDEFINITE_LENGTH_MAJOR_TYPE
+            raise ActionPack::WebAuthn::InvalidCborError, "Indefinite-length string chunk must be a definite-length string of the same type"
+          end
+
+          str << read_bytes(read_argument).pack("C*").force_encoding(encoding)
+        end
       end
     end
 

--- a/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/lib/action_pack/web_authn/cbor_decoder.rb
@@ -166,7 +166,11 @@ class ActionPack::WebAuthn::CborDecoder
       if indefinite_length?
         Array.new.tap { |arr| arr << decode until break_code? }
       else
-        Array.new(read_argument) { decode }
+        # Build incrementally rather than Array.new(count) { ... }: a declared
+        # count must not pre-size the backing store. read_length caps the count
+        # at the remaining bytes, and nested containers still exhaust the input
+        # (and hit the depth limit) before the array can grow large.
+        Array.new.tap { |arr| read_length.times { arr << decode } }
       end
     end
 
@@ -175,7 +179,7 @@ class ActionPack::WebAuthn::CborDecoder
         Hash.new.tap { |hash| hash[decode] = decode until break_code? }
       else
         Hash.new.tap do |hash|
-          read_argument.times do
+          read_length.times do
             hash[decode] = decode
           end
         end
@@ -249,6 +253,22 @@ class ActionPack::WebAuthn::CborDecoder
 
     def break_code?
       read_byte if peek == BREAK_CODE
+    end
+
+    # Reads a definite-length container's element count and rejects any count
+    # that exceeds the number of bytes left to read. Every CBOR data item
+    # occupies at least one byte, so a well-formed array or map can never
+    # declare more elements than there are remaining bytes. Without this bound
+    # a tiny input can name a multi-billion element array (e.g. 0x9a ff ff ff
+    # ff) and drive an out-of-memory pre-allocation before decoding begins.
+    def read_length
+      length = read_argument
+
+      if length > @bytes.length - @position
+        raise ActionPack::WebAuthn::InvalidCborError, "Declared length exceeds remaining input"
+      end
+
+      length
     end
 
     def read_bytes(length)

--- a/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/lib/action_pack/web_authn/cbor_decoder.rb
@@ -96,6 +96,13 @@ class ActionPack::WebAuthn::CborDecoder
   POSITIVE_BIGNUM_TAG = 2
   NEGATIVE_BIGNUM_TAG = 3
 
+  # Bounds the byte length of a CBOR bignum (tag 2/3). Conversion shifts an
+  # ever-growing integer one byte at a time, which is quadratic, so a multi-MB
+  # bignum permitted by MAX_SIZE would tie up a worker for seconds. WebAuthn
+  # attestation objects carry no bignums; this ceiling is generous for any
+  # legitimate value while keeping the conversion trivially cheap.
+  MAX_BIGNUM_BYTES = 1024
+
   class << self
     # Decodes a CBOR-encoded byte sequence into a Ruby object.
     #
@@ -189,6 +196,11 @@ class ActionPack::WebAuthn::CborDecoder
     def read_indefinite_string(major, encoding)
       String.new(encoding: encoding).tap do |str|
         until break_code?
+          # break_code? reads falsy at EOF (peek returns nil), so guard here or
+          # major_type below would do nil >> 5 and raise an uncaught NoMethodError
+          # on an unterminated indefinite string such as 0x5f 0x40.
+          raise ActionPack::WebAuthn::InvalidCborError, "Unexpected end of input" if @position >= @bytes.length
+
           charge_element
 
           unless major_type == major && additional_info(consume: false) != INDEFINITE_LENGTH_MAJOR_TYPE
@@ -266,10 +278,24 @@ class ActionPack::WebAuthn::CborDecoder
       value = decode
 
       case tag
-      when POSITIVE_BIGNUM_TAG then value.bytes.inject(0) { |n, b| (n << 8) | b }
-      when NEGATIVE_BIGNUM_TAG then -1 - value.bytes.inject(0) { |n, b| (n << 8) | b }
+      when POSITIVE_BIGNUM_TAG then decode_bignum(value)
+      when NEGATIVE_BIGNUM_TAG then -1 - decode_bignum(value)
       else value
       end
+    end
+
+    def decode_bignum(value)
+      # A bignum's content must be a byte string; anything else (an integer,
+      # array, ...) would otherwise raise NoMethodError on #bytes below.
+      unless value.is_a?(String)
+        raise ActionPack::WebAuthn::InvalidCborError, "Bignum value must be a byte string"
+      end
+
+      if value.bytesize > MAX_BIGNUM_BYTES
+        raise ActionPack::WebAuthn::InvalidCborError, "Bignum exceeds maximum size"
+      end
+
+      value.bytes.inject(0) { |n, b| (n << 8) | b }
     end
 
     def decode_half_float

--- a/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/lib/action_pack/web_authn/cbor_decoder.rb
@@ -159,7 +159,15 @@ class ActionPack::WebAuthn::CborDecoder
 
     def decode_byte_string
       if indefinite_length?
-        String.new(encoding: Encoding::ASCII_8BIT).tap { |str| str << decode_byte_string until break_code? }
+        # Charge each chunk: an indefinite byte string is a stream of chunks,
+        # so a flood of empty 0x40 chunks would otherwise iterate and allocate
+        # without touching the array/map budget.
+        String.new(encoding: Encoding::ASCII_8BIT).tap do |str|
+          until break_code?
+            charge_element
+            str << decode_byte_string
+          end
+        end
       else
         read_bytes(read_argument).pack("C*")
       end
@@ -167,7 +175,12 @@ class ActionPack::WebAuthn::CborDecoder
 
     def decode_text_string
       if indefinite_length?
-        String.new(encoding: Encoding::UTF_8).tap { |str| str << decode_text_string until break_code? }
+        String.new(encoding: Encoding::UTF_8).tap do |str|
+          until break_code?
+            charge_element
+            str << decode_text_string
+          end
+        end
       else
         read_bytes(read_argument).pack("C*").force_encoding(Encoding::UTF_8)
       end

--- a/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/lib/action_pack/web_authn/cbor_decoder.rb
@@ -83,6 +83,15 @@ class ActionPack::WebAuthn::CborDecoder
   MAX_DEPTH = 16
   MAX_SIZE = 10.megabytes
 
+  # Caps the total number of container elements (array entries and map pairs)
+  # decoded from a single input. The byte-size limit alone is not enough: a
+  # definite-length array of millions of one-byte items, or an indefinite-length
+  # container of the same, stays under MAX_SIZE yet forces the decoder to build
+  # millions of Ruby objects (hundreds of MB) before any later type check can
+  # reject it. Real WebAuthn attestation objects hold only a handful of elements,
+  # so this ceiling is generous while still bounding worst-case allocation.
+  MAX_ELEMENTS = 65_536
+
   # Tags
   POSITIVE_BIGNUM_TAG = 2
   NEGATIVE_BIGNUM_TAG = 3
@@ -98,13 +107,15 @@ class ActionPack::WebAuthn::CborDecoder
     end
   end
 
-  def initialize(bytes, max_depth: MAX_DEPTH, max_size: MAX_SIZE) # :nodoc:
+  def initialize(bytes, max_depth: MAX_DEPTH, max_size: MAX_SIZE, max_elements: MAX_ELEMENTS) # :nodoc:
     raise ActionPack::WebAuthn::InvalidCborError, "Input exceeds maximum size" if bytes.length > max_size
 
     @bytes = bytes
     @max_depth = max_depth
+    @max_elements = max_elements
     @position = 0
     @depth = 0
+    @element_count = 0
   end
 
   # Decodes the next CBOR data item from the byte sequence.
@@ -164,25 +175,49 @@ class ActionPack::WebAuthn::CborDecoder
 
     def decode_array
       if indefinite_length?
-        Array.new.tap { |arr| arr << decode until break_code? }
+        # No declared count to charge up front, so charge each element as it
+        # arrives to bound an indefinite stream of tiny items.
+        Array.new.tap { |arr| arr << decode_element until break_code? }
       else
         # Build incrementally rather than Array.new(count) { ... }: a declared
         # count must not pre-size the backing store. read_length caps the count
-        # at the remaining bytes, and nested containers still exhaust the input
-        # (and hit the depth limit) before the array can grow large.
+        # at the remaining bytes and against the element budget, rejecting an
+        # oversized declaration before a single element is built.
         Array.new.tap { |arr| read_length.times { arr << decode } }
       end
     end
 
     def decode_map
       if indefinite_length?
-        Hash.new.tap { |hash| hash[decode] = decode until break_code? }
+        # decode_element charges the pair as the key arrives; the break check
+        # runs first, so a closing 0xFF is never charged.
+        Hash.new.tap { |hash| hash[decode_element] = decode until break_code? }
       else
         Hash.new.tap do |hash|
           read_length.times do
             hash[decode] = decode
           end
         end
+      end
+    end
+
+    # Decodes one element of an indefinite-length container, charging it against
+    # the element budget first so the stream is bounded even without a declared
+    # length.
+    def decode_element
+      charge_element
+      decode
+    end
+
+    # Charges +count+ elements against the running budget, rejecting the input
+    # once the total would exceed MAX_ELEMENTS. Mirrors the byte-size ceiling:
+    # a bound on how much the decoder will allocate, independent of the declared
+    # or streamed shape of the data.
+    def charge_element(count = 1)
+      @element_count += count
+
+      if @element_count > @max_elements
+        raise ActionPack::WebAuthn::InvalidCborError, "Decoded element count exceeds maximum"
       end
     end
 
@@ -267,6 +302,11 @@ class ActionPack::WebAuthn::CborDecoder
       if length > @bytes.length - @position
         raise ActionPack::WebAuthn::InvalidCborError, "Declared length exceeds remaining input"
       end
+
+      # Charge the whole declared count before decoding any element, so an
+      # array or map that names millions of one-byte items is rejected up front
+      # rather than after the backing store has already been grown.
+      charge_element(length)
 
       length
     end

--- a/lib/action_pack/web_authn/cose_key.rb
+++ b/lib/action_pack/web_authn/cose_key.rb
@@ -116,7 +116,7 @@ class ActionPack::WebAuthn::CoseKey
 
       x = parameters[EC2_X_LABEL]
       y = parameters[EC2_Y_LABEL]
-      raise ActionPack::WebAuthn::InvalidKeyError, "Missing EC2 key coordinates" if x.nil? || y.nil?
+      raise ActionPack::WebAuthn::InvalidKeyError, "Missing EC2 key coordinates" unless x.is_a?(String) && y.is_a?(String)
       raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 coordinate length" unless x.bytesize == P256_COORDINATE_LENGTH && y.bytesize == P256_COORDINATE_LENGTH
 
       # Uncompressed point format: 0x04 || x || y
@@ -140,7 +140,7 @@ class ActionPack::WebAuthn::CoseKey
       raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported OKP curve: #{curve}" unless curve == ED25519
 
       x = parameters[OKP_X_LABEL]
-      raise ActionPack::WebAuthn::InvalidKeyError, "Missing OKP key coordinate" if x.nil?
+      raise ActionPack::WebAuthn::InvalidKeyError, "Missing OKP key coordinate" unless x.is_a?(String)
 
       asn1 = OpenSSL::ASN1::Sequence([
         OpenSSL::ASN1::Sequence([
@@ -157,11 +157,18 @@ class ActionPack::WebAuthn::CoseKey
     def build_rsa_rs256_key
       n_bytes = parameters[RSA_N_LABEL]
       e_bytes = parameters[RSA_E_LABEL]
-      raise ActionPack::WebAuthn::InvalidKeyError, "Missing RSA key parameters" if n_bytes.nil? || e_bytes.nil?
-      raise ActionPack::WebAuthn::InvalidKeyError, "RSA key must be at least #{MINIMUM_RSA_KEY_BITS} bits" if n_bytes.bytesize * 8 < MINIMUM_RSA_KEY_BITS
+      raise ActionPack::WebAuthn::InvalidKeyError, "Missing RSA key parameters" unless n_bytes.is_a?(String) && e_bytes.is_a?(String)
 
       n = OpenSSL::BN.new(n_bytes, 2)
       e = OpenSSL::BN.new(e_bytes, 2)
+
+      # Validate the *actual* modulus size, not the encoded byte length: a
+      # leading-zero encoding can pad a much smaller modulus up to 2048 bytes.
+      raise ActionPack::WebAuthn::InvalidKeyError, "RSA key must be at least #{MINIMUM_RSA_KEY_BITS} bits" if n.num_bits < MINIMUM_RSA_KEY_BITS
+      # Reject degenerate public exponents (e.g. e=1, which makes signatures
+      # trivially forgeable) and require the standard odd exponent form.
+      exponent = e.to_i
+      raise ActionPack::WebAuthn::InvalidKeyError, "Invalid RSA public exponent" if exponent < 3 || exponent.even?
 
       asn1 = OpenSSL::ASN1::Sequence([
         OpenSSL::ASN1::Sequence([

--- a/lib/action_pack/web_authn/cose_key.rb
+++ b/lib/action_pack/web_authn/cose_key.rb
@@ -78,6 +78,11 @@ class ActionPack::WebAuthn::CoseKey
     #   cose_key.algorithm # => -7 (ES256)
     def decode(bytes)
       data = ActionPack::WebAuthn::CborDecoder.decode(bytes)
+
+      unless data.is_a?(Hash)
+        raise ActionPack::WebAuthn::InvalidKeyError, "COSE key is not a map"
+      end
+
       new(
         key_type: data[KEY_TYPE_LABEL],
         algorithm: data[ALGORITHM_LABEL],

--- a/lib/action_pack/web_authn/public_key_credential.rb
+++ b/lib/action_pack/web_authn/public_key_credential.rb
@@ -143,7 +143,7 @@ class ActionPack::WebAuthn::PublicKeyCredential
   def to_h
     {
       credential_id: id,
-      public_key: public_key.to_der,
+      public_key: public_key.public_to_der,
       sign_count: sign_count,
       aaguid: aaguid,
       backed_up: backed_up,

--- a/test/controllers/my/passkeys_controller_test.rb
+++ b/test/controllers/my/passkeys_controller_test.rb
@@ -23,4 +23,33 @@ class My::PasskeysControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_my_passkey_path(passkey, created: true)
     assert_equal [ "internal" ], passkey.transports
   end
+
+  test "malformed attestation is rejected with a redirect, not a 500" do
+    challenge = request_webauthn_challenge(purpose: "registration")
+    params = build_attestation_params(challenge: challenge)
+    params[:passkey][:attestation_object] = "this-is-not-a-valid-attestation-object"
+
+    assert_no_difference -> { identities(:kevin).passkeys.count } do
+      post my_passkeys_path, params: params
+    end
+
+    assert_redirected_to my_passkeys_path
+    assert_equal "We couldn't register that passkey. Please try again.", flash[:alert]
+  end
+
+  test "re-registering an existing credential is rejected with a friendly message" do
+    challenge = request_webauthn_challenge(purpose: "registration")
+    credential_id = SecureRandom.random_bytes(32)
+
+    post my_passkeys_path, params: build_attestation_params(challenge: challenge, credential_id: credential_id)
+    assert_response :redirect
+
+    challenge = request_webauthn_challenge(purpose: "registration")
+    assert_no_difference -> { ActionPack::Passkey.count } do
+      post my_passkeys_path, params: build_attestation_params(challenge: challenge, credential_id: credential_id)
+    end
+
+    assert_redirected_to my_passkeys_path
+    assert_equal "That passkey is already registered.", flash[:alert]
+  end
 end

--- a/test/lib/action_pack/passkey_test.rb
+++ b/test/lib/action_pack/passkey_test.rb
@@ -43,6 +43,16 @@ class ActionPack::PasskeyTest < ActiveSupport::TestCase
     assert @passkey.backed_up?
   end
 
+  test "persists a spec-legal uint32-max sign count" do
+    # WebAuthn sign counts are unsigned 32-bit; the column must hold the full
+    # range. A signed INT4 column overflowed at 2147483647 with a RangeError.
+    max_uint32 = 4_294_967_295
+
+    @passkey.update!(sign_count: max_uint32)
+
+    assert_equal max_uint32, @passkey.reload.sign_count
+  end
+
   test "to_public_key_credential" do
     credential = @passkey.to_public_key_credential
 

--- a/test/lib/action_pack/web_authn/authenticator/assertion_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/assertion_response_test.rb
@@ -65,6 +65,24 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponseTest < ActiveSupport
     end
   end
 
+  test "accepts a predecoded Authenticator::Data instance, preserving Data.wrap's documented input" do
+    # A library caller may decode once and hand the response an existing
+    # Authenticator::Data (Data.wrap returns it as-is). The malformed-input
+    # guard must not reject that supported branch.
+    data = ActionPack::WebAuthn::Authenticator::Data.wrap(@authenticator_data)
+
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: data,
+      signature: @signature,
+      credential: @credential,
+      origin: @origin
+    )
+
+    assert_same data, response.authenticator_data
+    assert_nothing_raised { response.validate! }
+  end
+
   test "validate! raises when type is not webauthn.get" do
     client_data_json = {
       challenge: @challenge,

--- a/test/lib/action_pack/web_authn/authenticator/assertion_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/assertion_response_test.rb
@@ -65,6 +65,17 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponseTest < ActiveSupport
     end
   end
 
+  test "rejects an oversized Base64 authenticator data before decoding it" do
+    max_encoded = ActionPack::WebAuthn::CborDecoder::MAX_SIZE / 3 * 4 + 4
+    oversized = "A" * (max_encoded + 1)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::Data.wrap(oversized)
+    end
+
+    assert_equal "Authenticator data is too large", error.message
+  end
+
   test "accepts a predecoded Authenticator::Data instance, preserving Data.wrap's documented input" do
     # A library caller may decode once and hand the response an existing
     # Authenticator::Data (Data.wrap returns it as-is). The malformed-input

--- a/test/lib/action_pack/web_authn/authenticator/assertion_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/assertion_response_test.rb
@@ -43,6 +43,28 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponseTest < ActiveSupport
     end
   end
 
+  test "raises for a non-string signature or authenticator data instead of a 500" do
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+        client_data_json: @client_data_json,
+        authenticator_data: @authenticator_data,
+        signature: 123, # scalar from a JSON request body
+        credential: @credential,
+        origin: @origin
+      )
+    end
+
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+        client_data_json: @client_data_json,
+        authenticator_data: { not: "a string" },
+        signature: @signature,
+        credential: @credential,
+        origin: @origin
+      )
+    end
+  end
+
   test "validate! raises when type is not webauthn.get" do
     client_data_json = {
       challenge: @challenge,

--- a/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
@@ -201,6 +201,54 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponseTest < ActiveSuppo
     assert_equal "Malformed attestation object", error.message
   end
 
+  test "raises for a non-string client data json or attestation object instead of a 500" do
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+        client_data_json: 123, attestation_object: ATTESTATION_NONE_VERIFIED, origin: @origin
+      )
+    end
+
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+        client_data_json: @client_data_json, attestation_object: 123, origin: @origin
+      )
+    end
+  end
+
+  test "validate! raises when attested credential data is missing (no AT flag)" do
+    # Valid CBOR + binary authData, but flags 0x05 (UP+UV, no AT), so there is
+    # no credential id / public key to persist. Must reject, not 500 on to_h.
+    auth_data = Digest::SHA256.digest("example.com") + [ 0x05 ].pack("C") + [ 0 ].pack("N")
+
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: none_attestation_object(auth_data),
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) { response.validate! }
+    assert_match(/Attested credential data is missing/, error.message)
+  end
+
+  # Builds a base64url "none" attestation object wrapping the given authData.
+  def none_attestation_object(auth_data)
+    cbor = "\xa3".b # map(3)
+    cbor << "\x63".b << "fmt".b << "\x64".b << "none".b
+    cbor << "\x67".b << "attStmt".b << "\xa0".b # {}
+    cbor << "\x68".b << "authData".b << cbor_byte_string_header(auth_data.bytesize) << auth_data.b
+    Base64.urlsafe_encode64(cbor, padding: false)
+  end
+
+  def cbor_byte_string_header(length)
+    if length < 24
+      [ 0x40 | length ].pack("C")
+    elsif length < 256
+      [ 0x58, length ].pack("C*")
+    else
+      [ 0x59 ].pack("C") + [ length ].pack("n")
+    end
+  end
+
   test "validate! calls registered verifier for custom format" do
     verified = false
     custom_verifier = Object.new

--- a/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
@@ -215,6 +215,22 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponseTest < ActiveSuppo
     end
   end
 
+  test "accepts a predecoded Attestation instance, preserving Attestation.wrap's documented input" do
+    # A library caller may decode once and hand the response an existing
+    # Attestation (Attestation.wrap returns it as-is). The malformed-input guard
+    # must not reject that supported branch.
+    attestation = ActionPack::WebAuthn::Authenticator::Attestation.wrap(ATTESTATION_NONE_VERIFIED)
+
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: attestation,
+      origin: @origin
+    )
+
+    assert_same attestation, response.attestation
+    assert_nothing_raised { response.validate! }
+  end
+
   test "validate! raises when attested credential data is missing (no AT flag)" do
     # Valid CBOR + binary authData, but flags 0x05 (UP+UV, no AT), so there is
     # no credential id / public key to persist. Must reject, not 500 on to_h.

--- a/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
@@ -215,6 +215,20 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponseTest < ActiveSuppo
     end
   end
 
+  test "rejects an oversized Base64 attestation object before decoding it" do
+    # An encoded value larger than the byte ceiling can only decode to an
+    # oversized blob, so Attestation.wrap must reject it before Base64 allocates
+    # the decoded copy.
+    max_encoded = ActionPack::WebAuthn::CborDecoder::MAX_SIZE / 3 * 4 + 4
+    oversized = "A" * (max_encoded + 1)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::Attestation.wrap(oversized)
+    end
+
+    assert_equal "Attestation object is too large", error.message
+  end
+
   test "accepts a predecoded Attestation instance, preserving Attestation.wrap's documented input" do
     # A library caller may decode once and hand the response an existing
     # Attestation (Attestation.wrap returns it as-is). The malformed-input guard

--- a/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
+++ b/test/lib/action_pack/web_authn/authenticator/attestation_response_test.rb
@@ -167,6 +167,40 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponseTest < ActiveSuppo
     assert_equal "Unsupported attestation format: packed", error.message
   end
 
+  test "validate! raises for non-object client data instead of a 500" do
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: "123", # valid JSON, but not an object
+      attestation_object: ATTESTATION_NONE_VERIFIED,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) { response.validate! }
+    assert_equal "Client data is not a JSON object", error.message
+  end
+
+  test "validate! raises for a non-string challenge instead of a 500" do
+    client_data_json = { challenge: { nested: "object" }, origin: @origin, type: "webauthn.create" }.to_json
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: client_data_json,
+      attestation_object: ATTESTATION_NONE_VERIFIED,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) { response.validate! }
+    assert_match(/Challenge (is invalid|missing)/, error.message)
+  end
+
+  test "validate! raises for an attestation object that is not a CBOR map instead of a 500" do
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: Base64.urlsafe_encode64("\x01".b, padding: false), # CBOR integer 1
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) { response.validate! }
+    assert_equal "Malformed attestation object", error.message
+  end
+
   test "validate! calls registered verifier for custom format" do
     verified = false
     custom_verifier = Object.new

--- a/test/lib/action_pack/web_authn/cbor_decoder_test.rb
+++ b/test/lib/action_pack/web_authn/cbor_decoder_test.rb
@@ -293,6 +293,22 @@ class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
     assert_equal "Input exceeds maximum size", error.message
   end
 
+  test "rejects an oversized string input before materializing its bytes" do
+    # A String over the limit must be rejected before String#bytes runs, since
+    # that conversion is itself the ~8x allocation the limit exists to prevent.
+    # This String refuses to be converted, so reaching #bytes would raise the
+    # wrong error and fail the assertion below.
+    oversized = Class.new(String) do
+      def bytes = raise "must not materialize bytes for an oversized input"
+    end.new("x" * 100)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(oversized, max_size: 10)
+    end
+
+    assert_equal "Input exceeds maximum size", error.message
+  end
+
   test "rejects an array whose declared length exceeds the remaining input" do
     # 0x9a = array, 4-byte length follows = 0xffffffff (~4.3 billion elements)
     # from a 5-byte input. Without a bound this drives a multi-gigabyte

--- a/test/lib/action_pack/web_authn/cbor_decoder_test.rb
+++ b/test/lib/action_pack/web_authn/cbor_decoder_test.rb
@@ -317,6 +317,59 @@ class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
     assert_equal [ 1, 2, 3 ], decode("83010203")
   end
 
+  test "rejects a definite-length array declaring more elements than the budget before allocating them" do
+    # 0x9a = array with a 4-byte element count = MAX_ELEMENTS + 1, followed by
+    # exactly that many one-byte items (unsigned integer 0). The declared count
+    # slips under both MAX_SIZE and the remaining-bytes bound, so only the
+    # element budget stops it from building tens of thousands of Ruby objects.
+    # The count is charged in read_length before the build loop runs, so the
+    # array is never grown.
+    over_budget = ActionPack::WebAuthn::CborDecoder::MAX_ELEMENTS + 1
+    header = [ 0x9a, over_budget ].pack("CN").bytes
+    payload = header + Array.new(over_budget, 0x00)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload)
+    end
+
+    assert_equal "Decoded element count exceeds maximum", error.message
+  end
+
+  test "rejects an indefinite-length array that streams more elements than the budget" do
+    # Indefinite-length containers carry no declared count, so the byte bound in
+    # read_length never sees them. 0x9f opens the stream, 0xff closes it; the
+    # per-element charge is what bounds it. Uses a small override to keep the
+    # fixture tiny while exercising the same guard as the default limit.
+    payload = [ 0x9f ] + Array.new(5, 0x00) + [ 0xff ]
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload, max_elements: 4)
+    end
+
+    assert_equal "Decoded element count exceeds maximum", error.message
+  end
+
+  test "rejects a definite-length map declaring more pairs than the budget" do
+    # 0xb8 = map with a 1-byte pair count. Six pairs (twelve one-byte items)
+    # exceed a budget of five.
+    payload = [ 0xb8, 0x06 ] + Array.new(12, 0x00)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload, max_elements: 5)
+    end
+
+    assert_equal "Decoded element count exceeds maximum", error.message
+  end
+
+  test "decodes a container whose element count is exactly at the budget" do
+    # Non-vacuity: the guard rejects strictly above the budget, so a container
+    # sized right at it still decodes. A five-element array under a budget of
+    # five proves the limit is a real boundary, not an always-raise.
+    payload = [ 0x85, 0x01, 0x02, 0x03, 0x04, 0x05 ]
+
+    assert_equal [ 1, 2, 3, 4, 5 ], ActionPack::WebAuthn::CborDecoder.decode(payload, max_elements: 5)
+  end
+
   private
     def decode(hex)
       bytes = [ hex ].pack("H*").bytes

--- a/test/lib/action_pack/web_authn/cbor_decoder_test.rb
+++ b/test/lib/action_pack/web_authn/cbor_decoder_test.rb
@@ -361,6 +361,30 @@ class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
     assert_equal "Decoded element count exceeds maximum", error.message
   end
 
+  test "rejects an indefinite-length byte string that streams more chunks than the budget" do
+    # 0x5f opens an indefinite byte string, each 0x40 is an empty chunk, 0xff
+    # closes it. Chunks carry almost no bytes but each is an iteration and an
+    # allocation, so they must be charged like array entries and map pairs.
+    payload = [ 0x5f ] + Array.new(6, 0x40) + [ 0xff ]
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload, max_elements: 5)
+    end
+
+    assert_equal "Decoded element count exceeds maximum", error.message
+  end
+
+  test "rejects an indefinite-length text string that streams more chunks than the budget" do
+    # 0x7f opens an indefinite text string, each 0x60 is an empty chunk.
+    payload = [ 0x7f ] + Array.new(6, 0x60) + [ 0xff ]
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload, max_elements: 5)
+    end
+
+    assert_equal "Decoded element count exceeds maximum", error.message
+  end
+
   test "decodes a container whose element count is exactly at the budget" do
     # Non-vacuity: the guard rejects strictly above the budget, so a container
     # sized right at it still decodes. A five-element array under a budget of

--- a/test/lib/action_pack/web_authn/cbor_decoder_test.rb
+++ b/test/lib/action_pack/web_authn/cbor_decoder_test.rb
@@ -428,6 +428,44 @@ class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
     assert_equal "Indefinite-length string chunk must be a definite-length string of the same type", error.message
   end
 
+  test "raises for an unterminated indefinite-length byte string instead of crashing at EOF" do
+    # 0x5f opens an indefinite byte string, 0x40 is an empty chunk, and the
+    # input ends with no 0xff break. break_code? reads falsy at EOF, so without
+    # the guard major_type would do nil >> 5 and raise an uncaught NoMethodError.
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("5f40")
+    end
+
+    assert_equal "Unexpected end of input", error.message
+  end
+
+  test "decodes a small CBOR bignum" do
+    # 0xc2 = tag 2 (positive bignum), 0x42 = byte string of length 2, 0x0100.
+    assert_equal 256, decode("c2420100")
+  end
+
+  test "rejects a CBOR bignum larger than the bignum byte limit" do
+    # Bignum conversion is quadratic, so an oversized value would tie up a
+    # worker. 0xc2 tag 2, 0x59 = byte string with a 2-byte length = 1025.
+    over = ActionPack::WebAuthn::CborDecoder::MAX_BIGNUM_BYTES + 1
+    payload = [ 0xc2, 0x59 ] + [ over ].pack("n").bytes + Array.new(over, 0x00)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload)
+    end
+
+    assert_equal "Bignum exceeds maximum size", error.message
+  end
+
+  test "rejects a CBOR bignum whose tagged value is not a byte string" do
+    # 0xc2 = tag 2 wrapping the integer 1, which has no #bytes.
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("c201")
+    end
+
+    assert_equal "Bignum value must be a byte string", error.message
+  end
+
   test "decodes a container whose element count is exactly at the budget" do
     # Non-vacuity: the guard rejects strictly above the budget, so a container
     # sized right at it still decodes. A five-element array under a budget of

--- a/test/lib/action_pack/web_authn/cbor_decoder_test.rb
+++ b/test/lib/action_pack/web_authn/cbor_decoder_test.rb
@@ -293,6 +293,30 @@ class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
     assert_equal "Input exceeds maximum size", error.message
   end
 
+  test "rejects an array whose declared length exceeds the remaining input" do
+    # 0x9a = array, 4-byte length follows = 0xffffffff (~4.3 billion elements)
+    # from a 5-byte input. Without a bound this drives a multi-gigabyte
+    # pre-allocation (memory-exhaustion DoS) before any element is decoded.
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("9affffffff")
+    end
+
+    assert_equal "Declared length exceeds remaining input", error.message
+  end
+
+  test "rejects a map whose declared length exceeds the remaining input" do
+    # 0xba = map, 4-byte pair count follows = 0xffffffff.
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("baffffffff")
+    end
+
+    assert_equal "Declared length exceeds remaining input", error.message
+  end
+
+  test "still decodes a well-formed definite-length array" do
+    assert_equal [ 1, 2, 3 ], decode("83010203")
+  end
+
   private
     def decode(hex)
       bytes = [ hex ].pack("H*").bytes

--- a/test/lib/action_pack/web_authn/cbor_decoder_test.rb
+++ b/test/lib/action_pack/web_authn/cbor_decoder_test.rb
@@ -385,6 +385,33 @@ class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
     assert_equal "Decoded element count exceeds maximum", error.message
   end
 
+  test "rejects an indefinite-length byte string whose chunk is itself indefinite instead of overflowing the stack" do
+    # RFC 8949 requires each chunk of an indefinite-length string to be a
+    # definite-length string of the same type. A chunk that is itself an
+    # indefinite byte string (0x5f) used to recurse without passing through the
+    # depth check, overflowing the stack (an uncaught SystemStackError) on a
+    # deeply nested payload. It must be rejected as InvalidCborError instead.
+    payload = [ 0x5f, 0x5f, 0xff, 0xff ]
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload)
+    end
+
+    assert_equal "Indefinite-length string chunk must be a definite-length string of the same type", error.message
+  end
+
+  test "rejects an indefinite-length string chunk of a mismatched major type" do
+    # 0x5f opens an indefinite byte string; 0x00 is an integer, not a byte-string
+    # chunk. Deeply nesting these was the stack-overflow vector.
+    payload = [ 0x5f, 0x00, 0xff ]
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode(payload)
+    end
+
+    assert_equal "Indefinite-length string chunk must be a definite-length string of the same type", error.message
+  end
+
   test "decodes a container whose element count is exactly at the budget" do
     # Non-vacuity: the guard rejects strictly above the budget, so a container
     # sized right at it still decodes. A five-element array under a budget of

--- a/test/lib/action_pack/web_authn/cose_key_test.rb
+++ b/test/lib/action_pack/web_authn/cose_key_test.rb
@@ -252,4 +252,37 @@ class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
 
     assert_match(/at least 2048 bits/i, error.message)
   end
+
+  test "raises error for RSA modulus padded with leading zero bytes below 2048 bits" do
+    # 2048 encoded bytes, but the actual number is only ~1024 bits — the old
+    # byte-length check would have accepted this.
+    padded_n = ("\x00" * 128) + RSA_N[0, 128]
+    parameters = @rsa_parameters.merge(-1 => padded_n)
+    key = ActionPack::WebAuthn::CoseKey.new(key_type: 3, algorithm: -257, parameters: parameters)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) { key.to_openssl_key }
+    assert_match(/at least 2048 bits/i, error.message)
+  end
+
+  test "raises error for degenerate RSA public exponent e=1" do
+    parameters = @rsa_parameters.merge(-2 => "\x01") # e = 1, forgeable
+    key = ActionPack::WebAuthn::CoseKey.new(key_type: 3, algorithm: -257, parameters: parameters)
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) { key.to_openssl_key }
+    assert_match(/public exponent/i, error.message)
+  end
+
+  test "raises error for non-string EC2 coordinates" do
+    parameters = @ec2_parameters.merge(-2 => 12345) # integer instead of bytes
+    key = ActionPack::WebAuthn::CoseKey.new(key_type: 2, algorithm: -7, parameters: parameters)
+
+    assert_raises(ActionPack::WebAuthn::InvalidKeyError) { key.to_openssl_key }
+  end
+
+  test "raises error for non-string OKP coordinate" do
+    parameters = @okp_parameters.merge(-2 => 12345)
+    key = ActionPack::WebAuthn::CoseKey.new(key_type: 1, algorithm: -8, parameters: parameters)
+
+    assert_raises(ActionPack::WebAuthn::InvalidKeyError) { key.to_openssl_key }
+  end
 end

--- a/test/lib/action_pack/web_authn/cose_key_test.rb
+++ b/test/lib/action_pack/web_authn/cose_key_test.rb
@@ -254,8 +254,8 @@ class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
   end
 
   test "raises error for RSA modulus padded with leading zero bytes below 2048 bits" do
-    # 2048 encoded bytes, but the actual number is only ~1024 bits — the old
-    # byte-length check would have accepted this.
+    # 256 encoded bytes (which the old bytesize*8 check read as 2048 bits), but
+    # the actual number is only ~1024 bits once the leading zero bytes are dropped.
     padded_n = ("\x00" * 128) + RSA_N[0, 128]
     parameters = @rsa_parameters.merge(-1 => padded_n)
     key = ActionPack::WebAuthn::CoseKey.new(key_type: 3, algorithm: -257, parameters: parameters)
@@ -284,5 +284,12 @@ class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
     key = ActionPack::WebAuthn::CoseKey.new(key_type: 1, algorithm: -8, parameters: parameters)
 
     assert_raises(ActionPack::WebAuthn::InvalidKeyError) { key.to_openssl_key }
+  end
+
+  test "raises error when the decoded COSE key is not a map" do
+    # CBOR null (0xf6) decodes to nil, not a key map.
+    assert_raises(ActionPack::WebAuthn::InvalidKeyError) do
+      ActionPack::WebAuthn::CoseKey.decode("\xf6".b)
+    end
   end
 end

--- a/test/lib/action_pack/web_authn/public_key_credential_test.rb
+++ b/test/lib/action_pack/web_authn/public_key_credential_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class ActionPack::WebAuthn::PublicKeyCredentialTest < ActiveSupport::TestCase
+  # COSE CBOR for an Ed25519 (OKP/EdDSA) public key: {1: 1, 3: -8, -1: 6, -2: <x 32 bytes>}
+  OKP_CBOR = [ "a4010103272006215820a95ee02872a2c5224b394832767bea746620e50776e8" \
+    "45872228716065f16005" ].pack("H*")
+
+  test "to_h serializes and round-trips an Ed25519 public key" do
+    public_key = ActionPack::WebAuthn::CoseKey.decode(OKP_CBOR).to_openssl_key
+
+    credential = ActionPack::WebAuthn::PublicKeyCredential.new(
+      id: "credential-id", public_key: public_key, sign_count: 0
+    )
+
+    # Regression: Ed25519 keys decode to a generic OpenSSL::PKey::PKey with no
+    # #to_der, which crashed to_h. public_to_der works for every key type and
+    # round-trips back into a usable verification key.
+    der = credential.to_h[:public_key]
+    restored = OpenSSL::PKey.read(der)
+
+    assert_equal "ED25519", restored.oid
+  end
+
+  test "to_h serializes and round-trips an EC public key" do
+    public_key = OpenSSL::PKey::EC.generate("prime256v1")
+
+    credential = ActionPack::WebAuthn::PublicKeyCredential.new(
+      id: "credential-id", public_key: public_key, sign_count: 0
+    )
+
+    restored = OpenSSL::PKey.read(credential.to_h[:public_key])
+
+    assert_instance_of OpenSSL::PKey::EC, restored
+  end
+end

--- a/test/lib/action_pack/web_authn_test.rb
+++ b/test/lib/action_pack/web_authn_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class ActionPack::WebAuthnTest < ActiveSupport::TestCase
+  test "every ceremony error descends from ActionPack::WebAuthn::Error" do
+    # A single rescuable superclass lets callers turn any parse or verification
+    # failure into a 4xx instead of an unhandled 500.
+    [
+      ActionPack::WebAuthn::InvalidResponseError,
+      ActionPack::WebAuthn::InvalidCborError,
+      ActionPack::WebAuthn::InvalidKeyError,
+      ActionPack::WebAuthn::UnsupportedKeyTypeError,
+      ActionPack::WebAuthn::InvalidOptionsError
+    ].each do |error_class|
+      assert_operator error_class, :<, ActionPack::WebAuthn::Error
+    end
+  end
+end

--- a/test/test_helpers/webauthn_test_helper.rb
+++ b/test/test_helpers/webauthn_test_helper.rb
@@ -33,8 +33,7 @@ module WebauthnTestHelper
       WEBAUTHN_PRIVATE_KEY
     end
 
-    def build_attestation_params(challenge:)
-      credential_id = SecureRandom.random_bytes(32)
+    def build_attestation_params(challenge:, credential_id: SecureRandom.random_bytes(32))
       auth_data = build_attestation_auth_data(credential_id: credential_id)
 
       {


### PR DESCRIPTION
A HackerOne researcher fuzzed `POST /:slug/my/passkeys` (2026-08-25 21:13–21:36 UTC, ~9 events, one actor) and produced five distinct uncaught 500s in the new `ActionPack::WebAuthn` / `ActionPack::Passkey` registration stack. On-call card: [On Call #10239040047](https://3.basecampapi.com/2914079/buckets/27/card_tables/cards/10239040047.json).

**Security read up front:** the verification stack itself is sound — the signed challenge is verified, origin and RP-ID hash are compared with `ActiveSupport::SecurityUtils.secure_compare`, cross-origin and token-binding responses are rejected, and each COSE algorithm is strictly matched to its key type. Every one of the five legs **fails closed**. None is an auth bypass, replay, origin/RP-ID confusion, or credential-swap. The defects are (a) validation failures and malformed input surfacing as 500s instead of a clean rejection, and (b) two schema/serialization bugs that also break *legitimate* authenticators.

## The five probed failures and their verdict

| Sentry | Trigger | Security verdict | Fix |
|--------|---------|------------------|-----|
| [FIZZY-VC](https://basecamp.sentry.io/issues/7692301515/) | attestation `fmt: "packed"` (no verifier registered) | **Benign.** Unverifiable format is correctly *rejected* (fails closed); no packed statement is ever trusted. Only the disposition was wrong (500 not 422). | common error superclass + controller rescue → redirect w/ alert (not 500) |
| [FIZZY-VD](https://basecamp.sentry.io/issues/7692301533/) | Ed25519 credential registration | **Genuine functional defect, not a vuln.** EdDSA keys decode to a generic `OpenSSL::PKey::PKey` with no `#to_der`, crashing serialization. Narrow (ES256 is offered first and negotiated by dual-alg authenticators). | `public_key.to_der` → `public_to_der` (round-trips EC/RSA/Ed25519) |
| [FIZZY-VE](https://basecamp.sentry.io/issues/7692301535/) | `sign_count = 4294967295` | **Security-adjacent but fails closed today.** Sign count is the replay/clone signal; the column was signed `INT4` (max 2147483647) while WebAuthn counts are `uint32`. A spec-legal counter raised `RangeError` rather than truncating — no bad write, but the credential was unusable. | widen `sign_count` to `bigint` |
| [FIZZY-VF](https://basecamp.sentry.io/issues/7692301578/) | non-empty `attStmt` under `fmt: "none"` | **Benign.** The `none` verifier correctly rejects a non-empty statement (fails closed). Disposition only. | superclass + rescue → redirect (not 500) |
| [FIZZY-VG](https://basecamp.sentry.io/issues/7692336566/) | re-registering an existing `credential_id` | **Benign — the global unique index is a *defense* (prevents credential-ID takeover).** Raw `RecordNotUnique` was just an unfriendly 500. | rescue `RecordNotUnique` → "already registered" |

## What the probing revealed beyond the five (fixed here)

- **CBOR memory-exhaustion DoS.** `Array.new(read_argument) { decode }` pre-sized the backing store to an attacker-declared count. A five-byte input (`0x9a ff ff ff ff`) named a ~4.3-billion-element array and drove a ~34 GB allocation (reproduced: hangs the process). Nested containers amplified further. Fixed by bounding a definite-length container's declared count by the remaining input and building arrays incrementally so a lying count can never pre-allocate.
- **Residual malformed-input 500s.** The common superclass only catches errors the code explicitly raises; several fuzzing vectors still escaped as `TypeError`/`NoMethodError`. Closed at the decode boundary: client data must be a JSON object, the challenge must be a string, `tokenBinding` must be an object, the attestation object must be a CBOR map with binary `authData`, and COSE coordinates must be byte strings.
- **RSA key validation.** The old check measured the *encoded* modulus byte length (a leading-zero pad defeats it) and accepted any exponent, including `e = 1` (verifies a forged signature with no private key — confirmed locally). Now validates the actual modulus bit length and rejects degenerate exponents. Reachability is low (registration is authenticated; the actor would only weaken their own credential), but it is cheap correctness in the exact COSE surface under probe.

## Fixes

- `lib/action_pack/web_authn.rb` — common `ActionPack::WebAuthn::Error` superclass for the five error classes.
- `app/controllers/my/passkeys_controller.rb` — `create` rescues `WebAuthn::Error` (→ alert) and `RecordNotUnique` (→ "already registered").
- `lib/action_pack/passkey.rb` — `authenticate` rescues the superclass on the assertion path.
- `lib/action_pack/web_authn/public_key_credential.rb` — `public_to_der`.
- `lib/action_pack/web_authn/authenticator/response.rb`, `attestation.rb`, `cose_key.rb` — decode-boundary type guards.
- `lib/action_pack/web_authn/cbor_decoder.rb` — declared-length bound + incremental array build.
- `db/migrate/20260825120000_widen_action_pack_passkeys_sign_count_to_bigint.rb` + `db/schema.rb` — `sign_count` → `bigint`.

## Tests

New/extended coverage for every leg: controller graceful-rejection + duplicate handling (`test/controllers/my/passkeys_controller_test.rb`), Ed25519/EC `to_h` round-trip (`public_key_credential_test.rb`), `uint32`-max sign-count persistence (`passkey_test.rb`), CBOR declared-length DoS bounds (`cbor_decoder_test.rb`), COSE type/RSA-exponent/bit-length guards (`cose_key_test.rb`), malformed client-data/challenge/attestation rejection (`attestation_response_test.rb`), and the error-hierarchy invariant (`web_authn_test.rb`). Full `bin/ci` green (rubocop, brakeman, all audits, OSS + system tests).

## Flagged, not fixed here (design-level, tracked on the card)

Not silently patched — surfaced for follow-up: challenge tokens are authenticated + expiring but **not single-use / not bound to the identity** (replayable within the TTL); the sign-count check/update is an unlocked read-check-write (racy under concurrency); the `credential_id` unique index uses a **case-insensitive** collation (`utf8mb4_0900_ai_ci`) while base64url IDs are case-sensitive, and the `string(255)` column is narrower than spec-legal credential IDs; `userVerification: required` is not server-enforced (no live impact — Fizzy uses the default `preferred`). These are separate from the 500 cluster and warrant their own assessment.

## Response contract

Registration failures **redirect back with a flash alert** (HTTP 302), consistent with this controller's `update`/`destroy` actions and the Turbo form flow — not a bare 422 body. The security property is that malformed input fails closed with a clean, non-500 response. (An earlier draft of this description said "422"; the redirect is the intended UX.)
