### PR TITLE
Add bin/deploy to bring the hotcell cell along with the app

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Deploys one destination. The work is SaaS-only, so it lives in saas/bin/deploy; this forwards there
+# once SaaS mode is on, the way bin/setup runs saas/bin/setup, and bin/kamal picks the SaaS config.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if ! ruby -r./lib/fizzy -e 'exit Fizzy.saas?'; then
+  echo "bin/deploy deploys the SaaS app. Run bin/rails saas:enable first." >&2
+  exit 1
+fi
+
+exec saas/bin/deploy "$@"

--- a/saas/AGENTS.md
+++ b/saas/AGENTS.md
@@ -13,7 +13,7 @@ Shared 37signals context: if "37signals Development Context" isn't already loade
 ## Deploy
 
 Pre-deploy: `bin/rails saas:enable`
-Deploy: `bin/kamal deploy -d <destination>`
+Deploy: `bin/deploy <destination>` — brings the hotcell accessory onto the pinned image, then runs `bin/kamal deploy -d <destination>`. Use `bin/kamal deploy` directly only when you need other kamal arguments.
 Destinations: production, staging, beta, beta1
 
 One `saas/config/deploy.<destination>.yml` each — paths here are given from the repository root, because that's where you're working from, and `config/deploy.yml` at the root is the self-hosting example rather than ours. `beta` is a template requiring the `BETA_NUMBER` env var; `beta1` is the only numbered target that exists. The `saas/.kamal/secrets.beta2` through `saas/.kamal/secrets.beta4` symlinks are leftovers and don't make those destinations real.

--- a/saas/README.md
+++ b/saas/README.md
@@ -83,54 +83,31 @@ Because the dev cell shells out to your laptop rather than to the image, every t
 | `HOTCELL_ROOT` | Registers the cell, which then carries every conversion. Unset, everything runs in the app. | `saas/config/deploy.yml` |
 | `HOTCELL_GROUP` | The gid the app and the cell share, so the cell can open a file the app hands it by name. Must match the `group-add` on the app's roles and the cell's own gid. Unset in development, where both sides run as one user. | `saas/config/deploy.yml` |
 
-### Building and shipping the image
-
-Kamal builds app images and not accessory images, so the cell's image has its own two scripts. They are separate so that building can happen anywhere and publishing is deliberate.
+### Deploying
 
 ```sh
-saas/hotcell/bin/build                        # locks the gem version, builds, pins deploy.yml to the tag
-saas/hotcell/bin/build --platform=linux/amd64 # what the hosts run
-saas/hotcell/bin/push                         # pushes that tag to the registry
-saas/hotcell/bin/check <destination>          # is that destination's accessory running the pinned tag?
+bin/deploy <destination>
 ```
 
-**The tag is a content hash**, the first 12 characters of a SHA-256 over the `Dockerfile`, `Gemfile`,
-`Gemfile.lock`, `config.rb` and `operations/*.rb` — see `bin/image`. Not a git revision: the commit that
-bumps the gem and pins the result could never name itself, because amending it changed the SHA the pin was
-meant to hold. Identical bytes give an identical tag, and changing something the image does not contain
-leaves it alone. `saas/test/lib/hotcell_accessory_test.rb` holds the pin in `deploy.yml` equal to what the
-tree builds, so a stale pin fails in CI.
+That is the whole deploy. It brings the destination's hotcell accessory onto the image this commit pins, then runs `bin/kamal deploy -d <destination>`. It takes nothing but the destination. For any other kamal argument run `bin/kamal deploy` yourself, with `SKIP_HOTCELL_CHECKS=1` if you mean to deploy over a broken cell.
 
-**`build` locks the cell's `Gemfile.lock` to the hotcell version in the app's `Gemfile.saas.lock`**,
-writing it if the two differ, and then builds. The app's lockfile is the source of truth: a client and
-server one version apart is a `protocol` failure on every request. So move the gem in the application
-first, then build.
+Underneath, `bin/deploy` forwards to `saas/bin/deploy`, which drives three scripts in `saas/hotcell/bin/`:
 
-**`build` also writes the pin in `saas/config/deploy.yml`**, and it belongs there rather than in `push`:
-the tag is a hash of the tree's contents, so the pin has to land in the same commit as the contents that
-produced it. `push` happens after that commit, so pinning there would leave every commit holding a stale
-pin. Both lockfiles, the operations, and the pin go in one change.
+| script | what it does |
+| --- | --- |
+| `check <destination>` | Is the pinned image in the registry, and is the accessory on one host of `<destination>` running it? The exit status names the fix: 2 build and push, 3 reboot, 1 the check could not tell. |
+| `build [--platform=linux/amd64]` | Locks `saas/hotcell/Gemfile.lock` to the hotcell version in `Gemfile.saas.lock`, builds the image, and pins `saas/config/deploy.yml` to its tag. |
+| `push` | Pushes the built tag to the registry. |
 
-Tags are immutable and there is no `latest`: a deploy does not update an accessory, so `bin/kamal accessory reboot hotcell -d <destination>` pulls whatever the tag names at that moment. A moving tag would make what a host runs depend on when it last rebooted.
+`bin/deploy` runs `check`, applies the fix its status names (`build --platform=linux/amd64` and `push`, then `bin/kamal accessory reboot hotcell`; or the reboot alone), runs `check` again, and only then deploys the app. `saas/.kamal/hooks/pre-deploy` runs the same `check` before a direct `bin/kamal deploy`, so a stale cell stops that deploy too, with the fix spelled out.
 
-### The pre-deploy check
+The check fails rather than guesses when it cannot answer: docker not logged in, ssh not getting through. Telling someone to rebuild a published image because `docker manifest inspect` could not authenticate is the failure mode that costs the most.
 
-Because a deploy never touches an accessory, an app that has been moved onto a cell can reach a host whose cell is still running an older pinned image, or no cell at all. `saas/hotcell/bin/check` is what `saas/.kamal/hooks/pre-deploy` runs to catch that, and it takes a destination so you can run it by hand at any time. `SKIP_HOTCELL_CHECKS=1` skips it in a deploy.
+### Changing the cell
 
-It asks two questions in order, because they have different fixes:
+Anything under `saas/hotcell/` that the image copies in, or a hotcell gem moving in `Gemfile.saas.lock`, means a new image. CI tells you when you owe one: `saas/test/lib/hotcell_accessory_test.rb` fails if the pin in `deploy.yml` no longer matches what the tree builds.
 
-1. **Is the pinned tag in the registry?** `docker manifest inspect` locally, so it costs no ssh. Missing means nobody built and pushed this commit's cell, and the remedy is `build` (with `--platform=linux/amd64` when your docker host is not amd64), `push`, then `accessory reboot`.
-2. **Is the accessory running it?** `docker inspect` of the `<service>-hotcell` container on one randomly chosen host. The image is published by this point, so the remedy is only `bin/kamal accessory reboot hotcell` — never a build or a push.
-
-Either question failing for a reason that is not an answer — docker not logged in, ssh not getting through — is reported as the check failing rather than as a verdict on the cell. Telling someone to rebuild a published image because `docker manifest inspect` could not authenticate is the failure mode that costs the most.
-
-### Deploying the cell: the runbook
-
-Deploy the cell when anything under `saas/hotcell/` changes, or when the hotcell gems move in
-`Gemfile.saas.lock`. CI tells you when you owe one: `hotcell_accessory_test.rb` fails if the pin in
-`deploy.yml` no longer matches what the tree builds.
-
-1. Build the image and pin it:
+1. Build, which pins `saas/config/deploy.yml`:
 
    ```sh
    saas/hotcell/bin/build --platform=linux/amd64
@@ -142,32 +119,29 @@ Deploy the cell when anything under `saas/hotcell/` changes, or when the hotcell
    bin/rails test saas/test/lib/hotcell_accessory_test.rb
    ```
 
-3. Commit everything together: the lockfiles, the `saas/config/deploy.yml` pin, and whatever
-   changed under `saas/hotcell/`.
+3. Commit everything together: both lockfiles, the pin, and whatever changed under `saas/hotcell/`.
 
-4. Push the image:
-
-   ```sh
-   saas/hotcell/bin/push
-   ```
-
-5. Reboot the accessory on each destination:
+4. Deploy each destination. `bin/deploy` sees the new pin is not in the registry, pushes it, reboots the cell, and deploys the app:
 
    ```sh
-   bin/kamal accessory reboot hotcell -d <destination>
+   bin/deploy <destination>
    ```
 
-6. Verify the destination: `/hotcellz` answers `OK`, `/hotcellz/test` (staff-only) passes all four
-   checks, `hotcell_up == 1` for every host in Prometheus, and no `WARN`/`ERROR` lines in Loki
-   under `{service_name="hotcell"}`.
+5. Verify the destination: `/hotcellz` answers `OK`, `/hotcellz/test` (staff-only) passes all four checks, `hotcell_up == 1` for every host in Prometheus, and no `WARN`/`ERROR` lines in Loki under `{service_name="hotcell"}`.
 
-When the hotcell gems moved, the app has to be deployed too — the usual rollout, separate from
-this one. A client and server more than one revision apart fail every request with a `protocol`
-error, so keep the two close together.
+`build` is the one step by hand, because the pin it writes belongs in your commit: the tag is a content hash and the commit that changes the contents has to carry it. `bin/deploy` refuses to push a pin that is not committed.
+
+#### Why it is built this way
+
+**The tag is a content hash**, the first 12 characters of a SHA-256 over the `Dockerfile`, `Gemfile`, `Gemfile.lock`, `config.rb` and `operations/*.rb` (see `saas/hotcell/bin/image`). Not a git revision: the commit that bumps the gem and pins the result could never name itself, because amending it changed the SHA the pin was meant to hold. Identical bytes give an identical tag, and changing something the image does not contain leaves it alone.
+
+**`build` locks the cell's `Gemfile.lock` to the app's hotcell version** because a client and server one version apart is a `protocol` failure on every request. The app's lockfile is the source of truth: move the gem in the application first, then build.
+
+**Tags are immutable and there is no `latest`.** A deploy does not update an accessory; `kamal accessory reboot` pulls whatever the tag names at that moment, and a moving tag would make what a host runs depend on when it last rebooted. That is also why a deploy that only bumps the gem still has to reboot the cell, and why `bin/deploy` does it for you.
 
 ## Environments
 
-Fizzy is deployed with [Kamal](https://kamal-deploy.org/). You'll need to have the 1Password CLI set up in order to access the secrets that are used when deploying. Provided you have that, it should be as simple as `bin/kamal deploy` to the correct environment.
+Fizzy is deployed with [Kamal](https://kamal-deploy.org/). You'll need to have the 1Password CLI set up in order to access the secrets that are used when deploying. Provided you have that, it should be as simple as `bin/deploy <destination>`.
 
 ## Handbook
 

--- a/saas/bin/deploy
+++ b/saas/bin/deploy
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Deploys one SaaS destination: gets its hotcell accessory onto the image this commit pins, then deploys
+# the app. bin/deploy forwards here once it has checked that SaaS mode is on. A deploy never touches an accessory, so the two drift apart; this is the one command that moves
+# them together.
+#
+# saas/hotcell/bin/check says what the cell needs and its exit status names the fix. An image nobody has
+# pushed is built for the hosts' platform, pushed, and booted; an accessory running something else, or
+# nothing, is rebooted. The app deploys only once the check passes. The first check is quiet because the
+# fix is applied here; the one after the fix is not, because if it still fails the reader has to act. Anything else — other kamal
+# arguments, deploying over a broken cell — is bin/kamal deploy, with SKIP_HOTCELL_CHECKS=1 if you mean it.
+#
+# saas/test/deploy-test runs this against stubs; run it after changing anything here.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+usage() {
+  cat >&2 <<USAGE
+Usage: bin/deploy <destination>
+
+Brings <destination>'s hotcell accessory onto the pinned image, then runs bin/kamal deploy -d <destination>.
+Pass anything else to kamal directly.
+USAGE
+  exit 1
+}
+
+[ $# -eq 1 ] || usage
+case "$1" in -*) usage ;; esac
+destination="$1"
+
+cd "$repo_root"
+
+status=0
+saas/hotcell/bin/check -q "$destination" || status=$?
+
+case $status in
+  0) ;;
+  2)
+    echo
+    echo "The pinned cell image is not in the registry. Building and pushing it, then rebooting the cell on $destination."
+    saas/hotcell/bin/build --platform=linux/amd64
+    # The tag is a hash of the cell's contents, so a build that moved the pin means this commit pinned
+    # an image it does not build. Deploying that pin is deploying an uncommitted config.
+    if ! git diff --quiet -- saas/config/deploy.yml saas/hotcell/Gemfile.lock; then
+      echo "Building moved the hotcell pin. Commit saas/config/deploy.yml and saas/hotcell/Gemfile.lock, then deploy again." >&2
+      exit 1
+    fi
+    saas/hotcell/bin/push
+    bin/kamal accessory reboot hotcell -d "$destination"
+    saas/hotcell/bin/check "$destination"
+    ;;
+  3)
+    echo
+    echo "$destination is not running the pinned cell image. Rebooting the cell."
+    bin/kamal accessory reboot hotcell -d "$destination"
+    saas/hotcell/bin/check "$destination"
+    ;;
+  *) exit $status ;;
+esac
+
+echo
+echo "The cell is on the pinned image. Deploying the app to $destination."
+bin/kamal deploy -d "$destination"

--- a/saas/hotcell/bin/check
+++ b/saas/hotcell/bin/check
@@ -9,24 +9,34 @@
 #
 # Asks one randomly chosen host out of the accessory's roles: sshing all ten costs a minute on
 # production, and the pin drifts per destination rather than per host.
+#
+# The exit status names the fix, so bin/deploy can apply it: 2 when the pinned image has to be built and
+# pushed, 3 when the accessory only has to be rebooted, 1 when the check itself could not tell. -q keeps
+# the verdict and drops the explanation, for a caller that will act on the status rather than read it.
 set -uo pipefail
 
 bin_dir="$(cd "$(dirname "$0")" && pwd)"
 cell_dir="$(cd "$bin_dir/.." && pwd)"
 repo_root="$(cd "$cell_dir/../.." && pwd)"
 
-destination="${1:-${KAMAL_DESTINATION:-production}}"
-
-case "${1:-}" in
-  --help|-h)
-    cat <<USAGE
-Usage: saas/hotcell/bin/check <destination>
+quiet=""
+destination=""
+for arg in "$@"; do
+  case $arg in
+    -q|--quiet) quiet=1 ;;
+    --help|-h)
+      cat <<USAGE
+Usage: saas/hotcell/bin/check [-q] <destination>
 
 Checks the hotcell accessory on one host of <destination> against the pin in saas/config/deploy.yml.
+With -q, reports the verdict and leaves the explanation and the fix to the caller.
 USAGE
-    exit 0
-    ;;
-esac
+      exit 0
+      ;;
+    *) destination="$arg" ;;
+  esac
+done
+destination="${destination:-${KAMAL_DESTINATION:-production}}"
 
 cd "$repo_root"
 
@@ -42,10 +52,16 @@ build_command() {
   fi
 }
 
+# The explanation and fix for a verdict. A caller passing -q acts on the exit status instead.
+explain() {
+  if [ -n "$quiet" ]; then cat >/dev/null; else cat >&2; fi
+}
+
 skip_note() {
+  [ -z "$quiet" ] || return 0
   cat >&2 <<MSG
 
-To deploy anyway and sort the cell out afterwards:
+bin/deploy $destination should do all of this for you. To deploy anyway and sort the cell out afterwards:
 
     SKIP_HOTCELL_CHECKS=1 bin/kamal deploy -d $destination
 MSG
@@ -81,8 +97,8 @@ if docker manifest inspect "$pinned" >/dev/null 2>"$errors"; then
   rm -f "$errors"
 elif grep -qiE 'manifest unknown|manifest_unknown|not found|no such manifest' "$errors"; then
   rm -f "$errors"
-  cat >&2 <<MSG
-  registry:  missing
+  echo "  registry:  missing"
+  explain <<MSG
 
 STOP. The hotcell image this commit pins has never been pushed.
 
@@ -99,7 +115,7 @@ Build it, push it, then boot it:
 Then deploy again.
 MSG
   skip_note
-  exit 1
+  exit 2
 else
   cat >&2 <<MSG
   registry:  unknown
@@ -124,8 +140,9 @@ running=$(ssh "app@$host" "docker inspect --format '{{.Config.Image}}' $service-
 
 if [ -z "$running" ]; then
   if grep -qiE 'no such object|no such container' "$errors"; then
-    cat >&2 <<MSG
-  running:   nothing (on $host)
+    status=3
+    echo "  running:   nothing (on $host)"
+    explain <<MSG
 
 STOP. No hotcell accessory is running on $host.
 
@@ -141,6 +158,7 @@ accessory, so boot it by hand:
 Then deploy again.
 MSG
   else
+    status=1
     cat >&2 <<MSG
   running:   unknown (on $host)
 
@@ -154,13 +172,13 @@ MSG
   fi
   rm -f "$errors"
   skip_note
-  exit 1
+  exit $status
 fi
 rm -f "$errors"
 
 if [ "$running" != "$pinned" ]; then
-  cat >&2 <<MSG
-  running:   $running (on $host)
+  echo "  running:   $running (on $host)"
+  explain <<MSG
 
 STOP. The hotcell accessory is running an image other than the one this commit pins.
 
@@ -177,7 +195,7 @@ is no latest, so the accessory goes on running what it booted with until it is r
 Then deploy again.
 MSG
   skip_note
-  exit 1
+  exit 3
 fi
 
 echo "  running:   the pinned image (on $host)"

--- a/saas/test/deploy-test
+++ b/saas/test/deploy-test
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Runs bin/deploy in a sandbox where bin/kamal and the saas/hotcell/bin scripts are recorder stubs, and
+# asserts the commands it issues for each answer saas/hotcell/bin/check can give.
+#
+#   saas/test/deploy-test
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+pass=0 fail=0
+ok()  { pass=$((pass+1)); echo "  ok: $1"; }
+bad() { fail=$((fail+1)); echo "  FAIL: $1"; }
+
+build_sandbox() { # build_sandbox <dir>
+  local sb="$1"
+  mkdir -p "$sb/bin" "$sb/saas/bin" "$sb/saas/hotcell/bin" "$sb/saas/config" "$sb/lib"
+  cp "$ROOT/bin/deploy" "$sb/bin/deploy"
+  cp "$ROOT/saas/bin/deploy" "$sb/saas/bin/deploy"
+  cp "$ROOT/lib/fizzy.rb" "$sb/lib/fizzy.rb"
+  echo "image: registry.example/fizzy-hotcell:abc" > "$sb/saas/config/deploy.yml"
+  env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -C "$sb" init -q
+  env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -C "$sb" \
+    -c user.name=test -c user.email=test@example.com add -A
+  env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -C "$sb" \
+    -c user.name=test -c user.email=test@example.com commit -q -m init
+
+  # Every stub records itself. check exits with the first status queued in STUB_CHECK_QUEUE and drops it,
+  # so a scenario can answer "needs a reboot" and then "fine". build moves the pin when STUB_BUILD_MOVES_PIN
+  # is set, as the real one does when the tree's pin is stale.
+  cat > "$sb/stub" <<'STUB'
+#!/usr/bin/env bash
+name="$(basename "$0")"
+printf '%s %s\n' "$name" "$*" >> "$STUB_RECORD"
+case "$name" in
+  check)
+    status="$(head -n1 "$STUB_CHECK_QUEUE")"
+    sed -i 1d "$STUB_CHECK_QUEUE"
+    exit "$status"
+    ;;
+  build)
+    if [ -n "${STUB_BUILD_MOVES_PIN:-}" ]; then
+      echo "image: registry.example/fizzy-hotcell:def" > "$(dirname "$0")/../../config/deploy.yml"
+    fi
+    ;;
+esac
+STUB
+  chmod +x "$sb/stub"
+  cp "$sb/stub" "$sb/bin/kamal"
+  for script in check build push; do cp "$sb/stub" "$sb/saas/hotcell/bin/$script"; done
+}
+
+run_scenario() { # run_scenario <name> <args> <check statuses> <expected commands> [VAR=value]...
+  local name="$1" args="$2" check_statuses="$3" expected="$4"; shift 4
+  local sb; sb="$(mktemp -d "${TMPDIR:-/tmp}/deploy-test.XXXXXX")"
+  build_sandbox "$sb"
+  printf '%s\n' $check_statuses > "$sb/check-queue"
+
+  echo "scenario: $name"
+  ( cd "$sb" && env SAAS=1 STUB_RECORD="$sb/commands.txt" STUB_CHECK_QUEUE="$sb/check-queue" "$@" \
+      bin/deploy $args > "$sb/output.txt" 2>&1 )
+  printf 'exit: %s\n' "$?" >> "$sb/commands.txt"
+
+  if [ "$(cat "$sb/commands.txt")" = "$expected" ]; then
+    ok "commands"
+  else
+    bad "commands"
+    diff -u <(echo "$expected") "$sb/commands.txt" | sed 's/^/    /'
+    sed 's/^/    | /' "$sb/output.txt"
+  fi
+  rm -rf "$sb"
+}
+
+run_scenario "cell is fine" staging 0 \
+"check -q staging
+kamal deploy -d staging
+exit: 0"
+
+run_scenario "cell needs a reboot" staging "3 0" \
+"check -q staging
+kamal accessory reboot hotcell -d staging
+check staging
+kamal deploy -d staging
+exit: 0"
+
+run_scenario "image is not in the registry" staging "2 0" \
+"check -q staging
+build --platform=linux/amd64
+push 
+kamal accessory reboot hotcell -d staging
+check staging
+kamal deploy -d staging
+exit: 0"
+
+run_scenario "the check cannot tell" staging 1 \
+"check -q staging
+exit: 1"
+
+run_scenario "the fix did not take" staging "3 3" \
+"check -q staging
+kamal accessory reboot hotcell -d staging
+check staging
+exit: 3"
+
+run_scenario "building moved the pin" staging "2" \
+"check -q staging
+build --platform=linux/amd64
+exit: 1" STUB_BUILD_MOVES_PIN=1
+
+run_scenario "no destination" "" "" \
+"exit: 1"
+
+run_scenario "extra arguments belong to kamal" "staging --skip-push" "" \
+"exit: 1"
+
+run_scenario "not in saas mode" staging "" \
+"exit: 1" SAAS=false
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
A deploy never touches an accessory, so `saas/hotcell/bin/check` could only tell the deployer which of build, push, or reboot they owed and stop the deploy there. Production is two containers and `bin/kamal deploy` knew about one of them.

This adds `bin/deploy <destination>`:

1. Runs `saas/hotcell/bin/check`, whose exit status now names the fix: 2 for build and push, 3 for reboot, 1 when the check could not tell.
2. Applies it. A missing image is built with `--platform=linux/amd64`, pushed, and the accessory rebooted; a stale or absent accessory is rebooted.
3. Runs the check again, and only if it passes runs `bin/kamal deploy -d <destination>`.

The destination is the only argument. Anything else, including deploying over a broken cell with `SKIP_HOTCELL_CHECKS=1`, is a `bin/kamal deploy` you run yourself. The pre-deploy hook is unchanged and still guards direct kamal deploys.

Two decisions worth a look:

- If building moves the pin in `saas/config/deploy.yml`, the script stops and asks for a commit rather than pushing an image this commit does not pin.
- The script requires SaaS mode, since `bin/kamal` only reads `saas/config/deploy.yml` under it.

`test/deploy-test` runs the script against recorder stubs, in the style of `test/setup-phases-test`.

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10265014345

