### PR TITLE
dep: declare ruby-vips and mini_magick after image_processing 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "rouge"
 gem "jbuilder"
 gem "lexxy", "0.9.31"
 gem "image_processing", "~> 2.0"
-gem "ruby-vips" # image_processing 2 no longer depends on it
+gem "ruby-vips", require: false # image_processing 2 no longer depends on it; Active Storage loads it itself
 gem "platform_agent"
 gem "aws-sdk-s3", require: false
 gem "web-push"

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "rouge"
 gem "jbuilder"
 gem "lexxy", "0.9.31"
 gem "image_processing", "~> 2.0"
+gem "ruby-vips" # image_processing 2 no longer depends on it
 gem "platform_agent"
 gem "aws-sdk-s3", require: false
 gem "web-push"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,14 @@ GEM
       tzinfo
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -447,6 +455,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (3.6.0)
     securerandom (0.4.1)
@@ -557,6 +568,7 @@ DEPENDENCIES
   rouge
   rqrcode
   rubocop-rails-omakase
+  ruby-vips
   selenium-webdriver
   solid_cable!
   solid_cache (~> 1.0)
@@ -625,6 +637,14 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   geared_pagination (1.2.0) sha256=16dc25b28e9d6945df27e9bcc6ed298d66eb9493ba45bf987037010724120cc7
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
@@ -721,6 +741,7 @@ CHECKSUMS
   rubocop-rails (2.34.0) sha256=d90eb95655bdb3a2276eff8daa8972b35d9b0fd0c0a71e812c714213a056d71e
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubyzip (3.6.0) sha256=268994d44d62282d1cfd99bf10eae48d7267199158ad7ea3e1fee2da9458b695
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -13,6 +13,7 @@ gem "audits1984", bc: "audits1984"
 # Attachment processing in an unprivileged sibling container
 gem "hotcell-client", "~> 0.3.1"
 gem "activestorage-hotcell-client", "~> 0.3.1"
+gem "mini_magick" # activestorage-hotcell-client 0.3.1 loads the ImageMagick transformer even when unused
 
 # Native push notifications (iOS/Android)
 gem "action_push_native"

--- a/Gemfile.saas
+++ b/Gemfile.saas
@@ -13,7 +13,7 @@ gem "audits1984", bc: "audits1984"
 # Attachment processing in an unprivileged sibling container
 gem "hotcell-client", "~> 0.3.1"
 gem "activestorage-hotcell-client", "~> 0.3.1"
-gem "mini_magick" # activestorage-hotcell-client 0.3.1 loads the ImageMagick transformer even when unused
+gem "mini_magick", require: false # activestorage-hotcell-client 0.3.1 loads the ImageMagick transformer even when unused
 
 # Native push notifications (iOS/Android)
 gem "action_push_native"

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -772,6 +772,7 @@ DEPENDENCIES
   kamal
   letter_opener
   lexxy (= 0.9.31)
+  mini_magick
   minitest-reporters
   mission_control-jobs
   mittens
@@ -788,6 +789,7 @@ DEPENDENCIES
   rouge
   rqrcode
   rubocop-rails-omakase
+  ruby-vips
   selenium-webdriver
   sentry-rails
   sentry-ruby
@@ -1035,26 +1037,6 @@ CHECKSUMS
   strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
   surfguard (0.2.0)
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
-  thruster (0.1.26) sha256=6e45e807086b29d51404841bd1ad493b67cd95892fd65dc5afcdd32e82e94ce8
-  thruster (0.1.26-aarch64-linux) sha256=2171cb34928c0250830008f535c4ab2ee57846cc3f5d3e96c3475f7b3de7a541
-  thruster (0.1.26-arm64-darwin) sha256=40676164c433abf31313422305d9e9e9210cf941b1befad88e2428b3b8dcc36c
-  thruster (0.1.26-x86_64-darwin) sha256=c7f7f0cbefd8030ea03bf88f6a988f595a0618a35a1a0d358e729c6898eb5b6a
-  thruster (0.1.26-x86_64-linux) sha256=3117a6ee430663f845a0457699fe9a05232dcc6c396e2cc83504de5a223c60e8
-  thruster (0.1.26) sha256=6e45e807086b29d51404841bd1ad493b67cd95892fd65dc5afcdd32e82e94ce8
-  thruster (0.1.26-aarch64-linux) sha256=2171cb34928c0250830008f535c4ab2ee57846cc3f5d3e96c3475f7b3de7a541
-  thruster (0.1.26-arm64-darwin) sha256=40676164c433abf31313422305d9e9e9210cf941b1befad88e2428b3b8dcc36c
-  thruster (0.1.26-x86_64-darwin) sha256=c7f7f0cbefd8030ea03bf88f6a988f595a0618a35a1a0d358e729c6898eb5b6a
-  thruster (0.1.26-x86_64-linux) sha256=3117a6ee430663f845a0457699fe9a05232dcc6c396e2cc83504de5a223c60e8
-  thruster (0.1.26) sha256=6e45e807086b29d51404841bd1ad493b67cd95892fd65dc5afcdd32e82e94ce8
-  thruster (0.1.26-aarch64-linux) sha256=2171cb34928c0250830008f535c4ab2ee57846cc3f5d3e96c3475f7b3de7a541
-  thruster (0.1.26-arm64-darwin) sha256=40676164c433abf31313422305d9e9e9210cf941b1befad88e2428b3b8dcc36c
-  thruster (0.1.26-x86_64-darwin) sha256=c7f7f0cbefd8030ea03bf88f6a988f595a0618a35a1a0d358e729c6898eb5b6a
-  thruster (0.1.26-x86_64-linux) sha256=3117a6ee430663f845a0457699fe9a05232dcc6c396e2cc83504de5a223c60e8
-  thruster (0.1.26) sha256=6e45e807086b29d51404841bd1ad493b67cd95892fd65dc5afcdd32e82e94ce8
-  thruster (0.1.26-aarch64-linux) sha256=2171cb34928c0250830008f535c4ab2ee57846cc3f5d3e96c3475f7b3de7a541
-  thruster (0.1.26-arm64-darwin) sha256=40676164c433abf31313422305d9e9e9210cf941b1befad88e2428b3b8dcc36c
-  thruster (0.1.26-x86_64-darwin) sha256=c7f7f0cbefd8030ea03bf88f6a988f595a0618a35a1a0d358e729c6898eb5b6a
-  thruster (0.1.26-x86_64-linux) sha256=3117a6ee430663f845a0457699fe9a05232dcc6c396e2cc83504de5a223c60e8
   thruster (0.1.26) sha256=6e45e807086b29d51404841bd1ad493b67cd95892fd65dc5afcdd32e82e94ce8
   thruster (0.1.26-aarch64-linux) sha256=2171cb34928c0250830008f535c4ab2ee57846cc3f5d3e96c3475f7b3de7a541
   thruster (0.1.26-arm64-darwin) sha256=40676164c433abf31313422305d9e9e9210cf941b1befad88e2428b3b8dcc36c


### PR DESCRIPTION
Since [#3056](https://github.com/basecamp/fizzy/pull/3056) (735922d8) neither `bin/setup` nor `bin/rails` boots on `main`. `image_processing` 2.x dropped its hard dependencies on `ruby-vips` and `mini_magick`, so the bump removed both from the lockfiles.

### Detail

- OSS: `config/initializers/vips.rb` raises `Please install libvips` because `Vips` is undefined without `ruby-vips`.
- SaaS: `activestorage-hotcell-client` 0.3.1 requires `ActiveStorage::Transformers::ImageMagick` at load time, which needs `mini_magick`, even though Fizzy's cell only uses the Vips transformer. The failure surfaces as `Bundler::GemRequireError` loading `fizzy-saas` from `saas/lib/fizzy/saas/cell.rb:6`.

This adds `ruby-vips` to `Gemfile` and `mini_magick` to `Gemfile.saas`, and re-resolves both lockfiles. `bin/bundle-drift` is clean. Bundler also collapsed duplicated `thruster` checksum lines in `Gemfile.saas.lock`.

### Additional information

The durable fix for the SaaS side is in hotcell: `activestorage-hotcell-client` should require the ImageMagick transformer lazily or declare `mini_magick` in its gemspec. Once that ships, `mini_magick` can come back out of `Gemfile.saas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
