### PR TITLE
Fix Pins read path has no authorization check

### DIFF
--- a/app/controllers/my/pins_controller.rb
+++ b/app/controllers/my/pins_controller.rb
@@ -6,7 +6,7 @@ class My::PinsController < ApplicationController
 
   private
     def user_pins
-      Current.user.pins.includes(:card).ordered.limit(pins_limit)
+      Current.user.pins.accessible.includes(:card).ordered.limit(pins_limit)
     end
 
     def pins_limit

--- a/app/jobs/card/broadcast_pin_updates_job.rb
+++ b/app/jobs/card/broadcast_pin_updates_job.rb
@@ -1,0 +1,7 @@
+class Card::BroadcastPinUpdatesJob < ApplicationJob
+  discard_on ActiveJob::DeserializationError
+
+  def perform(card)
+    card.broadcast_pin_updates
+  end
+end

--- a/app/models/card/pinnable.rb
+++ b/app/models/card/pinnable.rb
@@ -4,7 +4,7 @@ module Card::Pinnable
   included do
     has_many :pins, dependent: :destroy
 
-    after_update_commit :broadcast_pin_updates, if: :preview_changed?
+    after_update_commit :broadcast_pin_updates_later, if: :preview_changed?
   end
 
   def pinned_by?(user)
@@ -23,10 +23,16 @@ module Card::Pinnable
     pins.find_by(user: user).tap { it.destroy }
   end
 
+  # Renders each tray in the same breath as it picks the pins to render, so that access
+  # revoked between the two cannot be broadcast.
+  def broadcast_pin_updates
+    pins.accessible.find_each do |pin|
+      pin.broadcast_replace_to [ pin.user, :pins_tray ], partial: "my/pins/pin"
+    end
+  end
+
   private
-    def broadcast_pin_updates
-      pins.accessible.find_each do |pin|
-        pin.broadcast_replace_later_to [ pin.user, :pins_tray ], partial: "my/pins/pin"
-      end
+    def broadcast_pin_updates_later
+      Card::BroadcastPinUpdatesJob.perform_later(self)
     end
 end

--- a/app/models/card/pinnable.rb
+++ b/app/models/card/pinnable.rb
@@ -23,10 +23,11 @@ module Card::Pinnable
     pins.find_by(user: user).tap { it.destroy }
   end
 
-  # Renders each tray in the same breath as it picks the pins to render, so that access
-  # revoked between the two cannot be broadcast.
+  # Renders the board this run has loaded, so it picks its recipients from that same board:
+  # a card that moves again while the job runs cannot widen the audience, and access revoked
+  # before the job runs is already gone from board.users.
   def broadcast_pin_updates
-    pins.accessible.find_each do |pin|
+    pins.where(user: board.users).find_each do |pin|
       pin.broadcast_replace_to [ pin.user, :pins_tray ], partial: "my/pins/pin"
     end
   end

--- a/app/models/card/pinnable.rb
+++ b/app/models/card/pinnable.rb
@@ -25,7 +25,7 @@ module Card::Pinnable
 
   private
     def broadcast_pin_updates
-      pins.find_each do |pin|
+      pins.accessible.find_each do |pin|
         pin.broadcast_replace_later_to [ pin.user, :pins_tray ], partial: "my/pins/pin"
       end
     end

--- a/app/models/pin.rb
+++ b/app/models/pin.rb
@@ -3,5 +3,9 @@ class Pin < ApplicationRecord
   belongs_to :card
   belongs_to :user
 
-  scope :ordered, -> { order(created_at: :desc) }
+  scope :ordered, -> { order(created_at: :desc, id: :desc) }
+
+  # Cards move between boards, and a pin outlives a move to a board its owner cannot reach.
+  # Only serve the pins whose owner still has access to the card's board.
+  scope :accessible, -> { where(card: Card.joins(board: :accesses).where("accesses.user_id = pins.user_id")) }
 end

--- a/test/controllers/my/pins_controller_test.rb
+++ b/test/controllers/my/pins_controller_test.rb
@@ -21,4 +21,56 @@ class My::PinsControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_ids.count, @response.parsed_body.count
     assert_equal expected_ids, @response.parsed_body.map { |card| card["id"] }
   end
+
+  test "index skips pins on a board the pinner cannot access" do
+    logout_and_sign_in_as :david
+    cards(:logo).pin_by(users(:david))
+    secret_column = move_to_private_board cards(:logo)
+
+    get my_pins_path
+
+    assert_response :success
+    assert_no_match boards(:private).name, @response.body
+    assert_no_match secret_column.name, @response.body
+  end
+
+  test "index as JSON skips pins on a board the pinner cannot access" do
+    logout_and_sign_in_as :david
+    cards(:logo).pin_by(users(:david))
+    cards(:layout).pin_by(users(:david))
+    move_to_private_board cards(:logo)
+
+    get my_pins_path(format: :json)
+
+    assert_response :success
+    assert_equal [ cards(:layout).id ], @response.parsed_body.map { |card| card["id"] }
+    assert_no_match boards(:private).name, @response.body
+  end
+
+  test "index as JSON skips pins after the pinner loses access to the board" do
+    accesses(:writebook_kevin).destroy
+
+    get my_pins_path(format: :json)
+
+    assert_response :success
+    assert_empty @response.parsed_body
+  end
+
+  test "index as JSON keeps pins on a board the pinner can access" do
+    move_to_private_board cards(:logo)
+
+    get my_pins_path(format: :json)
+
+    assert_response :success
+    assert_includes @response.parsed_body.map { |card| card["id"] }, cards(:logo).id
+  end
+
+  private
+    def move_to_private_board(card)
+      with_current_user(:kevin) do
+        boards(:private).columns.create!(name: "Ultrasecret", color: "var(--color-card-1)").tap do
+          card.update!(board: boards(:private))
+        end
+      end
+    end
 end

--- a/test/models/card/pinnable_test.rb
+++ b/test/models/card/pinnable_test.rb
@@ -35,6 +35,15 @@ class Card::PinnableTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not broadcast pin update to a pinner whose access is revoked before the broadcast runs" do
+    cards(:logo).update!(title: "New title")
+    accesses(:writebook_kevin).destroy
+
+    assert_turbo_stream_broadcasts([ pins(:logo_kevin).user, :pins_tray ], count: 0) do
+      perform_enqueued_jobs except: Board::CleanInaccessibleDataJob
+    end
+  end
+
   test "does not broadcast pin update when other properties change" do
     perform_enqueued_jobs do
       assert_turbo_stream_broadcasts([ pins(:logo_kevin).user, :pins_tray ], count: 0) do

--- a/test/models/card/pinnable_test.rb
+++ b/test/models/card/pinnable_test.rb
@@ -17,9 +17,21 @@ class Card::PinnableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcasts pin update when board changes" do
+  test "broadcasts pin update when board changes to a board the pinner can access" do
     assert_broadcasted_pin_update do
       cards(:logo).update!(board: boards(:private), column: nil)
+    end
+  end
+
+  test "does not broadcast pin update to a pinner who cannot access the new board" do
+    cards(:logo).pins.create!(user: users(:jz))
+
+    perform_enqueued_jobs do
+      assert_turbo_stream_broadcasts([ users(:jz), :pins_tray ], count: 0) do
+        assert_turbo_stream_broadcasts([ pins(:logo_kevin).user, :pins_tray ]) do
+          cards(:logo).update!(board: boards(:private), column: nil)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

A pin outlives the card it points at. When a card moves to a board the pinner cannot access, or the pinner's access to that board is revoked, the pin stays in place until `Card::CleanInaccessibleDataJob` deletes it.

Both readers of a user's pins take the surviving pin as authority. `/my/pins` and `/my/pins.json` render the pinned card, which hands the pinner the destination board's id, name and url, plus every column name on that board. The card's move also pushes the same rendering to the pinner's tray over Turbo, unprompted. The card's own URL and the board's URL return 404 for that user the whole time.

The window is however long the cleanup job takes. A failed or backed-up queue makes it unbounded.

## Solution

`My::PinsController#index` now filters through `Pin.accessible`, which keeps only the pins whose owner currently has an `Access` record for the card's board. The tray and the JSON both go through it.

The broadcast moves into `Card::BroadcastPinUpdatesJob`, which picks its recipients from `board.users` and renders them in the same run. `broadcast_replace_later_to` chose recipients in the callback and rendered them later in Turbo's job, so anything that changed in between (an access revoked, the card moving on again) was rendered to whoever had been chosen earlier. Taking the recipients from the board the job is about to render keeps the two in step.

The pin is still deleted by the cleanup job, but how long it survives no longer decides what the pinner can see.

`Pin.ordered` now breaks created_at ties by id, so two pins made in the same instant come back in a stable order.

Known remaining case: a user who loses access keeps whatever their tray already rendered until they reload, since nothing broadcasts a removal when the cleanup job deletes the pin. That is the pre-move rendering, which they were allowed to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
