### PR TITLE
Guard nil user.settings in Notification#bundle (fix FIZZY-VM)

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -57,7 +57,7 @@ class Notification < ApplicationRecord
     end
 
     def bundle
-      user.bundle(self) if user.settings.bundling_emails?
+      user.bundle(self) if user.settings&.bundling_emails?
     end
 
     def broadcast_update

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -84,4 +84,14 @@ class NotificationTest < ActiveSupport::TestCase
       notification.destroy
     end
   end
+
+  test "bundle skips without raising when user has no settings" do
+    jason = users(:jason)
+    assert_nil jason.settings
+
+    assert_no_difference -> { Notification::Bundle.count } do
+      notification = Notification.create!(user: jason, source: events(:layout_commented), creator: users(:david))
+      assert notification.persisted?
+    end
+  end
 end


### PR DESCRIPTION
## Root cause

`Notification#bundle` (a private `after_create` / `after_update` callback in `app/models/notification.rb`) calls `user.settings.bundling_emails?` unconditionally. `User` `has_one :settings` (`User::Settings`), created via an `after_create` callback on `User` — but a user with no settings record has `user.settings == nil`, so the call raised `NoMethodError: undefined method 'bundling_emails?' for nil`.

This failed the notification write, which in turn failed its enqueuing job (`NotifyRecipientsJob` → `notifiable.notify_recipients`) into the SolidQueue failed set, driving the `FizzySolidQueueFailedJobs` alert. Reported in Sentry as FIZZY-VM.

## Fix

Nil-guard the call:

```ruby
def bundle
  user.bundle(self) if user.settings&.bundling_emails?
end
```

A user with no settings record hasn't opted into bundling, so skipping is semantically correct and crash-safe. Scoped to this one call site — `User::Settings#bundling_emails?` itself is unchanged.

## Test

Added a regression test in `test/models/notification_test.rb` using the `jason` fixture (which has no `User::Settings` fixture, so `jason.settings` is genuinely `nil`), asserting notification creation does not raise and no `Notification::Bundle` is created. Confirmed non-vacuous: fails with the exact same `NoMethodError` before the fix, passes after.

## Impact

Clears `FizzySolidQueueFailedJobs` for this failure mode.

Refs: Sentry FIZZY-VM, On-Call card 10266322819.