### PR TITLE
Upgrade hotcell to 0.3.1

### DIFF
--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -11,8 +11,8 @@ gem "console1984", bc: "console1984"
 gem "audits1984", bc: "audits1984"
 
 # Attachment processing in an unprivileged sibling container
-gem "hotcell-client", "~> 0.3.0"
-gem "activestorage-hotcell-client", "~> 0.3.0"
+gem "hotcell-client", "~> 0.3.1"
+gem "activestorage-hotcell-client", "~> 0.3.1"
 
 # Native push notifications (iOS/Android)
 gem "action_push_native"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -245,9 +245,9 @@ GEM
       activemodel (>= 7.0)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 7.0)
-    activestorage-hotcell-client (0.3.0)
+    activestorage-hotcell-client (0.3.1)
       activestorage (>= 8.2.0.alpha)
-      hotcell-client (= 0.3.0)
+      hotcell-client (= 0.3.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ansi (1.6.0)
@@ -356,10 +356,10 @@ GEM
       signet (>= 0.16, < 2.a)
     gvltools (0.5.0)
     hashdiff (1.2.1)
-    hotcell-client (0.3.0)
+    hotcell-client (0.3.1)
       activesupport (>= 7.1)
-      hotcell-core (= 0.3.0)
-    hotcell-core (0.3.0)
+      hotcell-core (= 0.3.1)
+    hotcell-core (0.3.1)
     http-2 (1.1.1)
     httpx (1.7.1)
       http-2 (>= 1.0.0)
@@ -742,7 +742,7 @@ DEPENDENCIES
   action_push_native
   actionpack-xml_parser
   activeresource
-  activestorage-hotcell-client (~> 0.3.0)
+  activestorage-hotcell-client (~> 0.3.1)
   audits1984!
   autotuner
   aws-sdk-s3
@@ -758,7 +758,7 @@ DEPENDENCIES
   fizzy-saas!
   geared_pagination (~> 1.2)
   gvltools
-  hotcell-client (~> 0.3.0)
+  hotcell-client (~> 0.3.1)
   image_processing (~> 1.14)
   importmap-rails
   jbuilder
@@ -826,7 +826,7 @@ CHECKSUMS
   activerecord (8.2.0.alpha)
   activeresource (6.2.0) sha256=818ca60d3cd1ff7bbb7277f41250ad4d61a7cdbe30fbf52b2145e1b66ed13900
   activestorage (8.2.0.alpha)
-  activestorage-hotcell-client (0.3.0) sha256=ee437b08b57673df0f823c2c902504d19483672566e2931e6cfafe10c70b6e6c
+  activestorage-hotcell-client (0.3.1) sha256=57c62cf0825eddcb47970ffce4bae4d05ca1b63740a21b67f676313cc66a4cd7
   activesupport (8.2.0.alpha)
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
@@ -888,8 +888,8 @@ CHECKSUMS
   googleauth (1.16.1) sha256=36776bce9d55d8c1a0c6638c939b000dcee5954ca5b728f06ec4c2df4a46709c
   gvltools (0.5.0) sha256=a15e480b3860e7e9661e5e53aff9b1802fe9018fa42a5e845adc2a19a7bcc65d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  hotcell-client (0.3.0) sha256=c2839b6e1e19991660c69f24bf1516936d61c510c9e2cc9be40abc863762cc1e
-  hotcell-core (0.3.0) sha256=b9665e2e78586293c40d03de5f4408cb9c344402750dafd502e118eb8660be2e
+  hotcell-client (0.3.1) sha256=bd1760634b532c660f1c37051eda20da2e0a4b0f8bfca239e04f5df1b4a32aff
+  hotcell-core (0.3.1) sha256=c72bc2b6d151a8bf22600eb2ad202b72baf6c5c454077684d63547db176c77ed
   http-2 (1.1.1) sha256=1141a5a03c2f4e6b8d2fa62394de581e1ff6387711cd7ed577212e9d95562bba
   httpx (1.7.1) sha256=ae380461539203c92f3ee65c13b22dfccb0d975156426869f57820505cacdf56
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5

--- a/saas/config/deploy.yml
+++ b/saas/config/deploy.yml
@@ -68,7 +68,7 @@ accessories:
     # would make what a host runs depend on when it last rebooted. saas/hotcell/bin/build writes this line;
     # saas/hotcell/bin/push publishes the tag. Until push has run the pull fails loudly, which is the right
     # way for an unbuilt image to fail.
-    image: registry.37signals.com/basecamp/fizzy-hotcell:ba753374f69a
+    image: registry.37signals.com/basecamp/fizzy-hotcell:d5cf91821660
     roles: [ web, jobs ]  # a descriptor cannot cross machines, so a cell lives on its caller's host
     # An accessory's own key, not one of the options below. Kamal always emits a --network of its own,
     # defaulting to `kamal`, so the same setting under `options:` is a second --network flag and Docker

--- a/saas/hotcell/Gemfile
+++ b/saas/hotcell/Gemfile
@@ -9,5 +9,5 @@
 
 source "https://rubygems.org"
 
-gem "hotcell-server", "~> 0.3.0"
-gem "activestorage-hotcell-server", "~> 0.3.0"
+gem "hotcell-server", "~> 0.3.1"
+gem "activestorage-hotcell-server", "~> 0.3.1"

--- a/saas/hotcell/Gemfile.lock
+++ b/saas/hotcell/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activestorage-hotcell-server (0.3.0)
-      hotcell-server (= 0.3.0)
+    activestorage-hotcell-server (0.3.1)
+      hotcell-server (= 0.3.1)
       image_processing (>= 2.0)
       mini_magick (>= 5.2.0)
       ruby-vips (>= 2.2.1)
@@ -17,9 +17,9 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    hotcell-core (0.3.0)
-    hotcell-server (0.3.0)
-      hotcell-core (= 0.3.0)
+    hotcell-core (0.3.1)
+    hotcell-server (0.3.1)
+      hotcell-core (= 0.3.1)
     image_processing (2.0.3)
     logger (1.7.0)
     mini_magick (5.3.3)
@@ -42,11 +42,11 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  activestorage-hotcell-server (~> 0.3.0)
-  hotcell-server (~> 0.3.0)
+  activestorage-hotcell-server (~> 0.3.1)
+  hotcell-server (~> 0.3.1)
 
 CHECKSUMS
-  activestorage-hotcell-server (0.3.0) sha256=e82db5cc602651ca4ce49486cf19c7c01e86cdeddb7105106b3aca50ae67f98b
+  activestorage-hotcell-server (0.3.1) sha256=660839dc4ef34b7b5cc0b4b8733bc5b90b6667a469eee72ff2c07a41c7703935
   bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
@@ -59,8 +59,8 @@ CHECKSUMS
   ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
-  hotcell-core (0.3.0) sha256=b9665e2e78586293c40d03de5f4408cb9c344402750dafd502e118eb8660be2e
-  hotcell-server (0.3.0) sha256=bb1c0137921ffa9c3d99709c2acc4704a49b1c6a6ebf48b08d24d78ae73571c1
+  hotcell-core (0.3.1) sha256=c72bc2b6d151a8bf22600eb2ad202b72baf6c5c454077684d63547db176c77ed
+  hotcell-server (0.3.1) sha256=170b68343d30c325392d86b24263507a69b2790e8e0a31a1e7063a2e0da89614
   image_processing (2.0.3) sha256=793e33f38470edd0a2d6bfd00acf8cb239c76284ba2e3dfb76633ac2b457f23a
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (5.3.3) sha256=b3beed8a8cef36bd03666365f14b89cd344da0ecd373af53e617c71bfd426aab

--- a/saas/hotcell/operations/reopen.rb
+++ b/saas/hotcell/operations/reopen.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # Copied from the hotcell repository's examples/operations/reopen.rb. The same round trip as echo, but
-# re-opening both descriptors by `/dev/fd/N` — a fresh open, rechecked against the cell's uid — which is
-# what every operation that hands a tool a filename does. A cell missing the shared group answers echo
-# perfectly and fails only this. It re-opens in both directions because reading and writing are different
-# permissions, and shipped operations do each.
+# re-opening both descriptors by name — `/dev/fd/N` on Linux, the file's own path on macOS — a fresh open,
+# rechecked against the cell's uid, which is what every operation that hands a tool a filename does. A cell
+# missing the shared group answers echo perfectly and fails only this. It re-opens in both directions
+# because reading and writing are different permissions, and shipped operations do each.
 module Examples
   class Reopen < HotCell::Operation
     operation "example.reopen"


### PR DESCRIPTION
An attachment the image pipeline refused — a source it cannot render
into the requested format — was retried on every future request,
forever, because the cell reported the refusal as transient. It is now
permanent: the attachment is rejected once, the blob marked, and the
request answered 422. Failures of this kind move from the `failed`
Yabeda counter to `unreadable`.

Nothing else here changes behavior in production. The other fix in the
release is macOS-only, so it reaches development cells and not the
fleet.

ref: https://github.com/basecamp/hotcell/blob/v0.3.1/CHANGELOG.md


