### PR TITLE
Reference in-repo workflows with GitHub's self-repository syntax

### DIFF
--- a/.github/workflows/ci-oss.yml
+++ b/.github/workflows/ci-oss.yml
@@ -10,6 +10,6 @@ permissions:
 jobs:
   test:
     if: github.event.pull_request.head.repo.full_name != github.repository
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       saas: false

--- a/.github/workflows/ci-saas.yml
+++ b/.github/workflows/ci-saas.yml
@@ -9,12 +9,12 @@ permissions:
 jobs:
   test_oss:
     name: Test (OSS)
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       saas: false
   test_saas:
     name: Test (SaaS)
-    uses: ./.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml
     with:
       saas: true
     secrets:


### PR DESCRIPTION
zizmor 1.30.0, which zizmor-action 0.6.3 runs by default, adds a self-repository audit that flags workspace-relative `uses: ./...` references to in-repo actions and reusable workflows. This repo pins zizmor-action 0.6.2 and would fail the audit on the next Dependabot bump.

GitHub's `uses: $/...` form is the syntax GitHub now recommends for same-repository references and the one zizmor's audit requires. For a job-level reusable-workflow call it changes nothing at runtime: `./` already resolves to the caller's commit, and reusable workflows are exempt from the org SHA-pinning policy, so the gain is conformance with the recommended form, not security. This rewrites the three reusable-workflow calls to `test.yml` in `ci-oss.yml` and `ci-saas.yml`; nothing else changes. This repo doesn't run actionlint, so no actionlint config is needed.

CI's GitHub Actions audit job on this PR is the proof: zizmor 1.30.0 locally goes from 3 self-repository findings to none.

Same change as basecamp/hey-sdk#171 and #174.
