### PR TITLE
Tell a deploy which hotcell fix it needs

### DIFF
--- a/saas/.kamal/hooks/pre-deploy
+++ b/saas/.kamal/hooks/pre-deploy
@@ -1,62 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DESTINATION="${KAMAL_DESTINATION:-production}"
-CONFIG_FILE="$(cd "$(dirname "$0")/../.." && pwd)/config/deploy.yml"
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-# A deploy never touches an accessory, so an app that has been moved onto a cell can arrive before the
-# cell it expects. One randomly chosen host out of the accessory's roles: ssh'ing to all ten costs a
-# minute on production, and the pin drifts per destination rather than per host.
-check_hotcell_pin() {
-    local accessory pinned service host running errors
-
-    # Through Kamal rather than the YAML: saas/config/deploy.yml resolves the gem's directory in ERB, and
-    # the numbered beta destinations are ERB that renders the shared beta template.
-    accessory=$(BUNDLE_GEMFILE=Gemfile.saas bundle exec ruby -r kamal -r pathname -e '
-      config = Kamal::Configuration.create_from(config_file: Pathname.new(ARGV[0]), destination: ARGV[1])
-      accessory = config.accessory(:hotcell)
-      puts config.service
-      puts accessory.image
-      puts accessory.hosts.sample
-    ' "$CONFIG_FILE" "$DESTINATION")
-
-    service=$(echo "$accessory" | sed -n 1p)
-    pinned=$(echo "$accessory" | sed -n 2p)
-    host=$(echo "$accessory" | sed -n 3p)
-
-    if [ -z "$host" ]; then
-        echo "Found no hotcell host for $DESTINATION, aborting" >&2
-        exit 1
-    fi
-
-    # Keep ssh's own chatter out of $running: a banner or a "Permanently added ... to the list of known
-    # hosts" warning folded into the image name compares unequal against a pin it prints identically to.
-    errors=$(mktemp)
-    running=$(ssh "app@$host" "docker inspect --format '{{.Config.Image}}' $service-hotcell" 2>"$errors") || {
-        echo "No hotcell accessory running on $host:" >&2
-        sed 's/^/  /' "$errors" >&2
-        rm -f "$errors"
-        report_remedy
-        exit 1
-    }
-    rm -f "$errors"
-
-    if [ "$running" != "$pinned" ]; then
-        echo "$host runs the hotcell image $running, but saas/config/deploy.yml pins $pinned" >&2
-        report_remedy
-        exit 1
-    fi
-
-    echo "Hotcell accessory on $host runs the pinned $running"
-}
-
-report_remedy() {
-    echo "Publish the pinned image and boot it:" >&2
-    echo "  saas/hotcell/bin/push" >&2
-    echo "  bin/kamal accessory reboot hotcell -d $DESTINATION" >&2
-    echo "Or set SKIP_HOTCELL_CHECKS=1 to deploy anyway" >&2
-}
-
+# A deploy never touches an accessory, so the cell can be older than the app that expects it.
 if [ -z "${SKIP_HOTCELL_CHECKS:-}" ]; then
-    check_hotcell_pin
+    "$repo_root/saas/hotcell/bin/check" "${KAMAL_DESTINATION:-production}"
 fi

--- a/saas/README.md
+++ b/saas/README.md
@@ -91,6 +91,7 @@ Kamal builds app images and not accessory images, so the cell's image has its ow
 saas/hotcell/bin/build                        # locks the gem version, builds, pins deploy.yml to the tag
 saas/hotcell/bin/build --platform=linux/amd64 # what the hosts run
 saas/hotcell/bin/push                         # pushes that tag to the registry
+saas/hotcell/bin/check <destination>          # is that destination's accessory running the pinned tag?
 ```
 
 **The tag is a content hash**, the first 12 characters of a SHA-256 over the `Dockerfile`, `Gemfile`,
@@ -111,6 +112,17 @@ produced it. `push` happens after that commit, so pinning there would leave ever
 pin. Both lockfiles, the operations, and the pin go in one change.
 
 Tags are immutable and there is no `latest`: a deploy does not update an accessory, so `bin/kamal accessory reboot hotcell -d <destination>` pulls whatever the tag names at that moment. A moving tag would make what a host runs depend on when it last rebooted.
+
+### The pre-deploy check
+
+Because a deploy never touches an accessory, an app that has been moved onto a cell can reach a host whose cell is still running an older pinned image, or no cell at all. `saas/hotcell/bin/check` is what `saas/.kamal/hooks/pre-deploy` runs to catch that, and it takes a destination so you can run it by hand at any time. `SKIP_HOTCELL_CHECKS=1` skips it in a deploy.
+
+It asks two questions in order, because they have different fixes:
+
+1. **Is the pinned tag in the registry?** `docker manifest inspect` locally, so it costs no ssh. Missing means nobody built and pushed this commit's cell, and the remedy is `build` (with `--platform=linux/amd64` when your docker host is not amd64), `push`, then `accessory reboot`.
+2. **Is the accessory running it?** `docker inspect` of the `<service>-hotcell` container on one randomly chosen host. The image is published by this point, so the remedy is only `bin/kamal accessory reboot hotcell` — never a build or a push.
+
+Either question failing for a reason that is not an answer — docker not logged in, ssh not getting through — is reported as the check failing rather than as a verdict on the cell. Telling someone to rebuild a published image because `docker manifest inspect` could not authenticate is the failure mode that costs the most.
 
 ### Deploying the cell: the runbook
 

--- a/saas/hotcell/bin/check
+++ b/saas/hotcell/bin/check
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Says whether a destination's hotcell accessory is running the image saas/config/deploy.yml pins, and
+# what to do when it is not. saas/.kamal/hooks/pre-deploy runs this before every deploy; run it by hand
+# any time.
+#
+# A deploy never touches an accessory, so an app that has been moved onto a cell can arrive on a host
+# whose cell is older, or absent. Two things can be wrong and they have different fixes, so they are
+# asked in order: has the pinned image been published at all, and is the accessory running it.
+#
+# Asks one randomly chosen host out of the accessory's roles: sshing all ten costs a minute on
+# production, and the pin drifts per destination rather than per host.
+set -uo pipefail
+
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+cell_dir="$(cd "$bin_dir/.." && pwd)"
+repo_root="$(cd "$cell_dir/../.." && pwd)"
+
+destination="${1:-${KAMAL_DESTINATION:-production}}"
+
+case "${1:-}" in
+  --help|-h)
+    cat <<USAGE
+Usage: saas/hotcell/bin/check <destination>
+
+Checks the hotcell accessory on one host of <destination> against the pin in saas/config/deploy.yml.
+USAGE
+    exit 0
+    ;;
+esac
+
+cd "$repo_root"
+
+# The tag is a hash of the cell's contents, so the build command is what produces the pinned tag, and the
+# hosts are amd64: an arm64 image reaches a host that cannot run it, so name the platform off amd64.
+build_command() {
+  local arch
+  arch="$(docker version --format '{{.Server.Arch}}' 2>/dev/null || true)"
+  if [ "$arch" = "amd64" ]; then
+    echo "saas/hotcell/bin/build"
+  else
+    echo "saas/hotcell/bin/build --platform=linux/amd64"
+  fi
+}
+
+skip_note() {
+  cat >&2 <<MSG
+
+To deploy anyway and sort the cell out afterwards:
+
+    SKIP_HOTCELL_CHECKS=1 bin/kamal deploy -d $destination
+MSG
+}
+
+# Through Kamal rather than the YAML: saas/config/deploy.yml resolves the gem's directory in ERB, and the
+# numbered beta destinations are ERB that renders the shared beta template.
+accessory=$(BUNDLE_GEMFILE=Gemfile.saas bundle exec ruby -r kamal -r pathname -e '
+  config = Kamal::Configuration.create_from(config_file: Pathname.new(ARGV[0]), destination: ARGV[1])
+  accessory = config.accessory(:hotcell)
+  puts config.service
+  puts accessory.image
+  puts accessory.hosts.sample
+' "$repo_root/saas/config/deploy.yml" "$destination")
+
+service=$(echo "$accessory" | sed -n 1p)
+pinned=$(echo "$accessory" | sed -n 2p)
+host=$(echo "$accessory" | sed -n 3p)
+
+if [ -z "$host" ]; then
+  echo "Found no hotcell host for $destination, aborting" >&2
+  exit 1
+fi
+
+echo "Checking the hotcell cell for $destination"
+echo "  pinned:    $pinned"
+
+# Is the pinned tag published at all? Local, so it costs no ssh, and answering it first separates "nobody
+# built this" from "nobody rebooted the accessory" — two different fixes.
+errors=$(mktemp)
+if docker manifest inspect "$pinned" >/dev/null 2>"$errors"; then
+  echo "  registry:  present"
+  rm -f "$errors"
+elif grep -qiE 'manifest unknown|manifest_unknown|not found|no such manifest' "$errors"; then
+  rm -f "$errors"
+  cat >&2 <<MSG
+  registry:  missing
+
+STOP. The hotcell image this commit pins has never been pushed.
+
+The tag is a hash of the cell's own contents, so a change under saas/hotcell/ gives a new tag, which has
+to be built and published before anything can run it. Rebooting the accessory now would find nothing to
+pull.
+
+Build it, push it, then boot it:
+
+    $(build_command)
+    saas/hotcell/bin/push
+    bin/kamal accessory reboot hotcell -d $destination
+
+Then deploy again.
+MSG
+  skip_note
+  exit 1
+else
+  cat >&2 <<MSG
+  registry:  unknown
+
+STOP. Could not tell whether the pinned hotcell image is in the registry.
+
+$(sed 's/^/    /' "$errors")
+
+That is this check failing rather than the deploy: docker may not be running, or you may not be logged
+in to registry.37signals.com. Sort that out and deploy again.
+MSG
+  rm -f "$errors"
+  skip_note
+  exit 1
+fi
+
+# The image is published, so anything wrong from here is a reboot and never a build or a push.
+# Keep ssh's own chatter out of $running: a banner or a "Permanently added ... to the list of known
+# hosts" warning folded into the image name compares unequal against a pin it prints identically to.
+errors=$(mktemp)
+running=$(ssh "app@$host" "docker inspect --format '{{.Config.Image}}' $service-hotcell" 2>"$errors") || running=""
+
+if [ -z "$running" ]; then
+  if grep -qiE 'no such object|no such container' "$errors"; then
+    cat >&2 <<MSG
+  running:   nothing (on $host)
+
+STOP. No hotcell accessory is running on $host.
+
+HOTCELL_ROOT is the only switch, so a registered cell carries every conversion and there is no
+in-process fallback: on this host attachment processing is failing now and will go on failing after the
+deploy.
+
+The pinned image is in the registry, so there is nothing to build or push. A deploy never boots an
+accessory, so boot it by hand:
+
+    bin/kamal accessory reboot hotcell -d $destination
+
+Then deploy again.
+MSG
+  else
+    cat >&2 <<MSG
+  running:   unknown (on $host)
+
+STOP. Could not ask $host what its hotcell accessory is running.
+
+$(sed 's/^/    /' "$errors")
+
+That is this check failing rather than the deploy: the ssh did not get through. Sort that out and deploy
+again.
+MSG
+  fi
+  rm -f "$errors"
+  skip_note
+  exit 1
+fi
+rm -f "$errors"
+
+if [ "$running" != "$pinned" ]; then
+  cat >&2 <<MSG
+  running:   $running (on $host)
+
+STOP. The hotcell accessory is running an image other than the one this commit pins.
+
+The cell that is running may well be converting files perfectly; what a version behind costs depends on
+what changed. But the app and its cell are built to match — a hotcell gem more than one revision apart
+fails every request with a protocol error — so the fix is to get the host onto the pinned image rather
+than to reason about the gap.
+
+The pinned image is in the registry, so there is nothing to build or push. Tags are immutable and there
+is no latest, so the accessory goes on running what it booted with until it is rebooted:
+
+    bin/kamal accessory reboot hotcell -d $destination
+
+Then deploy again.
+MSG
+  skip_note
+  exit 1
+fi
+
+echo "  running:   the pinned image (on $host)"


### PR DESCRIPTION
### Motivation / Background

`check_hotcell_pin` in `saas/.kamal/hooks/pre-deploy` asked one question — does `docker inspect` of `<service>-hotcell` on one host match the accessory's pinned image? — and `report_remedy` printed the same three lines for every way it could fail:

    Publish the pinned image and boot it:
      saas/hotcell/bin/push
      bin/kamal accessory reboot hotcell -d production

So a deployer whose image was already in the registry went and rebuilt it, which on an arm64 laptop is a slow way to learn nothing. An ssh that did not get through printed `No hotcell accessory running on <host>` — a verdict on the cell, when it was the check that had failed. And a cell one version behind was described as though it were broken, which it usually isn't.

Same change as [basecamp/bc3#13073](https://github.com/basecamp/bc3/pull/13073) and [basecamp/haystack#8755](https://github.com/basecamp/haystack/pull/8755).

### Detail

The check moves out of the hook into `saas/hotcell/bin/check`, beside the `build` and `push` it names, and takes a destination so it can be run by hand:

    saas/hotcell/bin/check beta1

It asks two questions in order, because they have different fixes.

**Is the pinned tag in the registry?** `docker manifest inspect`, locally, so it costs no ssh:

    Checking the hotcell cell for production
      pinned:    registry.37signals.com/basecamp/fizzy-hotcell:7c31a9de40b2
      registry:  missing

    STOP. The hotcell image this commit pins has never been pushed.

    The tag is a hash of the cell's own contents, so a change under saas/hotcell/ gives a new tag, which has
    to be built and published before anything can run it. Rebooting the accessory now would find nothing to
    pull.

    Build it, push it, then boot it:

        saas/hotcell/bin/build --platform=linux/amd64
        saas/hotcell/bin/push
        bin/kamal accessory reboot hotcell -d production

`--platform=linux/amd64` appears only when `docker version --format '{{.Server.Arch}}'` is not `amd64`, so nobody on amd64 reads a flag they don't need.

**Is the accessory running it?** The image is published by now, so the remedy is a reboot and never a build:

      running:   registry.37signals.com/basecamp/fizzy-hotcell:1a2b3c4d5e6f (on fizzy-web-1.fizzy.com)

    STOP. The hotcell accessory is running an image other than the one this commit pins.

    The cell that is running may well be converting files perfectly; what a version behind costs depends on
    what changed. But the app and its cell are built to match — a hotcell gem more than one revision apart
    fails every request with a protocol error — so the fix is to get the host onto the pinned image rather
    than to reason about the gap.

    The pinned image is in the registry, so there is nothing to build or push. Tags are immutable and there
    is no latest, so the accessory goes on running what it booted with until it is rebooted:

        bin/kamal accessory reboot hotcell -d production

No accessory at all keeps a firm tone. `HOTCELL_ROOT` is the only switch here, so a registered cell carries every conversion with no in-process fallback — that host is failing attachment processing right now, not merely lagging:

      running:   nothing (on fizzy-web-1.fizzy.com)

    STOP. No hotcell accessory is running on fizzy-web-1.fizzy.com.

    HOTCELL_ROOT is the only switch, so a registered cell carries every conversion and there is no
    in-process fallback: on this host attachment processing is failing now and will go on failing after the
    deploy.

Either question failing for a reason that is *not* an answer now says so:

      running:   unknown (on fizzy-web-1.fizzy.com)

    STOP. Could not ask fizzy-web-1.fizzy.com what its hotcell accessory is running.

        ssh: connect to host fizzy-web-1.fizzy.com port 22: Connection timed out

    That is this check failing rather than the deploy: the ssh did not get through.

Success is three aligned lines instead of one sentence:

      pinned:    registry.37signals.com/basecamp/fizzy-hotcell:7c31a9de40b2
      registry:  present
      running:   the pinned image (on fizzy-web-1.fizzy.com)

`SKIP_HOTCELL_CHECKS=1` still skips the check. Its note now reads "to deploy anyway and sort the cell out afterwards" rather than claiming the hosts have no working cell.

### Additional information

The hook keeps `SKIP_HOTCELL_CHECKS` and is now the whole file:

    repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"

    # A deploy never touches an accessory, so the cell can be older than the app that expects it.
    if [ -z "${SKIP_HOTCELL_CHECKS:-}" ]; then
        "$repo_root/saas/hotcell/bin/check" "${KAMAL_DESTINATION:-production}"
    fi

`saas/README.md` gains `bin/check` in the command list and a "pre-deploy check" section describing the two questions.

One new way for the check to stop a deploy: `docker manifest inspect` needs a logged-in docker. A deploy satisfies that already, since Kamal logs in to build the app image first, but running `bin/check` by hand on a cold laptop lands in "registry: unknown" instead of an answer. Safe direction — it does not tell you to rebuild — but a stop that did not exist before.

All four paths exercised with stubbed `docker`, `ssh` and `bundle` against a fake repo root, not against the real registry or a real host.
