### PR TITLE
Create settings for imported users that arrive without them

### DIFF
--- a/app/models/account/import.rb
+++ b/app/models/account/import.rb
@@ -60,6 +60,7 @@ class Account::Import < ApplicationRecord
     end
 
     add_importer_to_all_access_boards
+    create_missing_user_settings
     reconcile_cards_count
     reconcile_account_storage
 
@@ -129,6 +130,10 @@ class Account::Import < ApplicationRecord
       account.boards.all_access.find_each do |board|
         board.accesses.grant_to(importer)
       end
+    end
+
+    def create_missing_user_settings
+      account.users.where.not(role: :system).where.missing(:settings).find_each(&:create_settings!)
     end
 
     def reconcile_account_storage

--- a/test/models/account/import_test.rb
+++ b/test/models/account/import_test.rb
@@ -33,6 +33,7 @@ class Account::ImportTest < ActiveSupport::TestCase
     identity = exporter.identity
 
     source_account_digest = account_digest(source_account)
+    source_user_settings = user_settings_digest(source_account)
 
     export = Account::Export.create!(account: source_account, user: exporter)
     export.build
@@ -57,9 +58,48 @@ class Account::ImportTest < ActiveSupport::TestCase
     assert import.completed?
 
     assert_equal source_account_digest, account_digest(target_account)
+    assert_equal source_user_settings, user_settings_digest(target_account).slice(*source_user_settings.keys)
+    assert_empty users_without_settings(target_account)
+    assert_empty duplicate_user_settings(target_account)
   ensure
     export_tempfile&.close
     export_tempfile&.unlink
+  end
+
+  test "import creates settings for users whose export carried none" do
+    source_account = accounts("37s")
+    exporter = users(:david)
+    identity = exporter.identity
+
+    export = Account::Export.create!(account: source_account, user: exporter)
+    export.build
+
+    export_tempfile = Tempfile.new([ "export", ".zip" ])
+    export.file.open { |f| FileUtils.cp(f.path, export_tempfile.path) }
+
+    stripped_tempfile = zip_without(export_tempfile.path, "data/user_settings/*")
+
+    source_account.destroy!
+
+    target_account = Account.create_with_owner(account: { name: "Import Test" }, owner: { identity: identity, name: exporter.name })
+    import = Account::Import.create!(identity: identity, account: target_account)
+    Current.set(account: target_account) do
+      import.file.attach(io: File.open(stripped_tempfile.path), filename: "export.zip", content_type: "application/zip")
+    end
+
+    import.check
+    import.process
+
+    assert import.completed?
+    assert_operator User.where(account: target_account).where.not(role: :system).count, :>, 1
+    assert_empty users_without_settings(target_account)
+    assert_empty duplicate_user_settings(target_account)
+    assert_empty User::Settings.where(account: target_account).joins(:user).where(user: { role: :system })
+  ensure
+    export_tempfile&.close
+    export_tempfile&.unlink
+    stripped_tempfile&.close
+    stripped_tempfile&.unlink
   end
 
   test "import reconciles cards count so new cards get correct numbers" do
@@ -288,7 +328,41 @@ class Account::ImportTest < ActiveSupport::TestCase
         column_colors: Column.where(account: account).order(:id).pluck(:color),
         card_count: Card.where(account: account).count,
         comment_count: Comment.where(account: account).count,
-        tag_count: Tag.where(account: account).count
+        tag_count: Tag.where(account: account).count,
+        user_ids: User.where(account: account).where.not(role: :system).order(:id).pluck(:id)
       }
+    end
+
+    def user_settings_digest(account)
+      User::Settings.where(account: account).pluck(:user_id, :bundle_email_frequency).to_h
+    end
+
+    def users_without_settings(account)
+      User.where(account: account).where.not(role: :system).where.missing(:settings)
+    end
+
+    def duplicate_user_settings(account)
+      User::Settings.where(account: account).group(:user_id).having("COUNT(*) > 1").count
+    end
+
+    def zip_without(path, pattern)
+      tempfile = Tempfile.new([ "stripped_export", ".zip" ])
+      tempfile.binmode
+      writer = ZipFile::Writer.new(tempfile)
+
+      File.open(path, "rb") do |file|
+        reader = ZipFile::Reader.new(file)
+
+        reader.glob("*").each do |entry|
+          next if entry.end_with?("/")
+          next if File.fnmatch(pattern, entry)
+
+          writer.add_file(entry, reader.read(entry))
+        end
+      end
+
+      writer.close
+      tempfile.rewind
+      tempfile
     end
 end


### PR DESCRIPTION
Follow-up to the diagnosis on [On Call card 10266322819](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10266322819): `NotifyRecipientsJob` was failing with `NoMethodError: undefined method 'bundling_emails?' for nil` (Sentry [FIZZY-VM](https://basecamp.sentry.io/issues/FIZZY-VM)) because `Notification#bundle` calls `user.settings.bundling_emails?` for a user with no `user_settings` row. #3099 nil-guards that call site. This fixes the reason the row is missing.

## Why users end up without settings

`User::Configurable` creates the row in a callback:

```ruby
after_create :create_settings, unless: :system?
```

`Account::DataTransfer::UserRecordSet#import_batch` writes imported users with `User.insert_all!`, which skips callbacks:

```ruby
account.users.where(identity_id: conflicting_identity_ids).destroy_all
User.insert_all!(batch_data)
```

`User::Settings` is in `Account::DataTransfer::Manifest`, so settings come back only when the export zip carries `data/user_settings/<id>.json` for that user. Nothing in `check` or `process` verifies it afterwards, so an import from a zip without those files leaves the user permanently settings-less. The `destroy_all` above makes it worse for the person doing the import: their freshly created owner user is destroyed along with its settings, then reinserted from the zip without callbacks.

## Production evidence

Read-only `rails query` against production:

```
User.count                                        => 87838
User.where.missing(:settings).count                => 39817
User.where.missing(:settings).group(:role).count   => {"system"=>39805, "owner"=>11, "member"=>1}
```

The 39,805 system users are by design and hold no board accesses, so they never become recipients. That leaves 12 real users across 12 accounts, one per account. Ten of them have a `created_at` older than the account they belong to, which only happens when the row is written by `insert_all!` with the timestamp from the zip. Every completed row in `account_imports` (6 of them, the rest expire after 24 hours via `Account::Import.cleanup`) produced exactly one such user.

Both failed jobs were `card_assigned` events where an account owner assigned a card to the imported user:

```
User::Settings Load  SELECT `user_settings`.* FROM `user_settings`
  WHERE `user_settings`.`user_id` = x'019e7eee0e84d434f08f732beee4d765' LIMIT 1
TRANSACTION ROLLBACK
Error performing NotifyRecipientsJob ... NoMethodError (undefined method 'bundling_emails?' for nil):
app/models/notification.rb:60:in 'Notification#bundle'
```

## The change

One sweep at the end of `Account::Import#process`, next to the other reconciliation steps:

```ruby
def create_missing_user_settings
  account.users.where.not(role: :system).where.missing(:settings).find_each(&:create_settings!)
end
```

I picked that seam over `UserRecordSet#import_batch` for two reasons:

- The `User::Settings` record set imports **after** the users in the manifest, and `user_settings` has a non-unique index on `user_id`. Creating settings per user batch would duplicate rows for every user whose settings the zip does carry.
- `Account::DataImportJob` is `ActiveJob::Continuable` and resumes with `import.process(start: cursor)`. The tail of `process` runs on every attempt, so the sweep covers partial and resumed imports; a per-batch fix would only cover the batches that ran in the successful attempt.

It is idempotent (`where.missing(:settings)` matches nothing on a second run), and it leaves imported settings untouched, so a real export keeps its `bundle_email_frequency` and `timezone_name`.

## Tests

- `account_digest` now covers non-system user ids, which it did not look at before, so the round-trip test could pass with users and settings missing.
- The round-trip test asserts every settings row the source had comes across with the same frequency, and that no non-system user in the target is left without settings.
- A new test strips `data/user_settings/` out of a real export zip and imports it, then asserts every non-system user has settings and no system user gained one.

Non-vacuity: with the `Account::Import` change reverted, both tests fail (Jason in the round trip, all four non-system users in the stripped-zip test). With it, `bin/rails test` is green at 1658 tests, 6219 assertions, and rubocop is clean.

## Backfill for the 12 existing users (operator-run, not in this PR)

This PR stops new imports from producing settings-less users. It does not repair the ones already in production. On a production console:

```ruby
users = User.where.not(role: :system).where.missing(:settings)
users.count # => 12
users.find_each(&:create_settings!)
users.count # => 0
```

## Follow-up, not in this PR

Three controllers call `user.settings.` with no guard, so those 12 users hit a 500 on their own settings today:

- `app/controllers/my/timezones_controller.rb:3`: `Current.user.settings.update!(timezone_name: timezone_param)`
- `app/controllers/notifications/settings_controller.rb:21`: `@settings = Current.user.settings`, then `@settings.update!`
- `app/controllers/notifications/unsubscribes_controller.rb:11`: `@user.settings.bundle_email_never!`

I left them alone deliberately. A nil-safe call there would silently no-op a setting the user just changed, so the right fix is a decision about where the invariant lives, not a one-liner. Worth its own pass once the backfill has run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
