### PR TITLE
Return 404 for day params that parse to nil in events timelines

### DIFF
--- a/app/controllers/concerns/day_timelines_scoped.rb
+++ b/app/controllers/concerns/day_timelines_scoped.rb
@@ -9,16 +9,20 @@ module DayTimelinesScoped
 
   private
     def set_day_timeline
-      @day_timeline = Current.user.timeline_for(day, filter: @filter)
+      if day
+        @day_timeline = Current.user.timeline_for(day, filter: @filter)
+      else
+        head :not_found
+      end
     end
 
     def day
-      if params[:day].present?
+      @day ||= if params[:day].present?
         Time.zone.parse(params[:day])
       else
         Time.current
       end
-    rescue ArgumentError
-      head :not_found
+    rescue ArgumentError, TypeError
+      nil
     end
 end

--- a/app/controllers/concerns/day_timelines_scoped.rb
+++ b/app/controllers/concerns/day_timelines_scoped.rb
@@ -9,11 +9,8 @@ module DayTimelinesScoped
 
   private
     def set_day_timeline
-      if day
-        @day_timeline = Current.user.timeline_for(day, filter: @filter)
-      else
-        head :not_found
-      end
+      raise ActiveRecord::RecordNotFound unless day
+      @day_timeline = Current.user.timeline_for(day, filter: @filter)
     end
 
     def day

--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -4,10 +4,14 @@ class Users::EventsController < ApplicationController
   before_action :set_user, :set_filter, :set_user_filtering
 
   def show
-    @filter = Current.user.filters.new(creator_ids: [ @user.id ])
-    @day_timeline = Current.user.timeline_for(day_param, filter: @filter)
+    if day_param
+      @filter = Current.user.filters.new(creator_ids: [ @user.id ])
+      @day_timeline = Current.user.timeline_for(day_param, filter: @filter)
 
-    fresh_when @day_timeline
+      fresh_when @day_timeline
+    else
+      head :not_found
+    end
   end
 
   private
@@ -16,10 +20,12 @@ class Users::EventsController < ApplicationController
     end
 
     def day_param
-      if params[:day].present?
+      @day_param ||= if params[:day].present?
         Time.zone.parse(params[:day])
       else
         Time.current
       end
+    rescue ArgumentError, TypeError
+      nil
     end
 end

--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -4,14 +4,12 @@ class Users::EventsController < ApplicationController
   before_action :set_user, :set_filter, :set_user_filtering
 
   def show
-    if day_param
-      @filter = Current.user.filters.new(creator_ids: [ @user.id ])
-      @day_timeline = Current.user.timeline_for(day_param, filter: @filter)
+    raise ActiveRecord::RecordNotFound unless day_param
 
-      fresh_when @day_timeline
-    else
-      head :not_found
-    end
+    @filter = Current.user.filters.new(creator_ids: [ @user.id ])
+    @day_timeline = Current.user.timeline_for(day_param, filter: @filter)
+
+    fresh_when @day_timeline
   end
 
   private

--- a/test/controllers/events/day_timeline/columns_controller_test.rb
+++ b/test/controllers/events/day_timeline/columns_controller_test.rb
@@ -27,4 +27,9 @@ class Events::DayTimeline::ColumnsControllerTest < ActionDispatch::IntegrationTe
     get events_day_timeline_column_path("invalid")
     assert_response :not_found
   end
+
+  test "show returns not found for an unparseable day param" do
+    get events_day_timeline_column_path("added", day: "garbage")
+    assert_response :not_found
+  end
 end

--- a/test/controllers/events/days_controller_test.rb
+++ b/test/controllers/events/days_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Events::DaysControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as :kevin
+  end
+
+  test "index" do
+    get events_days_path
+    assert_response :success
+  end
+
+  test "index with a valid day param" do
+    get events_days_path(day: "2026-08-23")
+    assert_response :success
+  end
+
+  test "index returns not found for an unparseable day param" do
+    get events_days_path(day: "garbage")
+    assert_response :not_found
+  end
+
+  test "index returns not found for an out-of-range day param" do
+    get events_days_path(day: "2026-99-99")
+    assert_response :not_found
+  end
+
+  test "index returns not found for a non-string day param" do
+    get events_days_path(day: [ "garbage" ])
+    assert_response :not_found
+  end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -37,4 +37,9 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       assert_includes event.text, boards(:writebook).name
     end
   end
+
+  test "index returns not found for an unparseable day param" do
+    get events_path(day: "garbage")
+    assert_response :not_found
+  end
 end

--- a/test/controllers/users/events_controller_test.rb
+++ b/test/controllers/users/events_controller_test.rb
@@ -14,4 +14,19 @@ class Users::EventsControllerTest < ActionDispatch::IntegrationTest
     get user_events_path(users(:david))
     assert_in_body "What has David been up to?"
   end
+
+  test "show returns not found for an unparseable day param" do
+    get user_events_path(users(:kevin), day: "garbage")
+    assert_response :not_found
+  end
+
+  test "show returns not found for an out-of-range day param" do
+    get user_events_path(users(:kevin), day: "2026-99-99")
+    assert_response :not_found
+  end
+
+  test "show returns not found for a non-string day param" do
+    get user_events_path(users(:kevin), day: [ "garbage" ])
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
Fixes two production 500 clusters in the events day timeline:

- [FIZZY-V7](https://basecamp.sentry.io/issues/7687550956/) — `NoMethodError: undefined method 'to_date' for nil` at `app/models/user/day_timeline.rb:45` (`cache_key`) via `Events::DaysController#index` (6 events, 2026-08-23)
- [FIZZY-V4](https://basecamp.sentry.io/issues/7685966234/) — `NoMethodError: undefined method 'all_day' for nil` at `app/models/user/day_timeline.rb:92` via `Events::DayTimeline::ColumnsController#show` (1 event, 2026-08-22)

## Mechanism

`DayTimelinesScoped#day` parses `params[:day]` with `Time.zone.parse` and rescued only `ArgumentError`. But `Time.zone.parse` returns **nil without raising** for strings that yield no date parts (`"garbage"`, `"."`, `"0"`), so a nil day reached `User::DayTimeline` and crashed at the first `day.*` call: `cache_key` for `events/days`, `window` (via `set_column` → `added_column`) for `events/day_timeline/columns/:id`. The Sentry events show empty query strings only because `send_default_pii = false` strips them.

Two sibling paths had the same defect:

- `EventsController#index` — third consumer of the concern, same nil path
- `Users::EventsController#day_param` — identical parse with **no rescue at all**, so out-of-range dates (`?day=2026-99-99`) also 500'd there

Array params (`?day[]=x`) raised `TypeError` through the same boundary — another unrescued 500 shape.

## Fix

Treat an unparseable `day` as not found at the controller boundary — `raise ActiveRecord::RecordNotFound unless day` (per review), which renders a conventional 404 — and rescue `TypeError` alongside `ArgumentError`. Valid requests are unchanged (default `Time.current`, parsed days, `fresh_when`/ETag behavior).

## Red-first proof

New tests run against main's code (fix stashed):

```
ERROR Events::DaysControllerTest#test_index_returns_not_found_for_an_unparseable_day_param
  NoMethodError: undefined method 'to_date' for nil
    app/models/user/day_timeline.rb:45:in 'User::DayTimeline#cache_key'
ERROR Events::DayTimeline::ColumnsControllerTest#test_show_returns_not_found_for_an_unparseable_day_param
  NoMethodError: undefined method 'all_day' for nil
    app/models/user/day_timeline.rb:92:in 'User::DayTimeline#window'
ERROR Events::DaysControllerTest#test_index_returns_not_found_for_a_non-string_day_param
  TypeError: no implicit conversion of Array into String
ERROR Users::EventsControllerTest#test_show_returns_not_found_for_an_unparseable_day_param
  NoMethodError: undefined method 'to_date' for nil
ERROR Users::EventsControllerTest#test_show_returns_not_found_for_an_out-of-range_day_param
  ArgumentError: argument out of range

14 tests, 45 assertions, 0 failures, 5 errors
```

With the fix: all touched test files green (`0 failures, 0 errors`).

On-call card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10247046852

