### PR TITLE
Upgrade hotcell to 0.3.0

### DIFF
--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -11,8 +11,8 @@ gem "console1984", bc: "console1984"
 gem "audits1984", bc: "audits1984"
 
 # Attachment processing in an unprivileged sibling container
-gem "hotcell-client", "~> 0.2.0"
-gem "activestorage-hotcell-client", "~> 0.2.0"
+gem "hotcell-client", "~> 0.3.0"
+gem "activestorage-hotcell-client", "~> 0.3.0"
 
 # Native push notifications (iOS/Android)
 gem "action_push_native"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -245,9 +245,9 @@ GEM
       activemodel (>= 7.0)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 7.0)
-    activestorage-hotcell-client (0.2.0)
+    activestorage-hotcell-client (0.3.0)
       activestorage (>= 8.2.0.alpha)
-      hotcell-client (= 0.2.0)
+      hotcell-client (= 0.3.0)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ansi (1.6.0)
@@ -356,10 +356,10 @@ GEM
       signet (>= 0.16, < 2.a)
     gvltools (0.5.0)
     hashdiff (1.2.1)
-    hotcell-client (0.2.0)
+    hotcell-client (0.3.0)
       activesupport (>= 7.1)
-      hotcell-core (= 0.2.0)
-    hotcell-core (0.2.0)
+      hotcell-core (= 0.3.0)
+    hotcell-core (0.3.0)
     http-2 (1.1.1)
     httpx (1.7.1)
       http-2 (>= 1.0.0)
@@ -742,7 +742,7 @@ DEPENDENCIES
   action_push_native
   actionpack-xml_parser
   activeresource
-  activestorage-hotcell-client (~> 0.2.0)
+  activestorage-hotcell-client (~> 0.3.0)
   audits1984!
   autotuner
   aws-sdk-s3
@@ -758,7 +758,7 @@ DEPENDENCIES
   fizzy-saas!
   geared_pagination (~> 1.2)
   gvltools
-  hotcell-client (~> 0.2.0)
+  hotcell-client (~> 0.3.0)
   image_processing (~> 1.14)
   importmap-rails
   jbuilder
@@ -826,7 +826,7 @@ CHECKSUMS
   activerecord (8.2.0.alpha)
   activeresource (6.2.0) sha256=818ca60d3cd1ff7bbb7277f41250ad4d61a7cdbe30fbf52b2145e1b66ed13900
   activestorage (8.2.0.alpha)
-  activestorage-hotcell-client (0.2.0) sha256=93f0cb4cb310704c4e5074982b2a5a3b606980fa39c93310395accec8961f5b9
+  activestorage-hotcell-client (0.3.0) sha256=ee437b08b57673df0f823c2c902504d19483672566e2931e6cfafe10c70b6e6c
   activesupport (8.2.0.alpha)
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
@@ -888,8 +888,8 @@ CHECKSUMS
   googleauth (1.16.1) sha256=36776bce9d55d8c1a0c6638c939b000dcee5954ca5b728f06ec4c2df4a46709c
   gvltools (0.5.0) sha256=a15e480b3860e7e9661e5e53aff9b1802fe9018fa42a5e845adc2a19a7bcc65d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  hotcell-client (0.2.0) sha256=53842b4a456d1b82b8f5a98b7ef2bc7d47bcb75b55dff0a035900f3a648cc654
-  hotcell-core (0.2.0) sha256=bf0c747dc724d2a57f3336e6cfdf6fd95d1464803945382b1f4ca5a04a8a0dba
+  hotcell-client (0.3.0) sha256=c2839b6e1e19991660c69f24bf1516936d61c510c9e2cc9be40abc863762cc1e
+  hotcell-core (0.3.0) sha256=b9665e2e78586293c40d03de5f4408cb9c344402750dafd502e118eb8660be2e
   http-2 (1.1.1) sha256=1141a5a03c2f4e6b8d2fa62394de581e1ff6387711cd7ed577212e9d95562bba
   httpx (1.7.1) sha256=ae380461539203c92f3ee65c13b22dfccb0d975156426869f57820505cacdf56
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5

--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -68,7 +68,7 @@ accessories:
     # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
     # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
     # way for an unbuilt image to fail.
-    image: registry.37signals.com/basecamp/fizzy-hotcell:275df248ed42
+    image: registry.37signals.com/basecamp/fizzy-hotcell:ba753374f69a
     roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
     # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
     # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker
@@ -91,8 +91,9 @@ accessories:
       memory: 2g
       memory-swap: 2g  # equal to memory; omitted, Docker allows twice memory in swap and the limit stops holding
       # Deliberately no `ulimit: stack`, so the cell inherits the daemon's 8MB. A thread that overflows a
-      # smaller stack dies on SIGSEGV, which the supervisor maps to killed/memory — permanent, so the
-      # verdict is written against the customer's file. Raise the cell's own memory instead.
+      # smaller stack dies on SIGSEGV, which the supervisor reports as killed/crashed — transient, so the
+      # request is retried against the same limit for as long as the job keeps trying, and no verdict
+      # names the setting that caused it. Raise the cell's own memory instead.
 
       # Security. Omit one and the protection is gone while the cell serves requests exactly as before.
       # `network: none` is above, because it is an accessory key rather than a raw Docker flag.

--- a/saas/hotcell/Dockerfile
+++ b/saas/hotcell/Dockerfile
@@ -23,9 +23,15 @@ RUN bundle install && rm -rf "$BUNDLE_PATH"/ruby/*/cache
 
 FROM ruby:${RUBY_VERSION}-slim
 
+# The upgrade applies Debian's pending security patches. `docker build --pull` takes the newest
+# `ruby:3.4-slim` tag, but that tag can sit behind an advisory already in `trixie-security` until
+# docker-library/ruby rebuilds it, so a clean build can ship a fixable High no rebuild of the cell would
+# clear. Upgrading here makes the patch level this image's own rather than upstream's release cadence.
+#
 # The tools this cell's operations run, and nothing else. No LibreOffice: Fizzy accepts office documents
 # and never previews them, so its parsers would be blast radius bought for nothing.
 RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends libvips42 mupdf-tools ffmpeg && \
     rm -rf /var/lib/apt/lists/*
 
@@ -66,6 +72,11 @@ COPY --from=build --chown=hotcell:hotcell /hotcell/bundle /hotcell/bundle
 COPY --chown=hotcell:hotcell Gemfile Gemfile.lock ./
 COPY --chown=hotcell:hotcell config.rb /hotcell/config.rb
 COPY --chown=hotcell:hotcell operations/ /hotcell/operations/
+
+# Nothing here needs to raise privilege, so nothing here should be able to. `no-new-privileges` on the
+# accessory already neutralizes a setuid binary at runtime; this removes the bits from the image itself,
+# so the two are independent and an image scan has nothing to report.
+RUN find / -xdev -type f -perm /06000 -exec chmod a-s {} +
 
 USER hotcell
 

--- a/saas/hotcell/Gemfile
+++ b/saas/hotcell/Gemfile
@@ -9,5 +9,5 @@
 
 source "https://rubygems.org"
 
-gem "hotcell-server", "~> 0.2.0"
-gem "activestorage-hotcell-server", "~> 0.2.0"
+gem "hotcell-server", "~> 0.3.0"
+gem "activestorage-hotcell-server", "~> 0.3.0"

--- a/saas/hotcell/Gemfile.lock
+++ b/saas/hotcell/Gemfile.lock
@@ -1,11 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activestorage-hotcell-server (0.2.0)
-      hotcell-server (= 0.2.0)
+    activestorage-hotcell-server (0.3.0)
+      hotcell-server (= 0.3.0)
       image_processing (>= 2.0)
-      mini_magick (>= 4.0)
-      ruby-vips (>= 2.2)
+      mini_magick (>= 5.2.0)
+      ruby-vips (>= 2.2.1)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -17,9 +17,9 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    hotcell-core (0.2.0)
-    hotcell-server (0.2.0)
-      hotcell-core (= 0.2.0)
+    hotcell-core (0.3.0)
+    hotcell-server (0.3.0)
+      hotcell-core (= 0.3.0)
     image_processing (2.0.3)
     logger (1.7.0)
     mini_magick (5.3.3)
@@ -42,11 +42,11 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  activestorage-hotcell-server (~> 0.2.0)
-  hotcell-server (~> 0.2.0)
+  activestorage-hotcell-server (~> 0.3.0)
+  hotcell-server (~> 0.3.0)
 
 CHECKSUMS
-  activestorage-hotcell-server (0.2.0) sha256=84e810b865e662c63719006e074e3f15b499c6240ea4de6fd445a02760ea9463
+  activestorage-hotcell-server (0.3.0) sha256=e82db5cc602651ca4ce49486cf19c7c01e86cdeddb7105106b3aca50ae67f98b
   bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
@@ -59,8 +59,8 @@ CHECKSUMS
   ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
-  hotcell-core (0.2.0) sha256=bf0c747dc724d2a57f3336e6cfdf6fd95d1464803945382b1f4ca5a04a8a0dba
-  hotcell-server (0.2.0) sha256=02ffc955c7ddfd7e2608a683a717b72aa1194b8840b2db809930190021df82f2
+  hotcell-core (0.3.0) sha256=b9665e2e78586293c40d03de5f4408cb9c344402750dafd502e118eb8660be2e
+  hotcell-server (0.3.0) sha256=bb1c0137921ffa9c3d99709c2acc4704a49b1c6a6ebf48b08d24d78ae73571c1
   image_processing (2.0.3) sha256=793e33f38470edd0a2d6bfd00acf8cb239c76284ba2e3dfb76633ac2b457f23a
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (5.3.3) sha256=b3beed8a8cef36bd03666365f14b89cd344da0ecd373af53e617c71bfd426aab

--- a/saas/hotcell/bin/build
+++ b/saas/hotcell/bin/build
@@ -79,7 +79,10 @@ fi
 tag="$(hotcell_image_tag "$repo_root")"
 
 echo "Building $tag"
+# --pull because `ruby:3.4-slim` is a mutable tag: without it a laptop that built last month builds on
+# whatever base it cached then, and the apt-get upgrade in the Dockerfile is left doing the whole job.
 docker build \
+  --pull \
   ${platform:+--platform="$platform"} \
   --tag "$tag" \
   "$cell_dir"

--- a/saas/hotcell/bin/build
+++ b/saas/hotcell/bin/build
@@ -59,7 +59,10 @@ fi
 # truth, and pinning below a requirement is exactly what a lockfile is for.
 if [ "$cell_version" != "$app_version" ]; then
   echo "Locking the cell to the application's hotcell $app_version (was ${cell_version:-none})"
-  sed -i "/hotcell/s/$cell_version/$app_version/g" "$cell_dir/Gemfile.lock"
+  # The CHECKSUMS lines carry a version too, and rewriting one there attaches the old release's sha256 to
+  # the new version, which bundler refuses as a checksum mismatch. Drop them instead and let the install
+  # below write the real ones.
+  sed -i "/hotcell/{/sha256=/d; s/$cell_version/$app_version/g}" "$cell_dir/Gemfile.lock"
   env -u RUBYOPT -u RUBYLIB -u BUNDLER_SETUP -u BUNDLER_VERSION -u BUNDLE_BIN_PATH -u BUNDLE_LOCKFILE \
     BUNDLE_GEMFILE="$cell_dir/Gemfile" bundle install --quiet
 

--- a/saas/lib/fizzy/saas/engine.rb
+++ b/saas/lib/fizzy/saas/engine.rb
@@ -65,9 +65,9 @@ module Fizzy
         end
       end
 
-      # Warns when a client wants an operation the cell does not carry, and when the timeout is too tight
-      # for what the cell says it may take. Never fails boot: a cell that is restarting is a degraded
-      # deployment, not a broken one.
+      # Warns when this process is outside HOTCELL_GROUP, and when the timeout is too tight for what the
+      # cell says it may take. Never fails boot: a cell that is restarting is a degraded deployment, not a
+      # broken one.
       config.after_initialize do
         ::HotCell.describe_cells
       end

--- a/saas/test/lib/hotcell_image_test.rb
+++ b/saas/test/lib/hotcell_image_test.rb
@@ -14,4 +14,10 @@ class HotcellImageTest < ActiveSupport::TestCase
     assert_match(/^(?:ENV )?\s*OMP_NUM_THREADS=2\b/, dockerfile)
     assert_match(/^(?:ENV )?\s*OMP_THREAD_LIMIT=8\b/, dockerfile)
   end
+
+  # Held here because the accessory's `no-new-privileges` covers this too, so dropping the strip breaks
+  # nothing a running cell can show you.
+  test "the cell carries no setuid or setgid binary" do
+    assert_match "find / -xdev -type f -perm /06000 -exec chmod a-s {} +", DOCKERFILE.read
+  end
 end


### PR DESCRIPTION
## Problem

Fizzy runs hotcell 0.2.0. [0.3.0](https://github.com/basecamp/hotcell/blob/v0.3.0/CHANGELOG.md) carries two image fixes that an upgrade cannot deliver on its own, because both live in the installer's `Dockerfile` template and the installer leaves an existing `Dockerfile` alone. Fizzy vendors `saas/hotcell/Dockerfile`, so neither reached it:

- **The image's patch level was upstream's, not ours.** `docker build --pull` takes the newest `ruby:3.4-slim`, but that tag can sit behind an advisory already in `trixie-security` until [docker-library/ruby](https://github.com/docker-library/ruby) rebuilds it — so a clean build could ship a fixable High that no rebuild of the cell would clear.
- **The image carried eleven setuid and setgid binaries** from the base: `su`, `passwd`, `mount`, `umount`, `newgrp`, `chage`, `chfn`, `chsh`, `expiry`, `gpasswd`, `unix_chkpwd`.

0.3.0's third image fix, the OpenMP thread bound, arrived here already in `717746f3` (#3094) with the same values upstream chose.

Two comments in the tree also described behaviour that is no longer true. `saas/lib/fizzy/saas/engine.rb` said `HotCell.describe_cells` warns when a client wants an operation the cell does not carry; 0.3.0 removed that warning, along with `HotCell.clients`, because the check could not tell an operation the application calls from one it merely loaded. And the `ulimit: stack` comment in `saas/config/deploy.yml` gave the wrong verdict for a stack overflow — upstream's `b3b4d6f3` corrected the docs.

Separately, `saas/hotcell/bin/build` could not perform a hotcell bump at all. It rewrites the cell lockfile's hotcell versions with

    sed -i "/hotcell/s/$cell_version/$app_version/g" "$cell_dir/Gemfile.lock"

which also matches the `CHECKSUMS` lines, so the old release's `sha256` came back labelled with the new version and the `bundle install` on the next line refused it as a checksum mismatch.

## Fix

Three commits, the first two independent of the bump:

1. `dbe63f60` — drop the hotcell `CHECKSUMS` lines rather than rewriting their versions, and let the install that follows write the real ones.
2. `64ea0b7c` — pass `--pull` to the `docker build`, so a laptop that last built a month ago does not build on a month-old base.
3. `7053c331` — the upgrade.

The upgrade moves the client gems in `Gemfile.saas` and the server gems in `saas/hotcell/Gemfile` together, because a client and server one version apart is a `protocol` failure on every request. Nothing transitive moved in either lockfile. It adds the `apt-get upgrade` and the setuid/setgid strip to `saas/hotcell/Dockerfile`, corrects the two comments, and repins the accessory to the rebuilt image, `fizzy-hotcell:ba753374f69a`.

The `engine.rb` comment now names what `describe_cells` does warn about in 0.3.0: a process outside `HOTCELL_GROUP`, and a timeout tighter than what the cell says it may take. The `deploy.yml` comment now says that a thread overflowing a lowered stack dies on `SIGSEGV`, which the supervisor reports as `killed`/`crashed` — transient, so the request is retried against the same limit for as long as the job keeps trying, and no verdict names the setting that caused it. Previously it said `killed`/`memory` and called the verdict permanent. Leaving `ulimit: stack` unset is still right; only the reason was wrong.

## Tests

`saas/test/lib/hotcell_image_test.rb` gains an assertion for the strip, next to the OMP ones. It holds a syntactic invariant in a file Fizzy vendors, which is the point: nothing upstream will restore the step if it is dropped, and the accessory's `no-new-privileges:true` means a running cell would look identical without it.

That runtime coverage is why this is defense-in-depth rather than an open hole — `cap-drop: ALL` and `no-new-privileges:true`, both asserted for every destination in `saas/test/lib/hotcell_accessory_test.rb`, already neutralize a setuid binary. The strip makes the image's own contents independent of those flags.

Checked the strip against the built images rather than trusting the Dockerfile assertion: `find / -xdev -type f -perm /06000` returns nothing in `ba753374f69a` and the eleven binaries listed above in the pre-strip `1ce3b2e9c0ba`.

`saas/test/lib/hotcell_lockfiles_test.rb` holds the two lockfiles at the same hotcell version, and `hotcell_accessory_test.rb` holds the `deploy.yml` pin equal to what the tree builds. Full suite: 1841 tests, 6737 assertions, 0 failures, 3 skips.

## Additional information

20 upstream commits: 9 no impact, 7 not affecting Fizzy, 4 needing mitigation. The plan and the per-commit assessments are in `37signals-hq` at `upgrade-analysis/fizzy-20260901-hotcell_v0.2.0..v0.3.0.md` (`011a8ec3`).

**The image is local only — `saas/hotcell/bin/push` has not run.** It must be published before any deploy, or the accessory pull fails, which is the intended way for an unbuilt image to fail.

0.3.0 also adds `hotcell.op` and `hotcell.stderr` to `worker.killed`, which is what makes a libgomp `exit(1)` legible instead of a bare `crashed`. Fizzy parses no hotcell log fields, so it is inert for this bump; wiring it into the on-call Grafana and Loki views is follow-up work.
