### PR TITLE
Support confidential clients with client_secret_post

### DIFF
--- a/app/controllers/oauth/base_controller.rb
+++ b/app/controllers/oauth/base_controller.rb
@@ -2,6 +2,11 @@ class Oauth::BaseController < ApplicationController
   disallow_account_scope
 
   private
+    def prevent_caching
+      response.headers["Cache-Control"] = "no-store"
+      response.headers["Pragma"] = "no-cache"
+    end
+
     def oauth_error(error, description = nil, status: :bad_request)
       render json: { error: error, error_description: description }.compact, status: status
     end

--- a/app/controllers/oauth/clients_controller.rb
+++ b/app/controllers/oauth/clients_controller.rb
@@ -2,6 +2,8 @@ class Oauth::ClientsController < Oauth::BaseController
   allow_unauthenticated_access
   skip_forgery_protection
 
+  after_action :prevent_caching
+
   rate_limit to: 10, within: 1.minute, only: :create, with: :oauth_rate_limit_exceeded
 
   before_action :validate_redirect_uris

--- a/app/controllers/oauth/clients_controller.rb
+++ b/app/controllers/oauth/clients_controller.rb
@@ -79,6 +79,7 @@ class Oauth::ClientsController < Oauth::BaseController
       {
         client_id: client.client_id,
         client_secret: client.client_secret,
+        client_secret_expires_at: (0 if client.client_secret),
         client_name: client.name,
         redirect_uris: client.redirect_uris,
         token_endpoint_auth_method: client.token_endpoint_auth_method,

--- a/app/controllers/oauth/clients_controller.rb
+++ b/app/controllers/oauth/clients_controller.rb
@@ -13,6 +13,7 @@ class Oauth::ClientsController < Oauth::BaseController
       name: params[:client_name] || "MCP Client",
       redirect_uris: Array(params[:redirect_uris]),
       scopes: validated_scopes,
+      token_endpoint_auth_method: registered_auth_method,
       dynamically_registered: true
 
     render json: dynamic_client_registration_response(client), status: :created
@@ -34,9 +35,13 @@ class Oauth::ClientsController < Oauth::BaseController
     end
 
     def validate_auth_method
-      unless performed? || params[:token_endpoint_auth_method].blank? || params[:token_endpoint_auth_method] == "none"
-        oauth_error "invalid_client_metadata", "Only 'none' token_endpoint_auth_method is supported"
+      unless performed? || registered_auth_method.in?(%w[ none client_secret_post ])
+        oauth_error "invalid_client_metadata", "Only 'none' and 'client_secret_post' token_endpoint_auth_methods are supported"
       end
+    end
+
+    def registered_auth_method
+      params[:token_endpoint_auth_method].presence || "none"
     end
 
     def all_registrable_uris?(uris)
@@ -71,12 +76,13 @@ class Oauth::ClientsController < Oauth::BaseController
     def dynamic_client_registration_response(client)
       {
         client_id: client.client_id,
+        client_secret: client.client_secret,
         client_name: client.name,
         redirect_uris: client.redirect_uris,
-        token_endpoint_auth_method: "none",
+        token_endpoint_auth_method: client.token_endpoint_auth_method,
         grant_types: %w[ authorization_code refresh_token ],
         response_types: %w[ code ],
         scope: client.scopes.join(" ")
-      }
+      }.compact
     end
 end

--- a/app/controllers/oauth/metadata_controller.rb
+++ b/app/controllers/oauth/metadata_controller.rb
@@ -10,7 +10,7 @@ class Oauth::MetadataController < Oauth::BaseController
       revocation_endpoint: oauth_revocation_url,
       response_types_supported: %w[ code ],
       grant_types_supported: %w[ authorization_code refresh_token ],
-      token_endpoint_auth_methods_supported: %w[ none ],
+      token_endpoint_auth_methods_supported: %w[ none client_secret_post ],
       code_challenge_methods_supported: %w[ S256 ],
       scopes_supported: %w[ read write ]
     }

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -16,13 +16,18 @@ class Oauth::TokensController < Oauth::BaseController
     before_action :set_identity
   end
 
+  before_action :set_refreshable_access_token, unless: :authorization_code_grant?
+
+  # Authenticate the posted client before validating that the refresh token
+  # belongs to it: a confidential client that fails auth must see invalid_client
+  # (401), not the invalid_grant that a client_id mismatch would raise first —
+  # which a client could misread as a revoked grant and discard.
+  before_action :authenticate_client
+
   with_options unless: :authorization_code_grant? do
-    before_action :set_refreshable_access_token
     before_action :validate_refresh_client
     before_action :set_refresh_scope
   end
-
-  before_action :authenticate_client
 
   def create
     if authorization_code_grant?

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -2,6 +2,8 @@ class Oauth::TokensController < Oauth::BaseController
   allow_unauthenticated_access
   skip_forgery_protection
 
+  after_action :prevent_caching
+
   rate_limit to: 20, within: 1.minute, only: :create, with: :oauth_rate_limit_exceeded
 
   before_action :validate_grant_type

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -119,11 +119,15 @@ class Oauth::TokensController < Oauth::BaseController
       granted_scopes(permission).join(" ")
     end
 
+    # client_secret_post authenticates with client_id and client_secret in
+    # the request body, per RFC 6749 §2.3.1.
     def authenticate_client
       client = @client || @access_token.oauth_client
 
-      if client.confidential? && !client.authenticate_secret(params[:client_secret])
-        oauth_error "invalid_client", "Client authentication failed", status: :unauthorized
+      if client.confidential?
+        unless params[:client_id] == client.client_id && client.authenticate_secret(params[:client_secret])
+          oauth_error "invalid_client", "Client authentication failed", status: :unauthorized
+        end
       end
     end
 

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -20,6 +20,8 @@ class Oauth::TokensController < Oauth::BaseController
     before_action :set_refresh_scope
   end
 
+  before_action :authenticate_client
+
   def create
     if authorization_code_grant?
       granted = @auth_code.scope.to_s.split
@@ -113,6 +115,14 @@ class Oauth::TokensController < Oauth::BaseController
 
     def scope_for(permission)
       granted_scopes(permission).join(" ")
+    end
+
+    def authenticate_client
+      client = @client || @access_token.oauth_client
+
+      if client.confidential? && !client.authenticate_secret(params[:client_secret])
+        oauth_error "invalid_client", "Client authentication failed", status: :unauthorized
+      end
     end
 
     def token_response(access_token, scope: nil)

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -120,12 +120,15 @@ class Oauth::TokensController < Oauth::BaseController
     end
 
     # client_secret_post authenticates with client_id and client_secret in
-    # the request body, per RFC 6749 §2.3.1.
+    # the request body, per RFC 6749 §2.3.1 — never the query string, where
+    # secrets leak into proxy and access logs.
     def authenticate_client
       client = @client || @access_token.oauth_client
 
       if client.confidential?
-        unless params[:client_id] == client.client_id && client.authenticate_secret(params[:client_secret])
+        credentials = request.request_parameters
+
+        unless credentials["client_id"] == client.client_id && client.authenticate_secret(credentials["client_secret"])
           oauth_error "invalid_client", "Client authentication failed", status: :unauthorized
         end
       end

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -19,9 +19,9 @@ class Oauth::TokensController < Oauth::BaseController
   before_action :set_refreshable_access_token, unless: :authorization_code_grant?
 
   # Authenticate the posted client before validating that the refresh token
-  # belongs to it: a confidential client that fails auth must see invalid_client
-  # (401), not the invalid_grant that a client_id mismatch would raise first —
-  # which a client could misread as a revoked grant and discard.
+  # belongs to it: a confidential client that fails auth must see invalid_client,
+  # not the invalid_grant that a client_id mismatch would raise first — which a
+  # client could misread as a revoked grant and discard.
   before_action :authenticate_client
 
   with_options unless: :authorization_code_grant? do
@@ -126,7 +126,9 @@ class Oauth::TokensController < Oauth::BaseController
 
     # client_secret_post authenticates with client_id and client_secret in
     # the request body, per RFC 6749 §2.3.1 — never the query string, where
-    # secrets leak into proxy and access logs.
+    # secrets leak into proxy and access logs. A failure is a 400 invalid_client
+    # (RFC 6749 §5.2): 401 is reserved for header-based schemes and would owe a
+    # WWW-Authenticate challenge we have no scheme to fill.
     def authenticate_client
       client = @client || @access_token.oauth_client
 
@@ -134,7 +136,7 @@ class Oauth::TokensController < Oauth::BaseController
         credentials = request.request_parameters
 
         unless credentials["client_id"] == client.client_id && client.authenticate_secret(credentials["client_secret"])
-          oauth_error "invalid_client", "Client authentication failed", status: :unauthorized
+          oauth_error "invalid_client", "Client authentication failed"
         end
       end
     end

--- a/app/models/oauth/client.rb
+++ b/app/models/oauth/client.rb
@@ -6,7 +6,10 @@ class Oauth::Client < ApplicationRecord
   validates :name, presence: true
   validates :client_id, uniqueness: true, allow_nil: true
   validates :redirect_uris, presence: true
+  validates :token_endpoint_auth_method, inclusion: { in: %w[ none client_secret_post ] }
   validate :redirect_uris_are_valid
+
+  before_create :generate_client_secret, if: :confidential?
 
   attribute :redirect_uris, default: -> { [] }
   attribute :scopes, default: -> { %w[ read ] }
@@ -14,6 +17,15 @@ class Oauth::Client < ApplicationRecord
   scope :trusted, -> { where trusted: true }
   scope :dynamically_registered, -> { where dynamically_registered: true }
 
+
+  def confidential?
+    token_endpoint_auth_method == "client_secret_post"
+  end
+
+  def authenticate_secret(secret)
+    confidential? && client_secret.present? && secret.present? &&
+      ActiveSupport::SecurityUtils.secure_compare(client_secret, secret)
+  end
 
   def allows_redirect?(uri)
     redirect_uris.include?(uri) || (loopback_uri?(uri) && matching_loopback?(uri))
@@ -25,6 +37,10 @@ class Oauth::Client < ApplicationRecord
   end
 
   private
+    def generate_client_secret
+      self.client_secret ||= self.class.generate_unique_secure_token
+    end
+
     def redirect_uris_are_valid
       redirect_uris.each { |uri| validate_redirect_uri(uri) }
     end

--- a/app/models/oauth/client.rb
+++ b/app/models/oauth/client.rb
@@ -23,7 +23,7 @@ class Oauth::Client < ApplicationRecord
   end
 
   def authenticate_secret(secret)
-    confidential? && client_secret.present? && secret.present? &&
+    confidential? && client_secret.present? && secret.is_a?(String) && secret.present? &&
       ActiveSupport::SecurityUtils.secure_compare(client_secret, secret)
   end
 

--- a/db/migrate/20260827110000_add_oauth_client_secrets.rb
+++ b/db/migrate/20260827110000_add_oauth_client_secrets.rb
@@ -1,0 +1,8 @@
+class AddOauthClientSecrets < ActiveRecord::Migration[8.2]
+  def change
+    change_table :oauth_clients, bulk: true do |t|
+      t.string :client_secret
+      t.string :token_endpoint_auth_method, null: false, default: "none"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -436,11 +436,13 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_28_120000) do
 
   create_table "oauth_clients", id: :uuid, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "client_id", null: false
+    t.string "client_secret"
     t.datetime "created_at", null: false
     t.boolean "dynamically_registered", default: false
     t.string "name", null: false
     t.json "redirect_uris"
     t.json "scopes"
+    t.string "token_endpoint_auth_method", default: "none", null: false
     t.boolean "trusted", default: false
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_oauth_clients_on_client_id", unique: true

--- a/db/schema_sqlite.rb
+++ b/db/schema_sqlite.rb
@@ -436,11 +436,13 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_28_120000) do
 
   create_table "oauth_clients", id: :uuid, force: :cascade do |t|
     t.string "client_id", limit: 255, null: false
+    t.string "client_secret", limit: 255
     t.datetime "created_at", null: false
     t.boolean "dynamically_registered", default: false
     t.string "name", limit: 255, null: false
     t.json "redirect_uris"
     t.json "scopes"
+    t.string "token_endpoint_auth_method", limit: 255, default: "none", null: false
     t.boolean "trusted", default: false
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_oauth_clients_on_client_id", unique: true

--- a/test/fixtures/oauth/clients.yml
+++ b/test/fixtures/oauth/clients.yml
@@ -19,3 +19,16 @@ trusted_client:
     - write
   dynamically_registered: false
   trusted: true
+
+confidential_client:
+  client_id: confidential_client_789
+  client_secret: confidential_secret_789
+  name: Confidential Connector
+  redirect_uris:
+    - https://connector.example.com/callback
+  scopes:
+    - read
+    - write
+  token_endpoint_auth_method: client_secret_post
+  dynamically_registered: true
+  trusted: false

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -407,6 +407,31 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_not_nil response.parsed_body["access_token"]
   end
 
+  test "token exchange for confidential client rejects credentials in the query string" do
+    client = oauth_clients(:confidential_client)
+    code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+
+    code = Oauth::AuthorizationCode.generate \
+      client_id: client.client_id,
+      identity_id: identities(:david).id,
+      code_challenge: code_challenge,
+      redirect_uri: "https://connector.example.com/callback",
+      scope: "read"
+
+    untenanted do
+      post oauth_token_path(client_id: client.client_id, client_secret: "confidential_secret_789"), params: {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: "https://connector.example.com/callback",
+        code_verifier: code_verifier
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
+  end
+
   test "token exchange for confidential client requires a matching client_id" do
     client = oauth_clients(:confidential_client)
     code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -485,6 +485,22 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "refresh grant for confidential client omitting client_id fails as invalid_client" do
+    client = oauth_clients(:confidential_client)
+    token = identities(:david).access_tokens.create!(oauth_client: client)
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_secret: "confidential_secret_789"
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
+  end
+
 
   # Refresh Grant
 

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -299,6 +299,115 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
   end
 
 
+  # Confidential Clients (client_secret_post)
+
+  test "token exchange for confidential client requires client secret" do
+    client = oauth_clients(:confidential_client)
+    code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+
+    code = Oauth::AuthorizationCode.generate \
+      client_id: client.client_id,
+      identity_id: identities(:david).id,
+      code_challenge: code_challenge,
+      redirect_uri: "https://connector.example.com/callback",
+      scope: "read"
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: "https://connector.example.com/callback",
+        code_verifier: code_verifier
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
+  end
+
+  test "token exchange for confidential client rejects a wrong client secret" do
+    client = oauth_clients(:confidential_client)
+    code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+
+    code = Oauth::AuthorizationCode.generate \
+      client_id: client.client_id,
+      identity_id: identities(:david).id,
+      code_challenge: code_challenge,
+      redirect_uri: "https://connector.example.com/callback",
+      scope: "read"
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: "https://connector.example.com/callback",
+        code_verifier: code_verifier,
+        client_secret: "wrong"
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
+  end
+
+  test "token exchange for confidential client succeeds with the client secret" do
+    client = oauth_clients(:confidential_client)
+    code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+
+    code = Oauth::AuthorizationCode.generate \
+      client_id: client.client_id,
+      identity_id: identities(:david).id,
+      code_challenge: code_challenge,
+      redirect_uri: "https://connector.example.com/callback",
+      scope: "read"
+
+    assert_difference "Identity::AccessToken.count", 1 do
+      untenanted do
+        post oauth_token_path, params: {
+          grant_type: "authorization_code",
+          code: code,
+          redirect_uri: "https://connector.example.com/callback",
+          code_verifier: code_verifier,
+          client_secret: "confidential_secret_789"
+        }, as: :json
+      end
+    end
+
+    assert_response :success
+    assert_not_nil response.parsed_body["access_token"]
+  end
+
+  test "refresh grant for confidential client requires the client secret" do
+    client = oauth_clients(:confidential_client)
+    token = identities(:david).access_tokens.create!(oauth_client: client)
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_id: client.client_id
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_id: client.client_id,
+        client_secret: "confidential_secret_789"
+      }, as: :json
+    end
+
+    assert_response :success
+  end
+
+
   # Refresh Grant
 
   test "refresh grant rotates access and refresh tokens" do
@@ -716,6 +825,53 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }
     end
     assert_response :bad_request
+  end
+
+  test "DCR registers a confidential client with client_secret_post" do
+    untenanted do
+      post oauth_clients_path, params: {
+        client_name: "Hosted Connector",
+        redirect_uris: [ "https://connector.example.com/callback" ],
+        token_endpoint_auth_method: "client_secret_post"
+      }, as: :json
+    end
+
+    assert_response :created
+    body = response.parsed_body
+
+    assert_equal "client_secret_post", body["token_endpoint_auth_method"]
+    assert_not_nil body["client_secret"]
+    assert Oauth::Client.find_by(client_id: body["client_id"]).confidential?
+  end
+
+  test "DCR omits client_secret for public clients" do
+    untenanted do
+      post oauth_clients_path, params: {
+        client_name: "Public Client",
+        redirect_uris: [ "http://127.0.0.1:8888/callback" ]
+      }, as: :json
+    end
+
+    assert_response :created
+    body = response.parsed_body
+
+    assert_equal "none", body["token_endpoint_auth_method"]
+    assert_not body.key?("client_secret")
+  end
+
+  test "DCR rejects unsupported token_endpoint_auth_method" do
+    assert_no_difference "Oauth::Client.count" do
+      untenanted do
+        post oauth_clients_path, params: {
+          client_name: "Basic Client",
+          redirect_uris: [ "https://connector.example.com/callback" ],
+          token_endpoint_auth_method: "client_secret_basic"
+        }, as: :json
+      end
+    end
+
+    assert_response :bad_request
+    assert_equal "invalid_client_metadata", response.parsed_body["error"]
   end
 
   test "DCR requires redirect_uris" do

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -397,6 +397,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
           code: code,
           redirect_uri: "https://connector.example.com/callback",
           code_verifier: code_verifier,
+          client_id: client.client_id,
           client_secret: "confidential_secret_789"
         }, as: :json
       end
@@ -404,6 +405,32 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_not_nil response.parsed_body["access_token"]
+  end
+
+  test "token exchange for confidential client requires a matching client_id" do
+    client = oauth_clients(:confidential_client)
+    code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+
+    code = Oauth::AuthorizationCode.generate \
+      client_id: client.client_id,
+      identity_id: identities(:david).id,
+      code_challenge: code_challenge,
+      redirect_uri: "https://connector.example.com/callback",
+      scope: "read"
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: "https://connector.example.com/callback",
+        code_verifier: code_verifier,
+        client_secret: "confidential_secret_789"
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
   end
 
   test "refresh grant for confidential client requires the client secret" do
@@ -677,6 +704,8 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_includes body["code_challenge_methods_supported"], "S256"
     assert_includes body["grant_types_supported"], "authorization_code"
     assert_includes body["grant_types_supported"], "refresh_token"
+    assert_includes body["token_endpoint_auth_methods_supported"], "none"
+    assert_includes body["token_endpoint_auth_methods_supported"], "client_secret_post"
   end
 
   test "protected resource metadata includes authorization server" do
@@ -867,6 +896,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
 
     assert_equal "client_secret_post", body["token_endpoint_auth_method"]
     assert_not_nil body["client_secret"]
+    assert_equal 0, body["client_secret_expires_at"]
     assert_equal "no-store", response.headers["Cache-Control"]
     assert Oauth::Client.find_by(client_id: body["client_id"]).confidential?
   end
@@ -884,6 +914,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
 
     assert_equal "none", body["token_endpoint_auth_method"]
     assert_not body.key?("client_secret")
+    assert_not body.key?("client_secret_expires_at")
   end
 
   test "DCR rejects unsupported token_endpoint_auth_method" do

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -352,6 +352,32 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 
+  test "token exchange for confidential client rejects a non-string client secret" do
+    client = oauth_clients(:confidential_client)
+    code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    code_challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+
+    code = Oauth::AuthorizationCode.generate \
+      client_id: client.client_id,
+      identity_id: identities(:david).id,
+      code_challenge: code_challenge,
+      redirect_uri: "https://connector.example.com/callback",
+      scope: "read"
+
+    untenanted do
+      post oauth_token_path, params: {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: "https://connector.example.com/callback",
+        code_verifier: code_verifier,
+        client_secret: [ "confidential_secret_789" ]
+      }, as: :json
+    end
+
+    assert_response :unauthorized
+    assert_equal "invalid_client", response.parsed_body["error"]
+  end
+
   test "token exchange for confidential client succeeds with the client secret" do
     client = oauth_clients(:confidential_client)
     code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
@@ -841,6 +867,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
 
     assert_equal "client_secret_post", body["token_endpoint_auth_method"]
     assert_not_nil body["client_secret"]
+    assert_equal "no-store", response.headers["Cache-Control"]
     assert Oauth::Client.find_by(client_id: body["client_id"]).confidential?
   end
 

--- a/test/integration/oauth_flow_test.rb
+++ b/test/integration/oauth_flow_test.rb
@@ -322,7 +322,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 
@@ -348,7 +348,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 
@@ -374,7 +374,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 
@@ -428,7 +428,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 
@@ -454,7 +454,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 
@@ -470,7 +470,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
 
     untenanted do
@@ -497,7 +497,7 @@ class OauthFlowTest < ActionDispatch::IntegrationTest
       }, as: :json
     end
 
-    assert_response :unauthorized
+    assert_response :bad_request
     assert_equal "invalid_client", response.parsed_body["error"]
   end
 

--- a/test/models/oauth/client_test.rb
+++ b/test/models/oauth/client_test.rb
@@ -171,6 +171,41 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert_equal %w[ read ], client.scopes
   end
 
+  test "confidential clients generate a client secret on create" do
+    client = Oauth::Client.create!(
+      name: "Confidential",
+      redirect_uris: %w[ https://connector.example.com/callback ],
+      token_endpoint_auth_method: "client_secret_post"
+    )
+    assert client.confidential?
+    assert_not_nil client.client_secret
+  end
+
+  test "public clients get no client secret" do
+    client = Oauth::Client.create!(name: "Public", redirect_uris: %w[ http://127.0.0.1:8888/callback ])
+    assert_not client.confidential?
+    assert_nil client.client_secret
+  end
+
+  test "token_endpoint_auth_method must be supported" do
+    client = Oauth::Client.new(
+      name: "Basic",
+      redirect_uris: %w[ http://127.0.0.1/cb ],
+      token_endpoint_auth_method: "client_secret_basic"
+    )
+    assert_not client.valid?
+    assert_includes client.errors[:token_endpoint_auth_method], "is not included in the list"
+  end
+
+  test "authenticate_secret" do
+    client = oauth_clients(:confidential_client)
+    assert client.authenticate_secret("confidential_secret_789")
+    assert_not client.authenticate_secret("wrong")
+    assert_not client.authenticate_secret("")
+    assert_not client.authenticate_secret(nil)
+    assert_not oauth_clients(:mcp_client).authenticate_secret("confidential_secret_789")
+  end
+
   test "trusted scope" do
     trusted = Oauth::Client.trusted
     assert trusted.all?(&:trusted?)

--- a/test/models/oauth/client_test.rb
+++ b/test/models/oauth/client_test.rb
@@ -203,6 +203,7 @@ class Oauth::ClientTest < ActiveSupport::TestCase
     assert_not client.authenticate_secret("wrong")
     assert_not client.authenticate_secret("")
     assert_not client.authenticate_secret(nil)
+    assert_not client.authenticate_secret([ "confidential_secret_789" ])
     assert_not oauth_clients(:mcp_client).authenticate_secret("confidential_secret_789")
   end
 


### PR DESCRIPTION
Stacked on the refresh-token PR. Third gap-closer for #2296, matching what beta2's bc3 authorization server advertises.

[8080b3f](https://github.com/basecamp/fizzy/commit/8080b3f2acead6cbb56fc747591e74cf33cd9e4b) adds confidential client support:

* Clients carry a `token_endpoint_auth_method` (`none` or `client_secret_post`). Confidential clients get a generated `client_secret` at creation, returned once in the DCR response (`.compact` keeps it out of public-client responses).
* The token endpoint authenticates confidential clients on both grants, answering `invalid_client` (400 — no header scheme is advertised, so no `WWW-Authenticate` challenge to carry on a 401) when the posted secret is missing or wrong. Public loopback clients are unchanged.
* Discovery advertises both auth methods; DCR rejects anything else (e.g. `client_secret_basic`).
* Secrets are stored plaintext with constant-time comparison, matching how the stack already stores access tokens.

Revocation stays unauthenticated by design: revoking requires holding the token itself, which is the same capability the credential guards.
