### PR TITLE
Move solid_queue and solid_cable to released versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ gem "turbo-rails", github: "hotwired/turbo-rails", branch: "offline-cache"
 gem "bootsnap", require: false
 gem "kamal", require: false
 gem "puma", "~> 8.0"
-gem "solid_cable", github: "rails/solid_cable"
+gem "solid_cable", "~> 4.0"
 gem "solid_cache", "~> 1.0"
-gem "solid_queue", github: "rails/solid_queue"
+gem "solid_queue", "~> 1.7"
 gem "sqlite3", ">= 2.0"
 gem "thruster", require: false
 gem "trilogy", "~> 2.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,28 +124,6 @@ GIT
       zeitwerk (~> 2.6)
 
 GIT
-  remote: https://github.com/rails/solid_cable.git
-  revision: c968ba777f990194596d035e6ba50e1ee677a09c
-  specs:
-    solid_cable (4.0.0)
-      actioncable (>= 7.2)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
-
-GIT
-  remote: https://github.com/rails/solid_queue.git
-  revision: a8c89374b2b600f7306cb44059dce1cc3fc45cec
-  specs:
-    solid_queue (1.4.0)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      concurrent-ruby (>= 1.3.1)
-      fugit (~> 1.11)
-      railties (>= 7.1)
-      thor (>= 1.3.1)
-
-GIT
   remote: https://github.com/rails/web-console.git
   revision: 90e3474306f2367cfeaf2875e91e2bc2d71b5f0f
   specs:
@@ -467,10 +445,22 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    solid_cable (4.0.2)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_cache (1.0.10)
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
+    solid_queue (1.7.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sqlite3 (2.9.6-aarch64-linux-gnu)
     sqlite3 (2.9.6-aarch64-linux-musl)
     sqlite3 (2.9.6-arm-linux-gnu)
@@ -570,9 +560,9 @@ DEPENDENCIES
   rubocop-rails-omakase
   ruby-vips
   selenium-webdriver
-  solid_cable!
+  solid_cable (~> 4.0)
   solid_cache (~> 1.0)
-  solid_queue!
+  solid_queue (~> 1.7)
   sqlite3 (>= 2.0)
   stackprof
   stimulus-rails
@@ -746,9 +736,9 @@ CHECKSUMS
   rubyzip (3.6.0) sha256=268994d44d62282d1cfd99bf10eae48d7267199158ad7ea3e1fee2da9458b695
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.48.0) sha256=0c8376ebc8a0a4879343fe6fe6eccdcea76748611cd25de370b33eded2077a94
-  solid_cable (4.0.0)
+  solid_cable (4.0.2) sha256=084636a67679ad00d23088b33c84047e614bcf41ee559db24b414d83cdc42d03
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
-  solid_queue (1.4.0)
+  solid_queue (1.7.0) sha256=6566b70b801d1c317c81bba7bcdd5677c019afac584a30374b4164002ca356d3
   sqlite3 (2.9.6-aarch64-linux-gnu) sha256=d8b1f7d23efd7abac285775a9566562fc7debfef79d594e3a20354406fb7907c
   sqlite3 (2.9.6-aarch64-linux-musl) sha256=3579e1c98cdc7ff5c3722847bb63ed4e1efb7ff675cb5e1e48ef2d4da5fb3bc9
   sqlite3 (2.9.6-arm-linux-gnu) sha256=33541500e3615da02afe54a9cc38b17a6985d3cf9d8b76d6d0a83002f114e7ec

--- a/Gemfile.saas.lock
+++ b/Gemfile.saas.lock
@@ -172,28 +172,6 @@ GIT
       zeitwerk (~> 2.6)
 
 GIT
-  remote: https://github.com/rails/solid_cable.git
-  revision: c968ba777f990194596d035e6ba50e1ee677a09c
-  specs:
-    solid_cable (4.0.0)
-      actioncable (>= 7.2)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
-
-GIT
-  remote: https://github.com/rails/solid_queue.git
-  revision: a8c89374b2b600f7306cb44059dce1cc3fc45cec
-  specs:
-    solid_queue (1.4.0)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      concurrent-ruby (>= 1.3.1)
-      fugit (~> 1.11)
-      railties (>= 7.1)
-      thor (>= 1.3.1)
-
-GIT
   remote: https://github.com/rails/web-console.git
   revision: 90e3474306f2367cfeaf2875e91e2bc2d71b5f0f
   specs:
@@ -647,10 +625,22 @@ GEM
     sniffer (0.5.0)
       anyway_config (>= 1.0)
       dry-initializer (~> 3)
+    solid_cable (4.0.2)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_cache (1.0.10)
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
+    solid_queue (1.7.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sqlite3 (2.9.6-aarch64-linux-gnu)
     sqlite3 (2.9.6-aarch64-linux-musl)
     sqlite3 (2.9.6-arm-linux-gnu)
@@ -793,9 +783,9 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
-  solid_cable!
+  solid_cable (~> 4.0)
   solid_cache (~> 1.0)
-  solid_queue!
+  solid_queue (~> 1.7)
   sqlite3 (>= 2.0)
   stackprof
   stimulus-rails
@@ -1019,9 +1009,9 @@ CHECKSUMS
   sentry-ruby (6.7.0) sha256=b4b915d79a0395ad02106d4012aa1914641456e042ce36393f15bd1630d8db42
   signet (0.21.0) sha256=d617e9fbf24928280d39dcfefba9a0372d1c38187ffffd0a9283957a10a8cd5b
   sniffer (0.5.0) sha256=cd040cc51929c04749b20baa4dd8f5985174210e13437491f4923b8de27e1359
-  solid_cable (4.0.0)
+  solid_cable (4.0.2) sha256=084636a67679ad00d23088b33c84047e614bcf41ee559db24b414d83cdc42d03
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
-  solid_queue (1.4.0)
+  solid_queue (1.7.0) sha256=6566b70b801d1c317c81bba7bcdd5677c019afac584a30374b4164002ca356d3
   sqlite3 (2.9.6-aarch64-linux-gnu) sha256=d8b1f7d23efd7abac285775a9566562fc7debfef79d594e3a20354406fb7907c
   sqlite3 (2.9.6-aarch64-linux-musl) sha256=3579e1c98cdc7ff5c3722847bb63ed4e1efb7ff675cb5e1e48ef2d4da5fb3bc9
   sqlite3 (2.9.6-arm-linux-gnu) sha256=33541500e3615da02afe54a9cc38b17a6985d3cf9d8b76d6d0a83002f114e7ec

--- a/db/queue_migrate/20260907161841_add_batches_to_solid_queue.rb
+++ b/db/queue_migrate/20260907161841_add_batches_to_solid_queue.rb
@@ -1,0 +1,39 @@
+class AddBatchesToSolidQueue < ActiveRecord::Migration[7.1]
+  def change
+    # Fresh installs create all of this with the base schema, so skip
+    # anything that already exists
+    add_column :solid_queue_jobs, :batch_id, :bigint, if_not_exists: true
+    add_index :solid_queue_jobs, :batch_id, if_not_exists: true
+
+    create_table :solid_queue_batches, if_not_exists: true do |t|
+      t.string :active_job_batch_id
+      t.string :description
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_failure
+      t.text :metadata
+      t.integer :total_jobs, default: 0, null: false
+      t.integer :completed_jobs, default: 0, null: false
+      t.integer :failed_jobs, default: 0, null: false
+      t.datetime :enqueued_at
+      t.datetime :finished_at
+      t.datetime :failed_at
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+
+      t.index :active_job_batch_id, unique: true
+      t.index :finished_at
+    end
+
+    create_table :solid_queue_batch_executions, if_not_exists: true do |t|
+      t.bigint :job_id, null: false
+      t.bigint :batch_id, null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+      t.index :batch_id
+      t.foreign_key :solid_queue_batches, column: :batch_id, on_delete: :cascade
+      t.foreign_key :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    end
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 1) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_07_161841) do
+  create_table "solid_queue_batch_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "batch_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["batch_id"], name: "index_solid_queue_batch_executions_on_batch_id"
+    t.index ["job_id"], name: "index_solid_queue_batch_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_batches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "active_job_batch_id"
+    t.string "description"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_failure"
+    t.text "metadata"
+    t.integer "total_jobs", default: 0, null: false
+    t.integer "completed_jobs", default: 0, null: false
+    t.integer "failed_jobs", default: 0, null: false
+    t.datetime "enqueued_at"
+    t.datetime "finished_at"
+    t.datetime "failed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_batch_id"], name: "index_solid_queue_batches_on_active_job_batch_id", unique: true
+    t.index ["finished_at"], name: "index_solid_queue_batches_on_finished_at"
+  end
+
   create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "concurrency_key", null: false
     t.datetime "created_at", null: false
@@ -49,7 +76,9 @@ ActiveRecord::Schema[8.2].define(version: 1) do
     t.string "queue_name", null: false
     t.datetime "scheduled_at"
     t.datetime "updated_at", null: false
+    t.bigint "batch_id"
     t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["batch_id"], name: "index_solid_queue_jobs_on_batch_id"
     t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
     t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
     t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
@@ -132,6 +161,8 @@ ActiveRecord::Schema[8.2].define(version: 1) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  add_foreign_key "solid_queue_batch_executions", "solid_queue_batches", column: "batch_id", on_delete: :cascade
+  add_foreign_key "solid_queue_batch_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade


### PR DESCRIPTION
Moves `solid_queue` and `solid_cable` off their edge git pins and onto rubygems releases: `solid_queue` `a8c89374` (1.4.0, 2026-05-30) → 1.7.0, and `solid_cable` `c968ba77` (4.0.0, 2026-06-26) → 4.0.2. Supersedes #3061 and #3057. `solid_cache` was already on a release (`~> 1.0`, 1.0.10) and is untouched.

### Detail

Both pins existed to pick up a fix ahead of its release, and both fixes have since shipped:

- `solid_queue` was pinned in `46509095` for [rails/solid_queue#747](https://github.com/rails/solid_queue/pull/747), the optional job argument to the adapter's `stopping?`. That commit is the pinned SHA itself, and it is an ancestor of `v1.7.0`.
- `solid_cable` was pinned in `e1892a23` because released 4.0.0 called `@server` on the subscription adapter after Rails edge removed it. The `pubsub_executor` shim is in `v4.0.2`, a descendant of the pinned SHA.

The `Gemfile` drops the `github:` sources for `gem "solid_queue", "~> 1.7"` and `gem "solid_cable", "~> 4.0"`. Both lockfiles were resolved with `bin/bundle-both update --conservative`; no other gem moved. `PLATFORMS` is unchanged.

Solid Queue 1.7.0 adds batches, which need two new tables and a `solid_queue_jobs.batch_id` column. Per [UPGRADING.md](https://github.com/rails/solid_queue/blob/v1.7.0/UPGRADING.md) the migration is optional until 2.0: until it runs, `Batch.migrated?` is false, `batch_id` is never written, and each dispatcher logs one deprecation warning at boot. This PR adds the migration anyway so we are not carrying that warning:

- `db/queue_migrate/20260907161841_add_batches_to_solid_queue.rb`, from `bin/rails solid_queue:update`. Every statement is `if_not_exists: true`, so it is a no-op on a database that loaded the new schema. `db/queue_migrate/` did not exist before; every `database*.yml` already points the `queue` database's `migrations_paths` at it.
- `db/queue_schema.rb`, re-dumped from the SaaS development MySQL queue database after running the migration, so fresh installs get the tables. The schema version moves from `1` to the migration timestamp as a side effect of the dump.

Deploy order does not matter: old code ignores the extra column, new code tolerates its absence.

### Additional information

Upgrade analysis for both gems, per commit, is in `37signals-hq` under `upgrade-analysis/fizzy-20260907-solid_queue_a8c89374..v1.7.0.md` (65 commits: 1 definite, 6 likely, 25 unlikely, 33 no impact) and `upgrade-analysis/fizzy-20260907-solid_cable_c968ba77..v4.0.2.md` (3 commits, none affecting fizzy). The batches schema is the only mitigation. Behavior changes in range that need no code change:

- Recurring schedules now default to the Rails time zone rather than the system zone ([rails/solid_queue@546864f1](https://github.com/rails/solid_queue/commit/546864f1)). Fizzy sets no `config.time_zone` and no `TZ` in the container, so every schedule in `config/recurring.yml` fires at the same UTC time as before.
- Recurring enqueue failures, previously only logged, are now reported through `Rails.error` and will reach Sentry with `source: "application.solid_queue"` ([rails/solid_queue@dfc36448](https://github.com/rails/solid_queue/commit/dfc36448)).
- `signal_all` no longer increments a semaphore past its limit ([rails/solid_queue@2124a51d](https://github.com/rails/solid_queue/commit/2124a51d)). This affects `Storage::ReconcileJob` and `Storage::MaterializeJob`, which use `limits_concurrency`. The fix does not repair rows already over the limit, so `SolidQueue::Semaphore.where("value > `limit`")` in a production console after deploy is worth a look.
- The override audit found nothing in `config/`, `lib/rails_ext/`, `saas/lib/yabeda/solid_queue.rb`, or `saas/lib/fizzy/saas/engine.rb` that depends on anything the range changed.

The new `bin/jobs check` subcommand fails in SaaS development because `config.solid_queue.connects_to` is only set in `config/environments/production.rb`, so it looks for `solid_queue_recurring_tasks` in the primary database. That predates this change and does not affect production, where `connects_to` is set.

The test environment uses `adapter: test` for Action Cable, so as with `e1892a23` the real `solid_cable` adapter is only exercised on beta. Worth a WebSocket connect after deploying there.

### Checklist

- [x] SaaS 1845 tests, OSS 1658 tests: no failures, no errors
- [x] SaaS System 18 tests, OSS System 18 tests: no failures, no errors
- [x] `bin/bundle-drift` reports the lockfiles in sync; `bin/bundler-audit check --update` reports no vulnerabilities; `bin/rubocop` clean
- [x] `PLATFORMS` unchanged from `main` in both lockfiles

ref: https://app.fizzy.do/5986089/cards/5265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
