### PR TITLE
Discard variant transform jobs when the blob's file is already gone

### DIFF
--- a/lib/rails_ext/active_storage_transform_jobs_discard_file_not_found.rb
+++ b/lib/rails_ext/active_storage_transform_jobs_discard_file_not_found.rb
@@ -1,0 +1,11 @@
+# A transform for a blob whose stored file is already gone is moot: the missing key is permanent,
+# so retrying can't succeed, and raising 500s requests that process variants immediately
+# (config/initializers/action_text.rb) after their save has already committed.
+#   e.g. when a user uploads a file but deletes it before the transform runs.
+#
+# Discard the job, reporting so a bug that deletes files still referenced would stay visible.
+ActiveSupport.on_load :active_storage_blob do
+  [ ActiveStorage::TransformJob, ActiveStorage::CreateVariantsJob ].each do |job|
+    job.discard_on ActiveStorage::FileNotFoundError, report: true
+  end
+end

--- a/test/lib/rails_ext/active_storage_transform_jobs_discard_file_not_found_test.rb
+++ b/test/lib/rails_ext/active_storage_transform_jobs_discard_file_not_found_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class ActiveStorageTransformJobsDiscardFileNotFoundTest < ActiveSupport::TestCase
+  TRANSFORMATIONS = { resize_to_limit: [ 100, 100 ] }
+
+  setup do
+    @blob = ActiveStorage::Blob.create_and_upload! \
+      io: file_fixture("moon.jpg").open, filename: "moon.jpg", content_type: "image/jpeg"
+  end
+
+  test "transform for a blob missing from storage discards cleanly" do
+    @blob.service.delete @blob.key
+
+    Rails.error.expects(:report).with { |error, **| error.is_a?(ActiveStorage::FileNotFoundError) }
+
+    assert_no_enqueued_jobs do
+      assert_nothing_raised do
+        ActiveStorage::TransformJob.perform_now @blob, TRANSFORMATIONS
+      end
+    end
+  end
+
+  test "transform for a present blob still runs" do
+    assert_difference -> { ActiveStorage::VariantRecord.count }, 1 do
+      ActiveStorage::TransformJob.perform_now @blob, TRANSFORMATIONS
+    end
+  end
+
+  test "create variants for a blob missing from storage discards cleanly" do
+    ActiveStorage::CreateVariantsJob.any_instance.stubs(:perform).raises(ActiveStorage::FileNotFoundError)
+
+    Rails.error.expects(:report).with { |error, **| error.is_a?(ActiveStorage::FileNotFoundError) }
+
+    assert_nothing_raised do
+      ActiveStorage::CreateVariantsJob.perform_now @blob, variants: [ TRANSFORMATIONS ], process: :immediately
+    end
+  end
+end


### PR DESCRIPTION
## Symptom

A steady ~2–3/week background `ActiveStorage::FileNotFoundError` from `ActiveStorage::TransformJob` (FIZZY-RQ), running since at least June. Because ActionText embeds declare their variants with `process: :immediately` (`config/initializers/action_text.rb`), the transform runs inline in the web request — `CreateVariantsJob.perform_now` → `TransformJob` — so the error 500s a save that has already committed (latest event: `cards#update` → `blob.open` → `S3Service#download`).

## Root cause

Saving rich text that references a blob whose stored object is already gone (upload-then-delete race: the file is purged between enqueue and execution) hits S3 for a key that no longer exists. Rails' stock jobs discard only `ActiveRecord::RecordNotFound`; `ActiveStorage::FileNotFoundError` is unhandled.

## Fix

`discard_on ActiveStorage::FileNotFoundError, report: true` on both `ActiveStorage::TransformJob` and `ActiveStorage::CreateVariantsJob`, as a `lib/rails_ext/` extension alongside the two existing AnalyzeJob race guards, mirroring the SaaS `Cell::UnprocessableAttachment` discard (`saas/lib/fizzy/saas/unprocessable_attachments.rb`).

**Why this isn't masking a deeper bug:** a missing key is permanent for a variant job — retrying cannot bring the file back, so the work is moot, not failed. Deletion here is driven by the legitimate detach/purge flow (`active_storage_purge_on_last_attachment.rb` purges a blob only once its last attachment is gone), and the rate has been flat since June, predating recent rollouts. Only this one error class is discarded — everything else still raises — and `report: true` keeps every occurrence flowing to Sentry as handled, so a bug that deleted files still referenced would remain visible rather than silenced.

## Test evidence

`test/lib/rails_ext/active_storage_transform_jobs_discard_file_not_found_test.rb`:

- a transform for a blob whose stored file was deleted discards cleanly — no raise, no re-enqueue, error reported
- a transform for a present blob still runs (variant record created)
- `CreateVariantsJob` discards and reports the same class

Full `bin/ci` green (1563 tests / 18 system tests, 0 failures) and signed off on 7d0b39995.
