### PR TITLE
Bump queenbee-plugin pin: constant-time data_secret compare

### DIFF
--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/basecamp/queenbee-plugin
-  revision: c0119be5940edb3739d4bb591c1a5c7064881638
+  revision: 643885bc86c3b6eeb949c88af5c02f2a4e22f3f4
   specs:
     queenbee (3.2.0)
       activeresource


### PR DESCRIPTION
Advances the `queenbee-plugin` git pin on `master` from `c0119be` to `643885b` (branch HEAD), picking up the timing-safe `data_secret` comparison merged in [queenbee-plugin#139](https://github.com/basecamp/queenbee-plugin/pull/139).

**Dual-lockfile note.** `queenbee-plugin` appears only in the **SaaS** lockfile, so only `Gemfile.saas.lock` changes; the OSS `Gemfile.lock` has no `queenbee-plugin` entry and is intentionally untouched. (`bin/bundle-drift` doesn't see git-source drift, so this was verified by hand.)

**Behavior-identical rollout.** Old and new pins reach identical accept/reject outcomes; only the secret comparison is now constant-time. Lock delta is the git `revision:` line only (`BUNDLE_GEMFILE=Gemfile.saas bundle update queenbee --conservative`) — no gem versions or dependencies change (queenbee stays 3.2.0). Risk is limited to a load/require regression, which CI catches.

Part of the per-consumer pin-bump rollout for the constant-time compare fix (Security Hardening card 10237485390). Pins can merge and deploy in any order. Draft pending CI + operator review; do not merge/deploy without the operator.