### PR TITLE
Raise the mise version floor to 2026.8.10

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-min_version = "2026.7.10"
+min_version = "2026.8.10"
 
 [settings]
 idiomatic_version_file_enable_tools = ["ruby"]

--- a/bin/setup
+++ b/bin/setup
@@ -39,7 +39,7 @@ step() {
   return $exit_code
 }
 
-mise_min_version="2026.7.10" # keep in lockstep with min_version in .mise.toml
+mise_min_version="2026.8.10" # keep in lockstep with min_version in .mise.toml
 
 mise_too_old() {
   local current="$(mise --version 2>/dev/null | awk '{ print $1; exit }')"


### PR DESCRIPTION
Lockstep floor bump with basecamp/shipyard@17cc9f6 (fleet floor raise to 2026.8.10): `min_version` in `.mise.toml` and the vendored `mise_min_version` in `bin/setup` move together, per shipyard's README train order (Shipyard first, then each app).

**Why now:** Arch's `extra/mise` reached 2026.8.10 — the laggard provider that deferred this raise on 2026-07-28. brew and mise.run carry 2026.8.14. Equality passes the not-older-than floor check, so Arch machines converge at exactly 2026.8.10.

**Release audit (2026.7.11..2026.8.10):** clear to raise; both consequential changes were absorbed before this bump. Strict `ruby.compile = false` (2026.8.2, jdx/mise#11710) hard-fails installs with no precompiled binary — shipyard's bootstrap-task already forces `MISE_RUBY_COMPILE=1` where a source build is intended. The embedded-aube npm backend (2026.7.12) is bounded loudly by shipyard's execute-probes. The 2026.7.11 macOS-12 tarball floor is vacuous against shipshape-reports (oldest active Mac: macOS 15).

**Precompiled-ruby spike (pin-and-disclose):** `test/ruby-precompiled-spike` run against this repo at head `50d945099804eff923e56a570bc693dd11972341` (tree `8e645fc2b55b0cf6c84114d15f784b045edb8c84`) with candidate mise 2026.8.10 (sha256 `a91ccafc1a90087c94c4c70bd61b455bfae087b899c1e5619f4ef515aa2e036f`): pinned ruby delivered precompiled with no compile activity, bundle installed frozen, native gems load from the built bundle. 56/56 assertions across the five apps. Harness blob `21be6714`, fragment blob `8e765b8a` — both as landed in shipyard@17cc9f6 (run recorded at pre-commit checkout 2b1e1c7 of the same blobs).