### PR TITLE
Accept https redirect URIs for dynamically registered clients

### DIFF
--- a/app/controllers/oauth/clients_controller.rb
+++ b/app/controllers/oauth/clients_controller.rb
@@ -52,11 +52,11 @@ class Oauth::ClientsController < Oauth::BaseController
     end
 
     def loopback_uri?(parsed)
-      parsed.scheme == "http" && Oauth::LOOPBACK_HOSTS.include?(parsed.host)
+      parsed.scheme == "http" && Oauth.loopback_host?(parsed.host)
     end
 
     def https_uri?(parsed)
-      parsed.scheme == "https" && parsed.host.present? && !Oauth::LOOPBACK_HOSTS.include?(parsed.host)
+      parsed.scheme == "https" && parsed.host.present? && !Oauth.loopback_host?(parsed.host)
     end
 
     def validated_scopes

--- a/app/controllers/oauth/clients_controller.rb
+++ b/app/controllers/oauth/clients_controller.rb
@@ -5,7 +5,7 @@ class Oauth::ClientsController < Oauth::BaseController
   rate_limit to: 10, within: 1.minute, only: :create, with: :oauth_rate_limit_exceeded
 
   before_action :validate_redirect_uris
-  before_action :validate_loopback_uris
+  before_action :validate_redirect_uri_origins
   before_action :validate_auth_method
 
   def create
@@ -27,9 +27,9 @@ class Oauth::ClientsController < Oauth::BaseController
       end
     end
 
-    def validate_loopback_uris
-      unless performed? || all_loopback_uris?(params[:redirect_uris])
-        oauth_error "invalid_redirect_uri", "Only loopback redirect URIs are allowed for dynamic registration"
+    def validate_redirect_uri_origins
+      unless performed? || all_registrable_uris?(params[:redirect_uris])
+        oauth_error "invalid_redirect_uri", "Only https or local loopback redirect URIs are allowed for dynamic registration"
       end
     end
 
@@ -39,18 +39,24 @@ class Oauth::ClientsController < Oauth::BaseController
       end
     end
 
-    def all_loopback_uris?(uris)
+    def all_registrable_uris?(uris)
       uris.is_a?(Array) &&
-        uris.all? { |uri| uri.is_a?(String) && valid_loopback_uri?(uri) }
+        uris.all? { |uri| uri.is_a?(String) && registrable_uri?(uri) }
     end
 
-    def valid_loopback_uri?(uri)
+    def registrable_uri?(uri)
       parsed = URI.parse(uri)
-      parsed.scheme == "http" &&
-        Oauth::LOOPBACK_HOSTS.include?(parsed.host) &&
-        parsed.fragment.nil?
+      parsed.fragment.nil? && (loopback_uri?(parsed) || https_uri?(parsed))
     rescue URI::InvalidURIError
       false
+    end
+
+    def loopback_uri?(parsed)
+      parsed.scheme == "http" && Oauth::LOOPBACK_HOSTS.include?(parsed.host)
+    end
+
+    def https_uri?(parsed)
+      parsed.scheme == "https" && parsed.host.present? && !Oauth::LOOPBACK_HOSTS.include?(parsed.host)
     end
 
     def validated_scopes

--- a/app/models/oauth.rb
+++ b/app/models/oauth.rb
@@ -1,6 +1,10 @@
 module Oauth
   LOOPBACK_HOSTS = %w[ 127.0.0.1 localhost ::1 [::1] ]
 
+  def self.loopback_host?(host)
+    LOOPBACK_HOSTS.include?(host.to_s.downcase)
+  end
+
   def self.table_name_prefix
     "oauth_"
   end

--- a/app/models/oauth.rb
+++ b/app/models/oauth.rb
@@ -2,7 +2,7 @@ module Oauth
   LOOPBACK_HOSTS = %w[ 127.0.0.1 localhost ::1 [::1] ]
 
   def self.loopback_host?(host)
-    LOOPBACK_HOSTS.include?(host.to_s.downcase)
+    LOOPBACK_HOSTS.include?(URI.decode_www_form_component(host.to_s).downcase)
   end
 
   def self.table_name_prefix

--- a/app/models/oauth.rb
+++ b/app/models/oauth.rb
@@ -3,6 +3,11 @@ module Oauth
 
   def self.loopback_host?(host)
     LOOPBACK_HOSTS.include?(URI.decode_www_form_component(host.to_s).downcase)
+  rescue ArgumentError
+    # A percent-encoding that decodes to invalid UTF-8 is not a usable host.
+    # Surface it as an invalid URI so every caller — all of which already
+    # rescue URI::InvalidURIError — rejects it instead of raising a 500.
+    raise URI::InvalidURIError, "invalid percent-encoding in host"
   end
 
   def self.table_name_prefix

--- a/app/models/oauth/client.rb
+++ b/app/models/oauth/client.rb
@@ -40,8 +40,8 @@ class Oauth::Client < ApplicationRecord
         errors.add :redirect_uris, "must not contain fragments"
       end
 
-      if dynamically_registered? && !valid_loopback_uri?(parsed)
-        errors.add :redirect_uris, "must be a local loopback URI for dynamically registered clients"
+      if dynamically_registered? && !valid_loopback_uri?(parsed) && !valid_https_uri?(parsed)
+        errors.add :redirect_uris, "must be an https or local loopback URI for dynamically registered clients"
       end
     rescue URI::InvalidURIError
       errors.add :redirect_uris, "includes an invalid URI"
@@ -55,6 +55,10 @@ class Oauth::Client < ApplicationRecord
 
     def valid_loopback_uri?(parsed)
       parsed.scheme == "http" && parsed.host.in?(Oauth::LOOPBACK_HOSTS)
+    end
+
+    def valid_https_uri?(parsed)
+      parsed.scheme == "https" && parsed.host.present? && !parsed.host.in?(Oauth::LOOPBACK_HOSTS)
     end
 
     def matching_loopback?(uri)

--- a/app/models/oauth/client.rb
+++ b/app/models/oauth/client.rb
@@ -15,12 +15,8 @@ class Oauth::Client < ApplicationRecord
   scope :dynamically_registered, -> { where dynamically_registered: true }
 
 
-  def loopback?
-    redirect_uris.all? { |uri| loopback_uri?(uri) }
-  end
-
   def allows_redirect?(uri)
-    redirect_uris.include?(uri) || (loopback? && loopback_uri?(uri) && matching_loopback?(uri))
+    redirect_uris.include?(uri) || (loopback_uri?(uri) && matching_loopback?(uri))
   end
 
   def allows_scope?(requested_scope)
@@ -36,7 +32,7 @@ class Oauth::Client < ApplicationRecord
     def validate_redirect_uri(uri)
       parsed = URI.parse(uri)
 
-      if parsed.fragment.present?
+      unless parsed.fragment.nil?
         errors.add :redirect_uris, "must not contain fragments"
       end
 

--- a/app/models/oauth/client.rb
+++ b/app/models/oauth/client.rb
@@ -44,17 +44,17 @@ class Oauth::Client < ApplicationRecord
     end
 
     def loopback_uri?(uri)
-      Oauth::LOOPBACK_HOSTS.include?(URI.parse(uri).host)
+      Oauth.loopback_host?(URI.parse(uri).host)
     rescue URI::InvalidURIError
       false
     end
 
     def valid_loopback_uri?(parsed)
-      parsed.scheme == "http" && parsed.host.in?(Oauth::LOOPBACK_HOSTS)
+      parsed.scheme == "http" && Oauth.loopback_host?(parsed.host)
     end
 
     def valid_https_uri?(parsed)
-      parsed.scheme == "https" && parsed.host.present? && !parsed.host.in?(Oauth::LOOPBACK_HOSTS)
+      parsed.scheme == "https" && parsed.host.present? && !Oauth.loopback_host?(parsed.host)
     end
 
     def matching_loopback?(uri)
@@ -64,8 +64,8 @@ class Oauth::Client < ApplicationRecord
         redirect = URI.parse(redirect_uri)
 
         redirect.scheme == parsed.scheme &&
-          redirect.host.in?(Oauth::LOOPBACK_HOSTS) &&
-          parsed.host.in?(Oauth::LOOPBACK_HOSTS) &&
+          Oauth.loopback_host?(redirect.host) &&
+          Oauth.loopback_host?(parsed.host) &&
           redirect.path == parsed.path
       end
     rescue URI::InvalidURIError

--- a/app/views/oauth/authorizations/new.html.erb
+++ b/app/views/oauth/authorizations/new.html.erb
@@ -17,7 +17,12 @@
       <strong>Application</strong>
       <p class="margin-none"><%= @client.name %></p>
       <% if @client.dynamically_registered? %>
-        <p class="txt-small txt-muted margin-none">Registered by a local tool. Only authorize if you trust it.</p>
+        <% redirect_host = URI.parse(@redirect_uri).host %>
+        <% if Oauth.loopback_host?(redirect_host) %>
+          <p class="txt-small txt-muted margin-none">Registered by a local tool. Only authorize if you trust it.</p>
+        <% else %>
+          <p class="txt-small txt-muted margin-none">Self-registered app that will receive access at <strong><%= redirect_host %></strong>. Only authorize if you trust it.</p>
+        <% end %>
       <% end %>
     </div>
 

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -450,6 +450,20 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_equal "invalid_redirect_uri", response.parsed_body["error"]
   end
 
+  test "DCR rejects a redirect whose host decodes to invalid UTF-8" do
+    assert_no_difference "Oauth::Client.count" do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "Broken Host",
+          redirect_uris: [ "https://%FF/callback" ]
+        }, as: :json
+      end
+    end
+
+    assert_response :bad_request
+    assert_equal "invalid_redirect_uri", response.parsed_body["error"]
+  end
+
   test "DCR rejects https redirect with fragment" do
     assert_no_difference "Oauth::Client.count" do
       untenanted do

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -377,18 +377,101 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_equal [ "http://127.0.0.1:8888/callback" ], body["redirect_uris"]
   end
 
-  test "DCR rejects non-loopback redirect" do
+  test "DCR creates client with https redirect" do
+    assert_difference "Oauth::Client.count", 1 do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "Hosted Connector",
+          redirect_uris: [ "https://connector.example.com/callback" ]
+        }, as: :json
+      end
+    end
+
+    assert_response :created
+    body = response.parsed_body
+
+    assert_not_nil body["client_id"]
+    assert_equal [ "https://connector.example.com/callback" ], body["redirect_uris"]
+  end
+
+  test "DCR rejects plain http non-loopback redirect" do
     assert_no_difference "Oauth::Client.count" do
       untenanted do
         post oauth_clients_path, params: {
           client_name: "Evil Client",
-          redirect_uris: [ "https://evil.com/steal" ]
+          redirect_uris: [ "http://evil.com/steal" ]
         }, as: :json
       end
     end
 
     assert_response :bad_request
     assert_equal "invalid_redirect_uri", response.parsed_body["error"]
+  end
+
+  test "DCR rejects https loopback redirect" do
+    assert_no_difference "Oauth::Client.count" do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "HTTPS Loopback",
+          redirect_uris: [ "https://127.0.0.1:8888/callback" ]
+        }, as: :json
+      end
+    end
+
+    assert_response :bad_request
+    assert_equal "invalid_redirect_uri", response.parsed_body["error"]
+  end
+
+  test "DCR rejects https redirect with fragment" do
+    assert_no_difference "Oauth::Client.count" do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "Fragment Client",
+          redirect_uris: [ "https://connector.example.com/callback#section" ]
+        }, as: :json
+      end
+    end
+
+    assert_response :bad_request
+    assert_equal "invalid_redirect_uri", response.parsed_body["error"]
+  end
+
+  test "https redirect requires exact match in authorization" do
+    sign_in_as :david
+
+    untenanted do
+      post oauth_clients_path, params: {
+        client_name: "Hosted Connector",
+        redirect_uris: [ "https://connector.example.com/callback" ]
+      }, as: :json
+    end
+    client_id = response.parsed_body["client_id"]
+
+    untenanted do
+      get new_oauth_authorization_path, params: {
+        client_id: client_id,
+        redirect_uri: "https://connector.example.com/callback",
+        response_type: "code",
+        code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+        code_challenge_method: "S256",
+        scope: "read",
+        state: "xyz123"
+      }
+    end
+    assert_response :success
+
+    untenanted do
+      get new_oauth_authorization_path, params: {
+        client_id: client_id,
+        redirect_uri: "https://connector.example.com:8443/callback",
+        response_type: "code",
+        code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+        code_challenge_method: "S256",
+        scope: "read",
+        state: "xyz123"
+      }
+    end
+    assert_response :bad_request
   end
 
   test "DCR requires redirect_uris" do

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -422,6 +422,20 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_equal "invalid_redirect_uri", response.parsed_body["error"]
   end
 
+  test "DCR rejects https loopback redirect regardless of host case" do
+    assert_no_difference "Oauth::Client.count" do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "Cased Loopback",
+          redirect_uris: [ "https://LOCALHOST:8888/callback" ]
+        }, as: :json
+      end
+    end
+
+    assert_response :bad_request
+    assert_equal "invalid_redirect_uri", response.parsed_body["error"]
+  end
+
   test "DCR rejects https redirect with fragment" do
     assert_no_difference "Oauth::Client.count" do
       untenanted do
@@ -459,6 +473,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }
     end
     assert_response :success
+    assert_match "connector.example.com", response.body
 
     untenanted do
       get new_oauth_authorization_path, params: {

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -436,6 +436,20 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_equal "invalid_redirect_uri", response.parsed_body["error"]
   end
 
+  test "DCR rejects percent-encoded https loopback redirect" do
+    assert_no_difference "Oauth::Client.count" do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "Encoded Loopback",
+          redirect_uris: [ "https://%6cocalhost:8888/callback" ]
+        }, as: :json
+      end
+    end
+
+    assert_response :bad_request
+    assert_equal "invalid_redirect_uri", response.parsed_body["error"]
+  end
+
   test "DCR rejects https redirect with fragment" do
     assert_no_difference "Oauth::Client.count" do
       untenanted do

--- a/test/models/oauth/client_test.rb
+++ b/test/models/oauth/client_test.rb
@@ -26,14 +26,23 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert_includes client.errors[:redirect_uris], "can't be blank"
   end
 
-  test "dynamically registered clients must use http loopback URIs" do
+  test "dynamically registered clients can use https URIs" do
+    client = Oauth::Client.new(
+      name: "Hosted Connector",
+      redirect_uris: %w[ https://connector.example.com/callback ],
+      dynamically_registered: true
+    )
+    assert client.valid?
+  end
+
+  test "dynamically registered clients reject plain http for non-loopback hosts" do
     client = Oauth::Client.new(
       name: "External",
-      redirect_uris: %w[ https://evil.com/callback ],
+      redirect_uris: %w[ http://example.com/callback ],
       dynamically_registered: true
     )
     assert_not client.valid?
-    assert_includes client.errors[:redirect_uris], "must be a local loopback URI for dynamically registered clients"
+    assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
   end
 
   test "dynamically registered clients reject https loopback" do
@@ -43,7 +52,17 @@ class Oauth::ClientTest < ActiveSupport::TestCase
       dynamically_registered: true
     )
     assert_not client.valid?
-    assert_includes client.errors[:redirect_uris], "must be a local loopback URI for dynamically registered clients"
+    assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
+  end
+
+  test "dynamically registered clients reject custom schemes" do
+    client = Oauth::Client.new(
+      name: "Native App",
+      redirect_uris: %w[ myapp://callback ],
+      dynamically_registered: true
+    )
+    assert_not client.valid?
+    assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
   end
 
   test "redirect URIs must not contain fragments" do

--- a/test/models/oauth/client_test.rb
+++ b/test/models/oauth/client_test.rb
@@ -45,6 +45,16 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
   end
 
+  test "dynamically registered clients reject https loopback regardless of host case" do
+    client = Oauth::Client.new(
+      name: "Cased Loopback",
+      redirect_uris: %w[ https://LOCALHOST:8888/callback ],
+      dynamically_registered: true
+    )
+    assert_not client.valid?
+    assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
+  end
+
   test "dynamically registered clients reject https loopback" do
     client = Oauth::Client.new(
       name: "HTTPS Loopback",

--- a/test/models/oauth/client_test.rb
+++ b/test/models/oauth/client_test.rb
@@ -55,6 +55,16 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
   end
 
+  test "dynamically registered clients reject percent-encoded https loopback" do
+    client = Oauth::Client.new(
+      name: "Encoded Loopback",
+      redirect_uris: %w[ https://%6cocalhost:8888/callback ],
+      dynamically_registered: true
+    )
+    assert_not client.valid?
+    assert_includes client.errors[:redirect_uris], "must be an https or local loopback URI for dynamically registered clients"
+  end
+
   test "dynamically registered clients reject https loopback" do
     client = Oauth::Client.new(
       name: "HTTPS Loopback",

--- a/test/models/oauth/client_test.rb
+++ b/test/models/oauth/client_test.rb
@@ -75,6 +75,16 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert_includes client.errors[:redirect_uris], "must not contain fragments"
   end
 
+  test "redirect URIs must not contain empty fragments" do
+    client = Oauth::Client.new(
+      name: "Empty Fragment",
+      redirect_uris: %w[ https://connector.example.com/callback# ],
+      dynamically_registered: true
+    )
+    assert_not client.valid?
+    assert_includes client.errors[:redirect_uris], "must not contain fragments"
+  end
+
   test "dynamically registered clients can use 127.0.0.1" do
     client = Oauth::Client.new(
       name: "Loopback",
@@ -102,16 +112,6 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert client.valid?
   end
 
-  test "loopback? returns true for loopback-only clients" do
-    client = Oauth::Client.new(redirect_uris: %w[ http://127.0.0.1:8888/cb http://localhost:9999/cb ])
-    assert client.loopback?
-  end
-
-  test "loopback? returns false for non-loopback clients" do
-    client = Oauth::Client.new(redirect_uris: %w[ https://example.com/cb ])
-    assert_not client.loopback?
-  end
-
   test "allows_redirect? matches exact URI" do
     client = Oauth::Client.new(redirect_uris: %w[ http://127.0.0.1:8888/callback ])
     assert client.allows_redirect?("http://127.0.0.1:8888/callback")
@@ -127,6 +127,13 @@ class Oauth::ClientTest < ActiveSupport::TestCase
   test "allows_redirect? requires matching path for loopback flexibility" do
     client = Oauth::Client.new(redirect_uris: %w[ http://127.0.0.1:8888/callback ])
     assert_not client.allows_redirect?("http://127.0.0.1:9999/other")
+  end
+
+  test "allows_redirect? keeps loopback flexibility for mixed registrations" do
+    client = Oauth::Client.new(redirect_uris: %w[ http://127.0.0.1:8888/callback https://connector.example.com/callback ])
+    assert client.allows_redirect?("http://127.0.0.1:9999/callback")
+    assert client.allows_redirect?("https://connector.example.com/callback")
+    assert_not client.allows_redirect?("https://connector.example.com:8443/callback")
   end
 
   test "allows_scope? checks client scopes" do


### PR DESCRIPTION
Stacked on #2296 (base: `oauth`). First of three gap-closers taking the minimal OAuth 2.1 stack to connector grade.

Hosted MCP connectors register over DCR with https callback URLs, which the loopback-only policy rejected. [9f7fa82](https://github.com/basecamp/fizzy/commit/9f7fa82122f2350df81f6c37a20d3964f0181f85) widens the registration policy:

* **Accepted**: http loopback URIs (unchanged, port-flexible matching) and https URIs on non-loopback hosts (exact matching, fragments rejected).
* **Still rejected**: plain http on public hosts, custom schemes, https on loopback hosts.
* Operator-provisioned clients are unaffected; the `trusted` flag stays manual provisioning only — dynamically registered https clients remain untrusted and go through the consent screen.

Model validation and the DCR endpoint enforce the same policy, with model and integration tests for both sides plus exact-match authorization behavior for https redirects.

Next in stack: refresh tokens + expiry, then confidential clients.