### PR TITLE
Keep .claude out of the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,3 +43,6 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 /public/assets
+
+# Ignore agent session state — worktrees under .claude/ are whole extra checkouts of this repo.
+/.claude


### PR DESCRIPTION
Local agent session state (`.claude`) can grow large — worktrees under `.claude/worktrees` are whole extra checkouts of the repo — and ships with the Docker build context, bloating images. Ignore it.