### PR TITLE
Gate the Active Storage preview parser on authorization

### DIFF
--- a/lib/rails_ext/active_storage_authorization.rb
+++ b/lib/rails_ext/active_storage_authorization.rb
@@ -105,6 +105,16 @@ Rails.application.config.to_prepare do
 
   ActiveStorage::Blobs::RedirectController.include ActiveStorage::Authorize
   ActiveStorage::Blobs::ProxyController.include ActiveStorage::Authorize
-  ActiveStorage::Representations::RedirectController.include ActiveStorage::Authorize
-  ActiveStorage::Representations::ProxyController.include ActiveStorage::Authorize
+
+  # set_representation is a before_action on Representations::BaseController that runs
+  # @blob.representation(...).processed — the ffmpeg/mutool/libvips parser. Because it is
+  # registered on the parent, it precedes the authorization callbacks this concern appends,
+  # so the parser would otherwise run against an unauthorized (or anonymous) request before
+  # ensure_accessible is ever consulted. Re-append set_representation on each representations
+  # controller so it runs after require_authentication and ensure_accessible.
+  [ ActiveStorage::Representations::RedirectController, ActiveStorage::Representations::ProxyController ].each do |controller|
+    controller.include ActiveStorage::Authorize
+    controller.skip_before_action :set_representation
+    controller.before_action :set_representation
+  end
 end

--- a/test/integration/active_storage_authorization_test.rb
+++ b/test/integration/active_storage_authorization_test.rb
@@ -63,6 +63,39 @@ class ActiveStorageAuthorizationTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  # Authorization must gate the preview parser itself, not just the returned bytes.
+  # set_representation runs @blob.representation(...).processed (ffmpeg/mutool/libvips);
+  # a forbidden or unauthenticated request must never reach it.
+  test "unauthenticated user does not run the representation parser" do
+    representation_path = rails_representation_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+    proxy_path = rails_storage_proxy_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+
+    ActiveStorage::Blob.any_instance.expects(:representation).never
+
+    get representation_path
+    assert_response :redirect
+    assert_match %r{/session/new}, response.location
+
+    get proxy_path
+    assert_response :redirect
+    assert_match %r{/session/new}, response.location
+  end
+
+  test "authenticated user without board access does not run the representation parser" do
+    sign_in_as :mike
+
+    representation_path = rails_representation_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+    proxy_path = rails_storage_proxy_path(@blob.representation(resize_to_limit: [ 100, 100 ]))
+
+    ActiveStorage::Blob.any_instance.expects(:representation).never
+
+    get representation_path
+    assert_response :forbidden
+
+    get proxy_path
+    assert_response :forbidden
+  end
+
   test "unauthenticated user can view blob on published board with published card" do
     @board.publish
 


### PR DESCRIPTION
## Problem

Authorization on the Active Storage representation controllers gated the returned bytes but not the parser that produced them.

`ActiveStorage::Representations::BaseController` registers `before_action :set_representation`, and `set_representation` runs `@blob.representation(...).processed` — the ffmpeg / mutool / libvips preview parser. Fizzy's `ActiveStorage::Authorize` concern appends `require_authentication` and `ensure_accessible` on the *subclasses* (`Representations::RedirectController`, `Representations::ProxyController`).

Rails runs parent-class `before_action`s before subclass ones, so the effective order was:

```
set_blob → set_representation (PARSER) → require_authentication → ensure_accessible
```

The parser therefore executed against an **anonymous or unauthorized** request before authorization was ever consulted. Authorization gated the bytes that came back; it never gated the parser. An unauthenticated request to a PDF/image representation reached mutool/libvips ahead of the auth check.

The concern's own comment ("Ensure require_authentication runs after set_blob") shows it was already reasoning about callback order — it ordered against `set_blob` and missed `set_representation`.

## Fix

Re-append `set_representation` on the two representations controllers so it runs after `require_authentication` and `ensure_accessible`:

```
set_blob → require_authentication → ensure_accessible → set_representation (PARSER)
```

Publicly-accessible blobs (e.g. avatars) still skip auth via the existing `unless: :publicly_accessible_blob?` guard and render normally, since `set_representation` is re-appended unconditionally.

The two `Blobs::` controllers run no parser and are untouched.

## Tests

Regression tests assert the parser (`Blob#representation`) is **never reached** for anonymous or authenticated-but-unauthorized representation requests, across both the redirect and proxy controllers — asserting on parser execution, not the response code (the response code was already correct and proved nothing). Red before the reorder, green after. Full `active_storage_authorization_test.rb` suite green (27 tests).