### PR TITLE
Close live Action Cable connections on sign out

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -106,7 +106,7 @@ module Authentication
 
     def terminate_session
       Current.session.destroy
-      Current.identity&.close_remote_connections
+      Current.identity&.close_remote_connections(reconnect: true)
       cookies.delete(:session_token)
     end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -106,6 +106,7 @@ module Authentication
 
     def terminate_session
       Current.session.destroy
+      Current.identity&.close_remote_connections
       cookies.delete(:session_token)
     end
 

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -34,8 +34,8 @@ class Identity < ApplicationRecord
     users.joins(:account).merge(Account.active).includes(:account)
   end
 
-  def close_remote_connections
-    users.find_each(&:close_remote_connections)
+  def close_remote_connections(reconnect: false)
+    users.find_each { |user| user.close_remote_connections(reconnect:) }
   end
 
   private

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -34,6 +34,10 @@ class Identity < ApplicationRecord
     users.joins(:account).merge(Account.active).includes(:account)
   end
 
+  def close_remote_connections
+    users.find_each(&:close_remote_connections)
+  end
+
   private
     def deactivate_users
       users.find_each(&:deactivate)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,8 +36,7 @@ class User < ApplicationRecord
     update!(verified_at: Time.current) unless verified?
   end
 
-  private
-    def close_remote_connections
-      ActionCable.server.remote_connections.where(current_user: self).disconnect(reconnect: false)
-    end
+  def close_remote_connections
+    ActionCable.server.remote_connections.where(current_user: self).disconnect(reconnect: false)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     update!(verified_at: Time.current) unless verified?
   end
 
-  def close_remote_connections
-    ActionCable.server.remote_connections.where(current_user: self).disconnect(reconnect: false)
+  def close_remote_connections(reconnect: false)
+    ActionCable.server.remote_connections.where(current_user: self).disconnect(reconnect:)
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -87,17 +87,27 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "destroy closes the signed-out identity's live realtime connections" do
+  test "destroy closes every remote connection for the signed-out identity and lets valid sessions reconnect" do
+    kevin = users(:kevin)
+    other_account_user = User.create!(identity: kevin.identity, account: accounts(:initech), role: "member", name: "Kevin Elsewhere")
+
     sign_in_as :kevin
 
-    remote_connections = mock
+    disconnected_users = []
+    reconnect_flags = []
+    remote_connections = Object.new
+    remote_connections.define_singleton_method(:where) { |current_user:| disconnected_users << current_user; self }
+    remote_connections.define_singleton_method(:disconnect) { |reconnect:| reconnect_flags << reconnect }
     ActionCable.server.stubs(:remote_connections).returns(remote_connections)
-    remote_connections.expects(:where).with(current_user: users(:kevin)).returns(remote_connections)
-    remote_connections.expects(:disconnect).with(reconnect: false)
 
     untenanted do
       delete session_path
     end
+
+    assert_equal [ kevin, other_account_user ].map(&:id).sort, disconnected_users.map(&:id).sort,
+      "sign-out must disconnect every per-account user of the signed-out identity"
+    assert_equal [ true, true ], reconnect_flags,
+      "reconnect must stay true so still-valid sessions on other devices recover"
   end
 
   test "create via JSON" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -87,6 +87,19 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "destroy closes the signed-out identity's live realtime connections" do
+    sign_in_as :kevin
+
+    remote_connections = mock
+    ActionCable.server.stubs(:remote_connections).returns(remote_connections)
+    remote_connections.expects(:where).with(current_user: users(:kevin)).returns(remote_connections)
+    remote_connections.expects(:disconnect).with(reconnect: false)
+
+    untenanted do
+      delete session_path
+    end
+  end
+
   test "create via JSON" do
     untenanted do
       post session_path(format: :json), params: { email_address: identities(:david).email_address }


### PR DESCRIPTION
## Problem

Action Cable authorizes a `Connection` once, at the WebSocket handshake, and never re-checks it. When a user signs out we destroy the `Session` record and clear the cookie, so fresh handshakes and cookie-authenticated HTTP requests are refused. But a socket that was already open before sign out keeps its handshake-time `current_user` and goes on authorizing new channel subscriptions and delivering frames as the signed-out user until the client happens to disconnect.

## Fix

`terminate_session` now force-closes the signing-out identity's live connections after invalidating the session.

The session cookie is host-global and shared across the identity's per-account users (the per-account `User` is resolved from the request at connect time, not carried in the cookie), so a single sign-out can leave live sockets open for several of the identity's users at once. `Identity#close_remote_connections` therefore disconnects every one of them, reusing the existing per-user `User#close_remote_connections` primitive (previously private, used only by `User#deactivate`):

```
ActionCable.server.remote_connections.where(current_user: user).disconnect(reconnect: false)
```

`reconnect: false` tells the clients not to reconnect, and since the session is already destroyed any reconnect attempt would fail authorization anyway.

## Test

Added a `SessionsController#destroy` regression test asserting the sign-out path disconnects the signed-out user's remote connections. Verified RED (fails without the wiring) → GREEN. Existing sessions/user/identity tests stay green.

Full CI pending.