### PR TITLE
Keep an account's only owner from deactivating themself

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   before_action :set_user, except: %i[ index ]
   before_action :ensure_permission_to_change_user, only: %i[ update destroy ]
+  before_action :ensure_user_is_not_sole_owner, only: %i[ destroy ]
 
   def index
     set_page_and_extract_portion_from Current.account.users.active.alphabetically.includes(:identity)
@@ -44,6 +45,15 @@ class UsersController < ApplicationController
 
     def ensure_permission_to_change_user
       head :forbidden unless Current.user.can_change?(@user)
+    end
+
+    def ensure_user_is_not_sole_owner
+      if @user.sole_owner?
+        respond_to do |format|
+          format.html { redirect_to account_settings_path, alert: "You're the only owner of this account and can't be removed" }
+          format.json { head :unprocessable_entity }
+        end
+      end
     end
 
     def user_params

--- a/app/models/user/role.rb
+++ b/app/models/user/role.rb
@@ -22,6 +22,10 @@ module User::Role
     admin? && !other.owner? && other != self
   end
 
+  def sole_owner?
+    owner? && account.users.owner.excluding(self).none?
+  end
+
   def can_administer_board?(board)
     admin? || board.creator == self
   end

--- a/app/models/user/role.rb
+++ b/app/models/user/role.rb
@@ -23,7 +23,7 @@ module User::Role
   end
 
   def sole_owner?
-    owner? && account.users.owner.excluding(self).none?
+    active? && owner? && account.users.owner.excluding(self).none?
   end
 
   def can_administer_board?(board)

--- a/docs/api/sections/users.md
+++ b/docs/api/sections/users.md
@@ -143,8 +143,15 @@ __Error responses:__
 
 ## `DELETE /:account_slug/users/:user_id`
 
-Deactivates a user. You can only deactivate users you have permission to change.
+Deactivates a user. You can only deactivate users you have permission to change. An account's only owner can't be deactivated.
 
 __Response:__
 
 Returns `204 No Content` on success.
+
+__Error responses:__
+
+| Status Code | Description |
+|--------|-------------|
+| `403 Forbidden` | You don't have permission to deactivate this user |
+| `422 Unprocessable Entity` | The user is the account's only owner |

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -55,6 +55,65 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert users(:jason).reload.active
   end
 
+  test "owner cannot deactivate themself while the only owner" do
+    sign_in_as :jason
+
+    assert_no_difference -> { User.active.count } do
+      delete user_path(users(:jason))
+    end
+
+    assert_redirected_to account_settings_path
+    assert_equal "You're the only owner of this account and can't be removed", flash[:alert]
+    assert users(:jason).reload.active
+    assert_includes accounts(:"37s").users.owner, users(:jason)
+  end
+
+  test "owner cannot deactivate themself while the only owner as JSON" do
+    sign_in_as :jason
+
+    assert_no_difference -> { User.active.count } do
+      delete user_path(users(:jason)), as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert users(:jason).reload.active
+  end
+
+  test "owner can deactivate themself when another owner remains" do
+    users(:kevin).update!(role: :owner)
+    sign_in_as :jason
+
+    assert_difference -> { User.active.count }, -1 do
+      delete user_path(users(:jason))
+    end
+
+    assert_redirected_to account_settings_path
+    assert_not users(:jason).reload.active
+    assert_includes accounts(:"37s").users.owner, users(:kevin)
+  end
+
+  test "admin can deactivate themself" do
+    sign_in_as :kevin
+
+    assert_difference -> { User.active.count }, -1 do
+      delete user_path(users(:kevin))
+    end
+
+    assert_redirected_to account_settings_path
+    assert_not users(:kevin).reload.active
+  end
+
+  test "member can deactivate themself" do
+    sign_in_as :jz
+
+    assert_difference -> { User.active.count }, -1 do
+      delete user_path(users(:jz))
+    end
+
+    assert_redirected_to account_settings_path
+    assert_not users(:jz).reload.active
+  end
+
   test "non-admins cannot perform actions" do
     sign_in_as :jz
 

--- a/test/models/user/role_test.rb
+++ b/test/models/user/role_test.rb
@@ -58,6 +58,19 @@ class User::RoleTest < ActiveSupport::TestCase
     assert_not_includes accounts("37s").users.admin, users(:kevin)
   end
 
+  test "sole owner?" do
+    assert users(:jason).sole_owner?
+    assert_not users(:kevin).sole_owner?
+    assert_not users(:david).sole_owner?
+
+    users(:kevin).update!(role: :owner)
+    assert_not users(:jason).sole_owner?
+    assert_not users(:kevin).sole_owner?
+
+    users(:kevin).update!(active: false)
+    assert users(:jason).sole_owner?
+  end
+
   test "can administer board?" do
     writebook_board = boards(:writebook)
     private_board = boards(:private)

--- a/test/models/user/role_test.rb
+++ b/test/models/user/role_test.rb
@@ -69,6 +69,9 @@ class User::RoleTest < ActiveSupport::TestCase
 
     users(:kevin).update!(active: false)
     assert users(:jason).sole_owner?
+
+    users(:jason).update!(active: false)
+    assert_not users(:jason).sole_owner?
   end
 
   test "can administer board?" do


### PR DESCRIPTION
An account's owner could deactivate themself by replaying the remove-person request with their own user id. The UI never offers it (the remove button is disabled for yourself), but `UsersController#destroy` is gated by `can_change?`, whose `other == self` arm admits the owner. The result is an account with no owner and no way to get one back: nobody left can cancel the account or change settings, and rejoining via join code creates a fresh member. Surfaced by a bug bounty report; closed as self-exploitation, but it is a foot-gun worth removing.

## Change

- `User#sole_owner?`: the user is an active owner and the account has no other active owner.
- `UsersController#destroy` refuses when the target is the sole owner: HTML redirects to account settings with an alert, JSON responds `422 Unprocessable Entity`. The check runs after the existing permission gate, so an admin trying to remove the owner is still `403 Forbidden`.
- API docs list the `403` and `422` responses for `DELETE /:account_slug/users/:user_id`.

## What stays the same

- Admins and members can still deactivate themselves (intentionally allowed).
- An owner can still deactivate themself if the account has another active owner.
- `User#deactivate` is untouched. `Identity#before_destroy` deactivates every user of the identity, owners included, and that path must keep working, so the rule sits at the request boundary rather than inside the model operation.

## Not done on purpose

- No lock against two owners of the same account racing to remove themselves at once. Only they can produce that state, against their own account, and the app has no way to create a second owner today.
- No transfer-ownership affordance. Separate feature.

## Tests

- Owner removing themself as the only owner: refused (HTML redirect with alert, JSON 422), still active, still the account's owner.
- Owner removing themself with a second owner present: allowed.
- Admin and member removing themselves: allowed.
- Admin removing the owner: still 403.
- `sole_owner?` across owner/admin/member, a second owner, and a deactivated second owner.
