### PR TITLE
Bound the cell's OpenMP thread pools

### DIFF
--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -68,7 +68,7 @@ accessories:
     # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
     # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
     # way for an unbuilt image to fail.
-    image: registry.37signals.com/basecamp/fizzy-hotcell:3a8101689974
+    image: registry.37signals.com/basecamp/fizzy-hotcell:275df248ed42
     roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
     # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
     # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker

--- a/saas/hotcell/Dockerfile
+++ b/saas/hotcell/Dockerfile
@@ -46,6 +46,20 @@ ENV HOME=/tmp \
     HOTCELL_OPERATIONS=/hotcell/operations \
     HOTCELL_DIR=/run/hotcell/cell
 
+# OpenMP sizes its thread team from the CPUs the process can SEE, and the accessory's `cpus: 2` is a CFS
+# quota rather than an affinity mask — so an unbounded cell asks for one thread per host core, well over
+# ninety on a production jobs host. Each thread's 8MB stack is private anonymous memory charged against
+# RLIMIT_DATA, and the worker's RLIMIT_DATA is 1536MB: past the line where those stacks clear it,
+# pthread_create returns EAGAIN, and libgomp treats a thread it cannot create as fatal — one line on
+# stderr and exit(1), with no signal and no Ruby exception to report. That killed 285 workers on the same
+# install in bc3 on 2026-08-31 (ref: card 10236548314); beta, whose hosts have 4 cores, saw nothing.
+#
+# NUM_THREADS matches the cell's CPU quota — the same number activestorage-hotcell-server already
+# defaults VIPS_CONCURRENCY to, so the two thread pools agree without a second variable to keep in sync.
+# THREAD_LIMIT backstops a library that raises the count itself with omp_set_num_threads.
+ENV OMP_NUM_THREADS=2 \
+    OMP_THREAD_LIMIT=8
+
 WORKDIR /hotcell
 
 COPY --from=build --chown=hotcell:hotcell /hotcell/bundle /hotcell/bundle

--- a/saas/test/lib/hotcell_image_test.rb
+++ b/saas/test/lib/hotcell_image_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+# OpenMP reads the host's core count, not the container's CPU quota, so an unbounded cell asks for one
+# thread per core, and each 8MB stack is charged to the worker's RLIMIT_DATA. Past about a hundred
+# threads pthread_create returns EAGAIN and libgomp exits the process outright. Held here rather than in
+# a cell test because no host we run tests on has enough cores to provoke it: beta has 4 and production
+# has far more, which is exactly how this reached production in bc3's hotcell.
+class HotcellImageTest < ActiveSupport::TestCase
+  DOCKERFILE = Rails.root.join("saas/hotcell/Dockerfile")
+
+  test "the cell bounds every OpenMP thread pool" do
+    dockerfile = DOCKERFILE.read
+
+    assert_match(/^(?:ENV )?\s*OMP_NUM_THREADS=2\b/, dockerfile)
+    assert_match(/^(?:ENV )?\s*OMP_THREAD_LIMIT=8\b/, dockerfile)
+  end
+end


### PR DESCRIPTION
## Problem

OpenMP sizes its thread team from the CPUs the process can see, not the container's Docker `cpus:` quota — a CFS quota isn't an affinity mask. The `saas/hotcell` cell has `cpus: 2` (`saas/config/deploy.yml`) but is unbounded, so a worker asks OpenMP for one thread per visible host core.

Each thread's 8MB stack is private anonymous memory charged against the worker's `RLIMIT_DATA` (1536MB, `saas/hotcell/config.rb`). Past the line where those stacks clear it, `pthread_create` returns `EAGAIN`, and libgomp treats a thread it cannot create as fatal: one line on stderr, `exit(1)`, no signal and no Ruby exception to report.

bc3's identically-configured hotcell cell hit exactly this on a many-core production host and lost 285 workers on 2026-08-31 (`Bound the cell's OpenMP thread pools`, bc3 commit `e1c179f4`). Beta hosts have 4 cores and never see it — it takes production-scale core counts to expose the bug, which is how it reached production in the first place. Card: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10256988095

## Fix

Set `OMP_NUM_THREADS=2` and `OMP_THREAD_LIMIT=8` in `saas/hotcell/Dockerfile`, following bc3's reference fix.

`OMP_NUM_THREADS=2` matches the accessory's `cpus: 2` quota. It's also what `activestorage-hotcell-server`'s `vips_operation.rb` already defaults `VIPS_CONCURRENCY` to when unset, so libvips's own thread pool and OpenMP's agree without a second variable to keep in sync — which is why `VIPS_CONCURRENCY` stays unset here rather than being pinned a second time. `OMP_THREAD_LIMIT=8` backstops a library that raises the count itself with `omp_set_num_threads`.

The Dockerfile's content hash changed, so `saas/config/deploy.yml` is repinned to the rebuilt image's tag via `saas/hotcell/bin/build`. The image still needs a push before any deploy can pull it (`saas/hotcell/bin/push`).

## Tests

`saas/test/lib/hotcell_image_test.rb` asserts both env vars are set in the Dockerfile. Beta can't catch a regression here — its hosts have 4 cores, production has far more — so the guard holds the value statically rather than relying on an environment that would notice.

Confirmed the fix at the libgomp level directly: called `omp_get_max_threads()` via Fiddle against `libgomp.so.1` inside the built image. Before the fix it returns the visible host core count (20 on a 20-core box); after, it returns 2.

I couldn't reproduce the card's suggested verification (write a GIF, count `/proc/self/task` during the write) on this Debian `libvips42`/`libimagequant` build — GIF, JPEG, and PNG writes all produced identical thread counts regardless of the OMP env vars, tracking `VIPS_CONCURRENCY`'s own thread pool rather than any OpenMP-parallel region in quantization. The libgomp probe above is the evidence I'm relying on instead.
