### PR TITLE
Trusted Types report-only pilot (fizzy CSP telemetry)

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,6 +16,45 @@
 #   script_src, style_src, connect_src, frame_src, img_src, font_src, media_src,
 #   worker_src, frame_ancestors, form_action, report_uri, report_only
 
+# Trusted Types report-only pilot — XSS counteroffensive Tier C (Chromium-only).
+#
+# Collects telemetry on raw-string writes to DOM sinks (innerHTML, outerHTML,
+# insertAdjacentHTML, document.write, ...) without enforcing anything. It rides
+# a SEPARATE Content-Security-Policy-Report-Only header so it never touches the
+# enforcing policy below — report-only can only report, never block, so no
+# un-migrated sink throws on Chromium. Non-Chromium browsers ignore the
+# directive entirely.
+#
+# Only `require-trusted-types-for 'script'` is emitted. We deliberately omit a
+# `trusted-types` policy-name allowlist: this pilot registers no named createHTML
+# policy (that is the parked enforcement phase, gated on the shared sanitize()
+# chokepoint), and leaving the allowlist off keeps policy creation unrestricted
+# so lexxy's isolated DOMPurify policy and any duplicates raise no policy-creation
+# noise — we only want sink-write violations.
+class TrustedTypesReportOnly
+  DIRECTIVE = "require-trusted-types-for 'script'"
+  HEADER = ActionDispatch::Constants::CONTENT_SECURITY_POLICY_REPORT_ONLY
+
+  def initialize(app, report_uri = nil)
+    @app = app
+    @policy = report_uri ? "#{DIRECTIVE}; report-uri #{report_uri}" : DIRECTIVE
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+
+    # Only documents run script, so only they can trip a Trusted Types sink.
+    # Stack as an additional report-only policy rather than overwriting: when the
+    # app policy is itself report-only, both headers ride together, each
+    # reporting independently.
+    if headers[Rack::CONTENT_TYPE].to_s.start_with?("text/html")
+      headers[HEADER] = [ headers[HEADER], @policy ].compact.join("\n")
+    end
+
+    [ status, headers, body ]
+  end
+end
+
 Rails.application.configure do
   # Helper to get additional CSP sources from ENV or config.x.
   # Supports: nil, string, space-separated string, or array.
@@ -75,6 +114,11 @@ Rails.application.configure do
 
   # Report violations without enforcing the policy.
   config.content_security_policy_report_only = report_only
+
+  # Trusted Types telemetry rides its own report-only header. Inserted outside
+  # the Rails CSP middleware so it appends after that header is written, letting
+  # it stack alongside (never clobber) an app policy that is itself report-only.
+  config.middleware.insert_before ActionDispatch::ContentSecurityPolicy::Middleware, TrustedTypesReportOnly, report_uri
 
   # Locked-down policy for the static pages served from public/ (error pages).
   # They carry no script or inline styles at all, so everything falls back to

--- a/test/integration/static_csp_test.rb
+++ b/test/integration/static_csp_test.rb
@@ -35,6 +35,26 @@ class StaticCspTest < ActionDispatch::IntegrationTest
     assert_not_equal STATIC_POLICY, csp
   end
 
+  test "Trusted Types telemetry rides a report-only header and never the enforcing policy" do
+    sign_in_as identities(:david)
+    get root_url
+
+    # Report-only pilot: the enforcing policy must not carry the directive, or an
+    # un-migrated sink would throw on Chromium.
+    enforcing = response.headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY]
+    assert_not_includes enforcing.to_s, "require-trusted-types-for",
+      "the enforcing CSP must stay free of Trusted Types in the report-only pilot"
+
+    report_only = response.headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY_REPORT_ONLY]
+    assert_includes report_only.to_s, "require-trusted-types-for 'script'",
+      "a report-only header must collect Trusted Types violations"
+
+    # No named createHTML policy is registered in this pilot, so no `trusted-types`
+    # allowlist is emitted.
+    assert_not_includes report_only.to_s, "trusted-types ",
+      "the pilot registers no named policy, so it emits no trusted-types allowlist"
+  end
+
   private
     # Suppress the diagnostics page the test environment would otherwise
     # render, so the request falls through to the exceptions app like in


### PR DESCRIPTION
## Trusted Types report-only pilot (XSS counteroffensive — Tier C)

Report-only telemetry pilot only — the greenlit **option 1** from the [Security Hardening card](https://app.basecamp.com/2914079/buckets/48540453/card_tables/cards/10239442945). Adds Trusted Types **violation reporting** to fizzy with **zero enforcement and zero app-code migration**, so we get real signal on which DOM sinks write raw strings before committing to the enforcement design.

### What ships

A new `TrustedTypesReportOnly` Rack middleware in [`config/initializers/content_security_policy.rb`](https://github.com/basecamp/fizzy/blob/main/config/initializers/content_security_policy.rb) emits a **separate** `Content-Security-Policy-Report-Only` header on HTML responses carrying:

```
require-trusted-types-for 'script'
```

plus `report-uri <uri>` when a report-uri is configured (reusing the existing `CSP_REPORT_URI` / `config.x.content_security_policy.report_uri` knob).

### Why a separate header, not the app policy

Fizzy ships a single Rails-managed CSP whose **whole header** flips between enforcing and report-only via one `report_only` flag (default: enforcing). Adding the Trusted Types directive into that policy would put it in the **enforcing** header wherever fizzy runs enforcing — and, with no named `createHTML` policy registered, every one of the un-migrated first-party sinks would `throw` on Chromium. That is the parked enforcement phase, not this PR.

So Trusted Types rides its **own always-report-only header** instead:

- The enforcing `Content-Security-Policy` header is **byte-for-byte unchanged**.
- Report-only can only *report*, never block — nothing breaks on any browser. Non-Chromium browsers ignore the directive entirely.
- The middleware is inserted **outside** `ActionDispatch::ContentSecurityPolicy::Middleware`, so when a deployment already runs the app policy as report-only, the Trusted Types policy **stacks** as a second report-only policy (newline-joined → two header lines) rather than clobbering it. Each reports independently.

### Why only `require-trusted-types-for 'script'` (no `trusted-types` allowlist)

The goal is sink-write telemetry. `require-trusted-types-for 'script'` is what makes a raw-string write to a DOM sink surface as a violation report. A `trusted-types <policy-name>` allowlist does something different — it restricts which policy *names* may be created — and since this pilot registers **no** named `createHTML` policy, adding an allowlist would only generate policy-creation noise (including from lexxy's isolated DOMPurify policy). Omitting it leaves policy creation unrestricted, which is exactly right for report-only.

### Verification

- New test in [`test/integration/static_csp_test.rb`](https://github.com/basecamp/fizzy/blob/main/test/integration/static_csp_test.rb): the enforcing CSP carries no `require-trusted-types-for`; a report-only header carries `require-trusted-types-for 'script'`; no `trusted-types` allowlist is emitted.
- Middleware behavior confirmed across three shapes: enforcing main policy (enforcing header untouched, TT rides its own RO header), main policy itself report-only (existing RO policy preserved, TT stacked as a second policy), and non-HTML responses (skipped).

### Parked follow-ons (Avenue B — the enforcement phase)

Everything below stays parked, gated on the shared `sanitize()` chokepoint landing:

1. **Enforcement** — register the single named `createHTML → sanitize()` policy and flip to enforcing, only after the report-only window enumerates every real sink and the 6 first-party fizzy sinks are migrated onto the chokepoint. Human sign-off required; not auto-PR-eligible.
2. **bc3 / haystack** — template the same ramp once fizzy proves it.
3. **trix / lexxy** — the library re-inflation boundaries ship the policy hook last so consumers opt in per app.
4. **Open design question** — [lexxy](https://github.com/basecamp/lexxy/blob/main/src/config/dom_purify.js) deliberately runs its own isolated DOMPurify instance, so the design doc's "one named policy per app vs. a shared vendored policy" question is live for the enforcement phase. This pilot is unaffected — report-only registers no policy.

Design doc: [trusted-types.md](https://github.com/basecamp/37signals-hq/blob/main/security-reports/audits/_xss-counteroffensive-2026-08/redesign/tier-c/trusted-types.md).
