### PR TITLE
Filter notification recipients by current board access; reconcile stale assignments

### DIFF
--- a/app/models/board/accessible.rb
+++ b/app/models/board/accessible.rb
@@ -47,7 +47,7 @@ module Board::Accessible
     notifications_for_user(user).destroy_all
     watches_for(user).destroy_all
     pins_for(user).destroy_all
-    assignments_for(user).delete_all
+    assignments_for(user).destroy_all
   end
 
   def watchers

--- a/app/models/board/accessible.rb
+++ b/app/models/board/accessible.rb
@@ -47,6 +47,7 @@ module Board::Accessible
     notifications_for_user(user).destroy_all
     watches_for(user).destroy_all
     pins_for(user).destroy_all
+    assignments_for(user).delete_all
   end
 
   def watchers
@@ -99,6 +100,10 @@ module Board::Accessible
 
     def watches_for(user)
       Watch.where(card: cards, user: user)
+    end
+
+    def assignments_for(user)
+      Assignment.where(card: cards, assignee: user)
     end
 
     def pins_for(user)

--- a/app/models/card/accessible.rb
+++ b/app/models/card/accessible.rb
@@ -13,6 +13,7 @@ module Card::Accessible
     accessible_user_ids = board.accesses.pluck(:user_id)
     pins.where.not(user_id: accessible_user_ids).in_batches.destroy_all
     watches.where.not(user_id: accessible_user_ids).in_batches.destroy_all
+    assignments.where.not(assignee_id: accessible_user_ids).in_batches.delete_all
   end
 
   private

--- a/app/models/card/accessible.rb
+++ b/app/models/card/accessible.rb
@@ -13,7 +13,7 @@ module Card::Accessible
     accessible_user_ids = board.accesses.pluck(:user_id)
     pins.where.not(user_id: accessible_user_ids).in_batches.destroy_all
     watches.where.not(user_id: accessible_user_ids).in_batches.destroy_all
-    assignments.where.not(assignee_id: accessible_user_ids).in_batches.delete_all
+    assignments.where.not(assignee_id: accessible_user_ids).in_batches.destroy_all
   end
 
   private

--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -15,7 +15,7 @@ class Notifier
   def notify
     if should_notify?
       # Processing recipients in order avoids deadlocks if notifications overlap.
-      recipients.sort_by(&:id).map do |recipient|
+      accessible_recipients.sort_by(&:id).map do |recipient|
         notification = Notification.create_or_find_by(user: recipient, card: source.card) do |n|
           n.source = source
           n.creator = creator
@@ -44,5 +44,10 @@ class Notifier
 
     def should_notify?
       !creator.system?
+    end
+
+    def accessible_recipients
+      accessible_user_ids = source.card.board.accesses.pluck(:user_id).to_set
+      recipients.select { |recipient| !recipient.active? || accessible_user_ids.include?(recipient.id) }
     end
 end

--- a/test/models/access_test.rb
+++ b/test/models/access_test.rb
@@ -81,6 +81,21 @@ class AccessTest < ActiveSupport::TestCase
     assert_not card.watched_by?(kevin)
   end
 
+  test "assignments are destroyed when access is lost" do
+    kevin = users(:kevin)
+    card = cards(:logo) # Kevin is assigned to this card
+
+    assert card.assigned_to?(kevin)
+
+    kevin_access = accesses(:writebook_kevin)
+
+    perform_enqueued_jobs only: Board::CleanInaccessibleDataJob do
+      kevin_access.destroy
+    end
+
+    assert_not card.reload.assigned_to?(kevin)
+  end
+
   test "pins are destroyed when access is lost" do
     kevin = users(:kevin)
     board = boards(:writebook)

--- a/test/models/card_test.rb
+++ b/test/models/card_test.rb
@@ -204,6 +204,19 @@ class CardTest < ActiveSupport::TestCase
     assert_not card.watched_by?(david), "David's watch should be deleted (no board access)"
   end
 
+  test "clean_inaccessible_data removes assignments for users without board access" do
+    card = boards(:private).cards.create!(title: "Secret", creator: users(:kevin))
+    david = users(:david)
+    card.assignments.create!(assignee: david, assigner: users(:kevin))
+
+    assert_not boards(:private).accessible_to?(david)
+    assert card.assigned_to?(david)
+
+    card.clean_inaccessible_data
+
+    assert_not card.reload.assigned_to?(david)
+  end
+
   test "card has reactions association" do
     card = cards(:logo)
     user = users(:david)

--- a/test/models/card_test.rb
+++ b/test/models/card_test.rb
@@ -212,7 +212,10 @@ class CardTest < ActiveSupport::TestCase
     assert_not boards(:private).accessible_to?(david)
     assert card.assigned_to?(david)
 
-    card.clean_inaccessible_data
+    travel 1.minute
+    assert_changes -> { card.reload.updated_at }, "cleanup must touch the card so board views refresh" do
+      card.clean_inaccessible_data
+    end
 
     assert_not card.reload.assigned_to?(david)
   end

--- a/test/models/notifier/event_notifier_test.rb
+++ b/test/models/notifier/event_notifier_test.rb
@@ -117,6 +117,26 @@ class Notifier::EventNotifierTest < ActiveSupport::TestCase
     assert_equal [ users(:jz) ], notifications.map(&:user)
   end
 
+  test "does not notify a watcher who lost board access after the card moved" do
+    card = cards(:logo)
+    david = users(:david)
+    card.watch_by(david)
+
+    Current.set(session: sessions(:kevin), user: users(:kevin)) do
+      card.update!(board: boards(:private))
+    end
+
+    assert_not boards(:private).accessible_to?(david), "david must not have destination-board access"
+    assert_includes card.reload.watchers, david, "stale watch persists in the async cleanup window"
+
+    comment = card.comments.create!(body: "Confidential", creator: users(:kevin))
+    event = card.board.events.create!(action: "comment_created", creator: users(:kevin), eventable: comment)
+
+    notifications = Notifier.for(event).notify
+
+    assert_not_includes notifications.map(&:user), david
+  end
+
   private
     def mention_html_for(user)
       ActionText::Attachment.from_attachable(user).to_html


### PR DESCRIPTION
## Problem

Two board-move follow-ups spun off from #3070 (H1 #3512076), both in the card access/notification path.

### P1 — notification leak via unfiltered `card.watchers` (security)

`card.watchers` is watch-scoped, not access-scoped:

```ruby
has_many :watchers, -> { active.merge(Watch.watching) }, through: :watches, source: :user
```

After a card moves to a board an assignee/watcher can't access, `handle_board_change` only *schedules* async cleanup (`clean_inaccessible_data_later`, `remove_inaccessible_notifications_later`). In that window the watch row still exists, so `Notifier::CommentEventNotifier#recipients` (and `CardEventNotifier`'s comment branch, and `card_published`'s force-included `card.assignees`) select recipients who no longer hold `Access` to the card's board. A new comment then pushes a private comment excerpt to them. Pre-existing; independent of #3070 (which turns the permanent over-grant into a transient window, not the origin).

### P2 — stale `Assignment` after access loss (correctness)

Neither `Card#clean_inaccessible_data` nor `Board#clean_inaccessible_data_for` reconciles `Assignment` rows. So a user can remain assigned to a card on a board they can't access. `Cards::AssignmentsController#create` resolves toggles via `@board.users.active.find(...)`, so unassigning that user raises `ActiveRecord::RecordNotFound`; the stale rows also count toward `Assignment::LIMIT`. Reachable **today** via admin access-revocation (`Access#destroy` → `Board#clean_inaccessible_data_for`), and via the move path once #3070's grant-skip lands.

## Fix

**P1 — one access gate at the notify point** (`Notifier#notify`), covering every branch (comment, publish, assignment, mention) and any future notifier, rather than patching each `card.watchers`/assignee call site:

```ruby
def accessible_recipients
  accessible_user_ids = source.card.board.accesses.pluck(:user_id).to_set
  recipients.select { |recipient| !recipient.active? || accessible_user_ids.include?(recipient.id) }
end
```

The `!recipient.active?` clause preserves existing behavior for **deactivated** users: `User#deactivate` destroys their `accesses`, and notifications are still created for them (never pushed — they have no session). The leak class is *active* users who lost access; `card.watchers` is already `active`-scoped, so this matches the actual exposure. On `all_access` boards every active user holds an `Access` row, so nothing legitimate is filtered.

Defense at the read/notify point, independent of the async cleanup — a pure per-send read filter, so no lock/marker/persisted intermediate state and no new TOCTOU or regenerate-race surface. Fails closed (no access row ⇒ active user not notified).

**P2 — reconcile stale assignments in both cleanup paths**, alongside the existing pins/watches reconciliation:

- `Card#clean_inaccessible_data` (move path): `assignments.where.not(assignee_id: accessible_user_ids).in_batches.delete_all`
- `Board#clean_inaccessible_data_for(user)` (access-revoke path): `assignments_for(user).delete_all`

`delete_all` avoids emitting spurious `card_unassigned` events for a cleanup.

## Tests

- `Notifier::EventNotifierTest` — an active watcher who loses board access on a move is **not** notified when a new comment is posted (stale watch asserted present in the window). Red before the notifier change, green after.
- `CardTest` — `clean_inaccessible_data` removes an assignment for a user without board access. Red before, green after.
- `AccessTest` — assignments are destroyed when a user's board access is revoked (mirrors the existing watches/pins/mentions coverage). Red before, green after.

Deactivated-user notification behavior is unchanged (existing `NotificationDeliveryTest` passes).

## Verification

- Full non-system suite green: 1590 tests, 6015 assertions, 0 failures (1 pre-existing skip). Rubocop clean, Brakeman 0 warnings. System tests deferred to CI.
- All three new tests confirmed red on the unpatched code, green after — no vacuous assertions.
- Scanned the diff and this description for credentials/PII/customer data — none.

## Out of scope / notes

- The notify-time gate also stops mentioning an **active** user who lacks board access from delivering an excerpt — a strict improvement, no legitimate flow relies on it.
- Fizzy is not HackerOne-bounty-eligible; H1 #3512076 resolves as kudos.

Relates to H1 #3512076; follow-up to #3070.
